### PR TITLE
Track selected route via LRM events.

### DIFF
--- a/src/tools.js
+++ b/src/tools.js
@@ -23,6 +23,9 @@ var Control = L.Control.extend({
     L.setOptions(this, options);
     this._lrm = lrm;
     lrm.on('routesfound', this._updateDownloadLink, this);
+    lrm.on('routeselected', function(e) {
+      this._selectedAlternative = e.route;
+    }, this);
   },
 
   onAdd: function(map) {
@@ -109,7 +112,7 @@ var Control = L.Control.extend({
       waypoints: this._lrm.getWaypoints(),
       language: this.options.language,
       units: this.options.units,
-      alternative: this._lrm.getSelectedAlternative(),
+      alternative: this._selectedAlternative,
     };
   },
 


### PR DESCRIPTION
Noticed `tools.js` uses a non-standard method `getSelectedAlternative` from LRM. Replaced it by tracking the `routeselected` event.

The same pattern should be applicable to fix #26.
