### PR TITLE
Correct French translation

### DIFF
--- a/i18n/fr.js
+++ b/i18n/fr.js
@@ -5,9 +5,9 @@ module.exports = {
   'Open in JOSM': 'Ouvrir dans JOSM',
   'Open in Debug Map': 'Ouvrir dans Debug Map',
   'Open in Mapillary': 'Ouvrir dans Mapillary',
-  'GPX': 'Export GPX file',
+  'GPX': 'Exporter fichier GPX',
   'Select language': 'Choisir la langue',
   'Start - press enter to drop marker': 'Point de départ',
-  'End - press enter to drop marker': 'Étape intermédiaire',
-  'Via point - press enter to drop marker': 'Point d\'arrivée'
+  'End - press enter to drop marker': 'Point d\'arrivée',
+  'Via point - press enter to drop marker': 'Étape intermédiaire'
 };


### PR DESCRIPTION
Switch the translations for "End" and "Via point" (there was a mistake), translate "GPX"