### PR TITLE
Update leaflet_options.js - Update tile URLs

### DIFF
--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -2,10 +2,10 @@
 
 var L = require('leaflet');
 
-var osmAttribution = '© <a href="https://www.openstreetmap.org/copyright/en">OpenStreetMap</a> contributors',
-    cartoAttribution = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
+var osmAttribution = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    cartoAttribution = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attribution">CARTO</a>',
     esriAttribution = 'Tiles © <a href="https://www.esri.com/">Esri</a> — Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AeroGRID, IGN, and the GIS User Community',
-    waymarkedtrailsAttribution = '© <a href="http://waymarkedtrails.org">Sarah Hoffmann</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)';
+    waymarkedtrailsAttribution = '© <a href="https://waymarkedtrails.org/">Sarah Hoffmann</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)';
 
 var streets = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
     attribution: cartoAttribution,
@@ -13,17 +13,17 @@ var streets = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager
     maxZoom: 19
   }),
   outdoors = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
-    attribution: osmAttribution + ', <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
+    attribution: osmAttribution + ', <a href="https://opentopomap.org/">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
     maxZoom: 17
   }),
   satellite = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
     attribution: esriAttribution,
     maxZoom: 19
   }),
-  osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: osmAttribution,
   }),
-  osm_de = L.tileLayer('https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png', {
+  osm_de = L.tileLayer('https://tile.openstreetmap.de/{z}/{x}/{y}.png', {
     attribution: osmAttribution,
   }),
   hiking = L.tileLayer('https://tile.waymarkedtrails.org/hiking/{z}/{x}/{y}.png', {


### PR DESCRIPTION
Updated tile URLs.

For OSM Carto -aka OSM Standard- tiles (as hosted by OSMF), see https://github.com/openstreetmap/operations/issues/737

For OSM-DE tiles, see [a,b,c.tile.openstreetmap.de subdomains von tile.openstreetmap.de werden aufgehoben](https://community.openstreetmap.org/t/a-b-c-tile-openstreetmap-de-subdomains-von-tile-openstreetmap-de-werden-aufgehoben/100830)

Others;

For OpenTopoMap, see #397.

Use HTTPS / direct links (if HTTP redirect).
<sub>also, OSM recommends EN page to users already, default copyright page URL is recommended for attribution.</sub>