### PR TITLE
Fix OSRM_CENTER in Dockerfile not working

### DIFF
--- a/scripts/replace.js
+++ b/scripts/replace.js
@@ -35,7 +35,7 @@ for (const filepath of [leafletOptions, debug]) {
     // Mapbox uses LngLat
     if (options.match('-122.4536, 37.796')) options = options.replace('-122.4536, 37.796', lnglat)
     // Leaflet uses LatLng
-    else options = options.replace('38.8995, -77.0269', latlng)
+    else options = options.replace('38.8995,-77.0269', latlng)
   }
 
   // Save Leaflet Options


### PR DESCRIPTION
When using docker setting `OSRM_CENTER` does not have any effect.

The reason is that the coordinates in the source code do not have a space between them and as such the search & replace fails. This is now fixed.

---

Issue found by https://github.com/seanphoenix