### PR TITLE
fix: fill first empty waypoint slot instead of counting filled waypoints

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -696,7 +696,8 @@ map.on('click', function (e) {
 });
 function addWaypoint(evt) {
   var waypoint = evt && evt.latlng ? evt.latlng : evt;
-  var length = lrmControl.getWaypoints().filter(function(pnt) {
+  var waypoints = lrmControl.getWaypoints();
+  var length = waypoints.filter(function(pnt) {
     return pnt.latLng;
   });
   length = length.length;
@@ -715,11 +716,23 @@ function addWaypoint(evt) {
     return;
   }
 
-  if (!length) {
-    lrmControl.spliceWaypoints(0, 1, waypoint);
+  // Find the first empty waypoint slot.
+  // Counting filled waypoints and deriving the index from that breaks when
+  // only the destination is pre-filled via URL (?loc=&loc=<dest>): the single
+  // filled point sits at index 1, so the old code overwrote the destination
+  // instead of filling the empty start at index 0.
+  var emptyIndex = -1;
+  for (var i = 0; i < waypoints.length; i++) {
+    if (!waypoints[i].latLng) {
+      emptyIndex = i;
+      break;
+    }
+  }
+  if (emptyIndex !== -1) {
+    lrmControl.spliceWaypoints(emptyIndex, 1, waypoint);
   } else {
-    if (length === 1) length = length + 1;
-    lrmControl.spliceWaypoints(length - 1, 1, waypoint);
+    // All slots are filled: replace the last one.
+    lrmControl.spliceWaypoints(waypoints.length - 1, 1, waypoint);
   }
 }
 


### PR DESCRIPTION
## Problem

When the page is opened with only the destination pre-filled via URL (`?loc=&loc=<dest>`), clicking the map overwrites the destination instead of filling the empty start slot.

The waypoint array looks like this:

| Index | latLng |
|-------|--------|
| 0     | null   | ← start, empty
| 1     | {...}  | ← destination, pre-filled

`addWaypoint()` counted the number of filled waypoints (= 1) and derived the target slot from that count. Since it assumed filled waypoints are always packed at the front, it computed slot 1 and overwrote the destination.

## Fix

Instead of counting filled waypoints, scan the array for the first slot without a coordinate and fill that. If all slots are filled, fall back to replacing the last one (previous behaviour).

## Use case

Sites that link to the router with a pre-filled destination (`?loc=&loc=<institution>`) so visitors can set their own start point
with a single map click. The old behaviour destroyed the destination on that click.

Fixes #479