### PR TITLE
Removed duplicate options that would overwrite those from options.js

### DIFF
--- a/src/directions_theme.js
+++ b/src/directions_theme.js
@@ -11,10 +11,7 @@ var secondaryColor = '#f1f075';
 
 var options = {
   lrm: {
-    routeWhileDragging: true,
-    addWaypoints: true,
     addButtonClassName: 'mapbox-directions-button-add',
-    waypointMode: 'snap',
     pointMarkerStyle: {
       radius: 6,
       color: 'black',


### PR DESCRIPTION
A few lrm options were added as duplicates of defaultControl in options.js. This caused them to be overwritten in L.extend:

`L.extend(options.controlDefaults, theme.options.lrm);`
