### PR TITLE
fix: keep the map view stable while dragging waypoints

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,11 @@ lrmControl.on('routeselected', function(e) {
 
   // Fit/pan: adjust the map view to the newly selected route
   var boundsCoordinates = routeZoom.getBoundsCoordinates(lrmControl && lrmControl._routes, route);
-  if (boundsCoordinates.length === 0) return;
+  if (boundsCoordinates.length === 0) {
+    // Nothing to fit to: drop the request instead of carrying it into a later route.
+    routeFitTracker.clearFitPending();
+    return;
+  }
 
   var container = document.querySelector('.leaflet-routing-container');
   var paneWidth = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -638,8 +638,10 @@ if (routingContainer) {
   routingContainer.classList.add('leaflet-routing-container-hide');
 }
 
-// Show pane when route is computed
+// Decides whether the next route or geocode result may move the map view
 var routeFitTracker = routeZoom.createRouteFitTracker();
+
+// Show pane when route is computed
 lrmControl.on('routesfound', function(e) {
   var container = document.querySelector('.leaflet-routing-container');
   if (container) {

--- a/src/index.js
+++ b/src/index.js
@@ -639,18 +639,31 @@ if (routingContainer) {
 }
 
 // Show pane when route is computed
-var shouldFitRoute = false;
+var routeFitTracker = routeZoom.createRouteFitTracker();
 lrmControl.on('routesfound', function(e) {
   var container = document.querySelector('.leaflet-routing-container');
   if (container) {
     container.classList.remove('leaflet-routing-container-hide');
   }
-  shouldFitRoute = true;
+  routeFitTracker.routesFound();
+});
+
+// Dragging a marker (or the route line) recomputes the route in place;
+// the view must stay where the user put it.
+plan.on('waypointdragstart', function() {
+  routeFitTracker.waypointDragStarted();
+});
+
+lrmControl.on('routingerror', function() {
+  routeFitTracker.routingFailed();
 });
 
 plan.on('waypointgeocoded', function(e) {
+  // A drag ends with a reverse geocode of the dropped marker; recentering on it
+  // would fight the pan the user just made.
+  if (!routeFitTracker.waypointGeocoded()) return;
   if (plan._waypoints.filter(function(wp) {
-    return !!wp.latLng; 
+    return !!wp.latLng;
   }).length < 2) {
     map.panTo(e.waypoint.latLng);
   }
@@ -703,6 +716,7 @@ function addWaypoint(evt) {
 
   var action = resolveWaypointSlot(waypoints, modifierPressed);
   if (action) {
+    routeFitTracker.waypointPlaced();
     lrmControl.spliceWaypoints(action.index, action.deleteCount, waypoint);
   }
 }
@@ -725,7 +739,7 @@ lrmControl.on('routeselected', function(e) {
   // On the initial route load, the LRM always selects route[0] first.
   // If the URL requested a different alternative, switch to it now.
   // Falls back to route[0] when the requested alternative no longer exists.
-  if (shouldFitRoute) {
+  if (routeFitTracker.isFitPending()) {
     var switchTo = resolveInitialAlternative(route, e.alternatives, state.options.alternative);
     if (switchTo) {
       // Re-fire on lrmControl so the LRM-internal listeners
@@ -764,19 +778,26 @@ lrmControl.on('routeselected', function(e) {
   toolsControl.setRouteGeoJSON(routeGeoJSON);
 
   // Fit/pan: adjust the map view to the newly selected route
-  if (!shouldFitRoute) return;
-  shouldFitRoute = false;
-
   var boundsCoordinates = routeZoom.getBoundsCoordinates(lrmControl && lrmControl._routes, route);
   if (boundsCoordinates.length === 0) return;
-
-  var bounds = L.latLngBounds(boundsCoordinates);
 
   var container = document.querySelector('.leaflet-routing-container');
   var paneWidth = 0;
   if (container && !container.classList.contains('leaflet-routing-container-hide')) {
     paneWidth = container.offsetWidth;
   }
+
+  if (!routeFitTracker.isFitPending()) {
+    // A drag leaves the view alone, unless it pushed the route into the
+    // directions pane — the route must never run underneath it.
+    var containerPoints = boundsCoordinates.map(function(coordinate) {
+      return map.latLngToContainerPoint(coordinate);
+    });
+    if (!routeZoom.isRouteUnderPane(containerPoints, map.getSize(), paneWidth)) return;
+  }
+  routeFitTracker.clearFitPending();
+
+  var bounds = L.latLngBounds(boundsCoordinates);
 
   var currentZoom = map.getZoom();
   var fitPadding = 20;

--- a/src/route_zoom.js
+++ b/src/route_zoom.js
@@ -16,6 +16,78 @@ function getBoundsCoordinates(routes, fallbackRoute) {
   return coordinates;
 }
 
+// Reports whether any part of the route runs into the directions pane. The route
+// must never disappear underneath the pane, so a drag that pushes it there still
+// refits the view even though drags otherwise leave the view alone.
+//
+// containerPoints are the route coordinates projected to container pixels,
+// mapSize is the map's pixel size, paneWidth the width of the directions pane
+// on the right edge (0 when the pane is hidden). A point counts as covered when
+// it lies right of the pane's left edge and within the viewport vertically.
+function isRouteUnderPane(containerPoints, mapSize, paneWidth) {
+  if (!containerPoints || !containerPoints.length) return false;
+  if (!mapSize || !paneWidth || paneWidth <= 0) return false;
+
+  var paneLeft = mapSize.x - paneWidth;
+
+  for (var i = 0; i < containerPoints.length; i++) {
+    var point = containerPoints[i];
+    if (!point) continue;
+    if (point.x > paneLeft && point.y >= 0 && point.y <= mapSize.y) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Tracks whether the map view should follow waypoint changes.
+// Dragging a marker must leave the view untouched: neither the recomputed route
+// nor the reverse geocode that follows the drag may move the map. Only waypoints
+// placed by a click (or typed into the geocoder) refit or recenter the view.
+//
+// A drag triggers a route request and a reverse geocode independently, and their
+// results can arrive in either order, so each is tracked with its own flag and
+// cleared by the result it belongs to.
+function createRouteFitTracker() {
+  var routeRequestFromDrag = false;
+  var geocodeFromDrag = false;
+  var fitPending = false;
+
+  return {
+    waypointDragStarted: function() {
+      routeRequestFromDrag = true;
+      geocodeFromDrag = true;
+    },
+    waypointPlaced: function() {
+      routeRequestFromDrag = false;
+      geocodeFromDrag = false;
+    },
+    routesFound: function() {
+      fitPending = !routeRequestFromDrag;
+      routeRequestFromDrag = false;
+    },
+    routingFailed: function() {
+      routeRequestFromDrag = false;
+    },
+    // Reports whether the geocoded waypoint should be centered, and consumes the
+    // drag state so a later typed geocode recenters as usual.
+    waypointGeocoded: function() {
+      var shouldPan = !geocodeFromDrag;
+      geocodeFromDrag = false;
+      return shouldPan;
+    },
+    isFitPending: function() {
+      return fitPending;
+    },
+    clearFitPending: function() {
+      fitPending = false;
+    }
+  };
+}
+
 module.exports = {
-  getBoundsCoordinates: getBoundsCoordinates
+  getBoundsCoordinates: getBoundsCoordinates,
+  isRouteUnderPane: isRouteUnderPane,
+  createRouteFitTracker: createRouteFitTracker
 };

--- a/src/route_zoom.js
+++ b/src/route_zoom.js
@@ -23,7 +23,10 @@ function getBoundsCoordinates(routes, fallbackRoute) {
 // containerPoints are the route coordinates projected to container pixels,
 // mapSize is the map's pixel size, paneWidth the width of the directions pane
 // on the right edge (0 when the pane is hidden). A point counts as covered when
-// it lies right of the pane's left edge and within the viewport vertically.
+// it falls inside the pane's rectangle: right of the pane's left edge and still
+// within the viewport. Points beyond the viewport are out of sight rather than
+// covered, and a route that reaches them crosses the pane's rectangle on its way
+// out, so it is caught by the points in between.
 function isRouteUnderPane(containerPoints, mapSize, paneWidth) {
   if (!containerPoints || !containerPoints.length) return false;
   if (!mapSize || !paneWidth || paneWidth <= 0) return false;
@@ -33,7 +36,7 @@ function isRouteUnderPane(containerPoints, mapSize, paneWidth) {
   for (var i = 0; i < containerPoints.length; i++) {
     var point = containerPoints[i];
     if (!point) continue;
-    if (point.x > paneLeft && point.y >= 0 && point.y <= mapSize.y) {
+    if (point.x > paneLeft && point.x <= mapSize.x && point.y >= 0 && point.y <= mapSize.y) {
       return true;
     }
   }

--- a/test/route_zoom.test.js
+++ b/test/route_zoom.test.js
@@ -32,3 +32,178 @@ describe('route_zoom', function() {
     expect(combined).toEqual(valid);
   });
 });
+
+describe('route running under the directions pane', function() {
+  var mapSize = {x: 1000, y: 600};
+  var paneWidth = 300;
+
+  test('reports covered when the whole route sits under the pane', function() {
+    var underPane = [{x: 750, y: 100}, {x: 900, y: 400}];
+
+    expect(routeZoom.isRouteUnderPane(underPane, mapSize, paneWidth)).toBe(true);
+  });
+
+  test('reports covered when a single route point reaches under the pane', function() {
+    var mostlyClear = [{x: 100, y: 100}, {x: 400, y: 200}, {x: 701, y: 400}];
+
+    expect(routeZoom.isRouteUnderPane(mostlyClear, mapSize, paneWidth)).toBe(true);
+  });
+
+  test('reports clear when the whole route stays left of the pane', function() {
+    var clear = [{x: 100, y: 100}, {x: 699, y: 400}];
+
+    expect(routeZoom.isRouteUnderPane(clear, mapSize, paneWidth)).toBe(false);
+  });
+
+  test('reports clear when the pane is hidden', function() {
+    var underPane = [{x: 750, y: 100}, {x: 900, y: 400}];
+
+    expect(routeZoom.isRouteUnderPane(underPane, mapSize, 0)).toBe(false);
+  });
+
+  test('ignores points that pass the pane above or below the viewport', function() {
+    var pastPaneOffScreen = [{x: 800, y: -50}, {x: 900, y: 650}];
+
+    expect(routeZoom.isRouteUnderPane(pastPaneOffScreen, mapSize, paneWidth)).toBe(false);
+  });
+
+  test('reports covered when the pane covers the whole map', function() {
+    var anywhere = [{x: 100, y: 100}];
+
+    expect(routeZoom.isRouteUnderPane(anywhere, {x: 280, y: 600}, 300)).toBe(true);
+  });
+
+  test('reports clear without route points to judge', function() {
+    expect(routeZoom.isRouteUnderPane([], mapSize, paneWidth)).toBe(false);
+    expect(routeZoom.isRouteUnderPane(null, mapSize, paneWidth)).toBe(false);
+  });
+
+  test('counts a point on the pane edge as clear', function() {
+    var onEdge = [{x: 700, y: 300}];
+
+    expect(routeZoom.isRouteUnderPane(onEdge, mapSize, paneWidth)).toBe(false);
+  });
+});
+
+describe('route fit tracker', function() {
+  test('requests a fit for routes that follow a clicked waypoint', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointPlaced();
+    tracker.routesFound();
+
+    expect(tracker.isFitPending()).toBe(true);
+  });
+
+  test('starts without a pending fit', function() {
+    expect(routeZoom.createRouteFitTracker().isFitPending()).toBe(false);
+  });
+
+  test('suppresses the fit for routes computed during a waypoint drag', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+    tracker.routesFound();
+
+    expect(tracker.isFitPending()).toBe(false);
+  });
+
+  test('keeps the previous fit request cleared while dragging repeatedly', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+    tracker.routesFound();
+    tracker.waypointDragStarted();
+    tracker.routesFound();
+
+    expect(tracker.isFitPending()).toBe(false);
+  });
+
+  test('fits again on the first route after a drag finished', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+    tracker.routesFound();
+    tracker.routesFound();
+
+    expect(tracker.isFitPending()).toBe(true);
+  });
+
+  test('clears the pending fit once it has been applied', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.routesFound();
+    tracker.clearFitPending();
+
+    expect(tracker.isFitPending()).toBe(false);
+  });
+
+  test('does not carry a failed drag over to the next clicked waypoint', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+    tracker.routingFailed();
+    tracker.routesFound();
+
+    expect(tracker.isFitPending()).toBe(true);
+  });
+
+  test('does not carry an unfinished drag over to the next clicked waypoint', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+    tracker.waypointPlaced();
+    tracker.routesFound();
+
+    expect(tracker.isFitPending()).toBe(true);
+  });
+
+  test('centers a geocoded waypoint that no drag produced', function() {
+    expect(routeZoom.createRouteFitTracker().waypointGeocoded()).toBe(true);
+  });
+
+  test('does not center the reverse geocode that follows a drag', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+
+    expect(tracker.waypointGeocoded()).toBe(false);
+  });
+
+  test('centers again on the geocode after the one a drag produced', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+    tracker.waypointGeocoded();
+
+    expect(tracker.waypointGeocoded()).toBe(true);
+  });
+
+  test('does not center a waypoint dragged after the route was found', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+    tracker.routesFound();
+
+    expect(tracker.waypointGeocoded()).toBe(false);
+  });
+
+  test('suppresses the fit for a drag whose geocode arrived first', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+    tracker.waypointGeocoded();
+    tracker.routesFound();
+
+    expect(tracker.isFitPending()).toBe(false);
+  });
+
+  test('centers a clicked waypoint after an unfinished drag', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointDragStarted();
+    tracker.waypointPlaced();
+
+    expect(tracker.waypointGeocoded()).toBe(true);
+  });
+});

--- a/test/route_zoom.test.js
+++ b/test/route_zoom.test.js
@@ -67,6 +67,18 @@ describe('route running under the directions pane', function() {
     expect(routeZoom.isRouteUnderPane(pastPaneOffScreen, mapSize, paneWidth)).toBe(false);
   });
 
+  test('ignores points that lie off screen to the right of the pane', function() {
+    var pastRightEdge = [{x: 1200, y: 300}, {x: 4000, y: 100}];
+
+    expect(routeZoom.isRouteUnderPane(pastRightEdge, mapSize, paneWidth)).toBe(false);
+  });
+
+  test('reports covered for a route that leaves the viewport through the pane', function() {
+    var acrossPaneAndOut = [{x: 400, y: 300}, {x: 850, y: 300}, {x: 1200, y: 300}];
+
+    expect(routeZoom.isRouteUnderPane(acrossPaneAndOut, mapSize, paneWidth)).toBe(true);
+  });
+
   test('reports covered when the pane covers the whole map', function() {
     var anywhere = [{x: 100, y: 100}];
 


### PR DESCRIPTION
## Problem

Dragging a waypoint marker moved the map twice over: the recomputed route triggered a refit, and the reverse geocode that follows a drag recentered on the dropped marker. The view jumped away from where the drag was made. Only waypoints placed by a click — or typed into the geocoder — should move the view.

## Change

`src/route_zoom.js` gains a route fit tracker that records whether the pending route and the pending reverse geocode originate from a drag. A drag fires both a route request and a reverse geocode, and their results can arrive in either order, so each is tracked with its own flag and cleared by the result it belongs to. A routing error clears the route flag so a failed drag cannot swallow the next click's fit.

`src/index.js` wires the tracker into `routesfound` / `routeselected` / `waypointgeocoded` and marks click-placed waypoints in `addWaypoint()`.

### Exception: the directions pane

The route must never run underneath the directions pane, so a drag-originated route that reaches into the pane still refits — the existing fit already pads by the pane width, so the route lands clear of it. `isRouteUnderPane()` decides this by projecting the route coordinates to container pixels and checking whether any of them fall right of the pane's left edge, within the viewport vertically.

## Tests

`test/route_zoom.test.js` covers both new pieces: the tracker (both orderings of the route and geocode results, drag-then-click, routing errors) and the pane predicate (whole route under, one point under, fully clear, pane hidden, pane covering the map, on-edge point, no points).

Verified in the browser against a live map (2560×1187 viewport, 344px pane) by instrumenting `fitBounds` / `panTo` / `setView` / `flyTo`:

| interaction | map view calls | result |
| --- | --- | --- |
| drag a marker, route clear of the pane | none | center and zoom unchanged |
| drag a marker into the pane | `panTo` | route pulled back clear of the pane |
| click-placed waypoint | `panTo`, `setView` | fits as before |

Ran locally before opening: `npm run test:lint`, `npm run build`, `npm test` (266 tests, including the docker integration test).

---

AI assistance: written with Claude Code — it implemented the tracker and the pane check, wrote the unit tests, and ran the browser verification above. Reviewed before submitting.