### PR TITLE
Added service selector dropdown.

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -895,3 +895,16 @@ td.distance {
     margin-right: -400px !important;
     transition: 0.5s;
 }
+
+.service-selector {
+    bottom: 35px;
+    left: 52px;
+    position: absolute;
+}
+.service-selector select {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    color: #555;
+    padding: 6px 12px;
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "leaflet.locatecontrol": "~0.44.0",
     "local-storage": "^1.4.2",
     "osrm-text-instructions": "~0.11.0",
-    "pem": "^1.12.5",
+    "pem": "1.12.5",
     "qs": "^6.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "leaflet.locatecontrol": "~0.44.0",
     "local-storage": "^1.4.2",
     "osrm-text-instructions": "~0.11.0",
+    "pem": "^1.12.5",
     "qs": "^6.1.0"
   }
 }

--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -30,6 +30,7 @@ module.exports = {
   },
   services: [{
     label: 'Car (fastest)',
+    profile: 'driving',
     path: 'https://router.project-osrm.org/route/v1'
   }],
   layer: [{


### PR DESCRIPTION
When the 'services' property contains a list of more than one
service, a drop-down menu will appear in the bottom left of the
map allowing the user to switch the router between any of the
configured services.

It is also now possible to specify a 'profile' for a service so
that the default of 'driving' can be changed. This 'profile'
affects the URL used when connecting to the service, e.g.:

`http://127.0.0.1:5000/route/v1/<profile>/13.3888,52.5170;...`

Takes care of #175.