### PR TITLE
Update Docker File to use current Alpine/Node (3.19 and 20.12.2)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.5
+FROM node:iron-alpine3.19
+# iron = v20 lts
 
 # Enables customized options using environment variables
 ENV OSRM_BACKEND='http://localhost:5000'
@@ -13,7 +14,7 @@ RUN mkdir -p /src
 COPY package.json /src
 
 # Install app dependencies
-RUN apk add --no-cache sed nodejs && \
+RUN apk add --no-cache sed && \
     cd /src && \
     npm install
 


### PR DESCRIPTION
I was getting an error when starting the container:

```
		/src/node_modules/micromatch/index.js:44  
		let isMatch = picomatch(String(patterns[i]), { ...options, onResult }, true);  
		                                               ^^^  
		SyntaxError: Unexpected token ...
```
In case the markdown formatter messes it up the error is at the object spread operator which was added in node v8.6.0 (source: [node.green](https://node.green/#ES2018-features-object-rest-spread-properties))

With the current base image, Alpine 3.5 the latest version of node is v6.9.5 (see https://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/). This PR updates it to Alpine 3.19 and node 20.12.2.  I've also got this built in the package for my fork and I'm already using it in my cluster https://github.com/gangstead/osrm-frontend/pkgs/container/osrm-frontend