### PR TITLE
add minzoom and maxzoom for debug vector layer

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -125,7 +125,9 @@ var simple = {
         },
         "osrm": {
             "type": "vector",
-            "tiles" : ["https://router.project-osrm.org/tile/v1/car/tile({x},{y},{z}).mvt"]
+            "tiles" : ["https://router.project-osrm.org/tile/v1/car/tile({x},{y},{z}).mvt"],
+            "minzoom": 12,
+            "maxzoom": 19
         }
     },
     "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",


### PR DESCRIPTION
stops unnecessary requests

values from here https://github.com/Project-OSRM/osrm-backend/blob/51e04209e3c458577d7829208bdee9632e045417/include/engine/api/tile_parameters.hpp#L64