### PR TITLE
docs: explain how to use a backend behind HTTP authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,38 @@ docker run -p 9966:9966 \
 2. If only `OSRM_MODES` is set, the frontend parses the JSON and configures the listed modes.
 3. If both are set, `OSRM_MODES` wins and the frontend emits a deprecation warning for `OSRM_BACKEND`.
 
+### Backends behind HTTP authentication
+
+The frontend has no configuration option for backend credentials, and embedding them in the
+backend URL (`https://user:password@example.com`) does not work: browsers refuse to send
+credentials embedded in subresource URLs, so the request either fails with `401` or never
+completes. This is browser policy and cannot be worked around from the page. Credentials placed
+in `OSRM_MODES` would also end up in `config.json`, readable by everyone who loads the frontend.
+
+The supported approach is to keep the credentials on the server side, behind a reverse proxy that
+serves the frontend and the routing endpoint from the same origin. With nginx:
+
+```nginx
+location /osrm/ {
+    proxy_pass https://osrm.internal.example.com/;
+    proxy_set_header Authorization "Basic <base64 of user:password>";
+}
+```
+
+Then point a mode at the proxied path instead of at the backend directly. Relative URLs are
+supported and produce same-origin requests:
+
+```bash
+docker run -p 9966:9966 \
+  -e 'OSRM_MODES=[{"name":"car","url":"/osrm"}]' \
+  ghcr.io/project-osrm/osrm-frontend:latest
+```
+
+If the proxy has to live on a different origin than the frontend, it must answer the CORS
+preflight (`OPTIONS`) request *without* requiring authentication, and include
+`Access-Control-Allow-Headers: authorization` in the response. Otherwise the browser rejects the
+routing request before it is ever sent.
+
 In case Docker complains about not being able to connect to the Docker daemon make sure you are in the `docker` group.
 
 ```

--- a/test/leaflet_options.test.js
+++ b/test/leaflet_options.test.js
@@ -351,6 +351,23 @@ describe('leaflet_options — runtime configuration overrides', () => {
       delete global.window;
     });
 
+    test('supports a relative backend URL for same-origin reverse proxies', () => {
+      // Deployments that put an authenticating proxy in front of the backend point
+      // a mode at a path on the frontend's own origin (see README).
+      const modesJSON = JSON.stringify([
+        { name: 'car', url: '/osrm' }
+      ]);
+      global.window = {
+        osrmConfig: {
+          OSRM_ENVIRONMENT: 'docker',
+          OSRM_MODES: modesJSON
+        }
+      };
+      const leafletOptions = require('../src/leaflet_options');
+      expect(leafletOptions.services[0].path).toBe('/osrm/route/v1');
+      delete global.window;
+    });
+
     test('defaults to three public profiles in dev mode', () => {
       global.window = { osrmConfig: { OSRM_ENVIRONMENT: undefined } };
       const leafletOptions = require('../src/leaflet_options');


### PR DESCRIPTION
Documents how to run the frontend against an OSRM backend that requires HTTP authentication, and adds a regression test for the mechanism the documentation relies on.

Addresses the question in #316.

## Background

There is no way to configure backend credentials in the frontend today, and the approach reported in #316 (`OSRM_BACKEND='https://user:password@host'`) cannot be made to work from the page:

- Browsers refuse to send credentials embedded in subresource URLs. Chrome strips them and the request fails with `401`; Firefox behaves differently but does not deliver a usable request either.
- Routing requests go through `@mapbox/corslite`, which calls `open()` and `send()` back to back with no hook for request headers, so an `Authorization` header cannot be attached without replacing the transport.
- Credentials set through `OSRM_MODES` are written to `config.json` and served to every visitor, so a browser-side credential option would not be a secret in the first place.

## Changes

- `README.md`: new *Backends behind HTTP authentication* section describing the supported setup — a reverse proxy that holds the credentials server-side and exposes the routing endpoint on the frontend's own origin, configured via a relative `OSRM_MODES` URL. Includes an nginx snippet and the CORS preflight requirement that applies when the proxy lives on a different origin.
- `test/leaflet_options.test.js`: relative mode URLs already resolve to a same-origin service path (`{"url":"/osrm"}` → `/osrm/route/v1`), but nothing covered it. Added a test so the documented configuration stays supported.

Documentation and test only; no behaviour change and no rebuilt bundle.

## Verification

- `npm run test:lint` passes.
- `npm run build` passes and produces no artifact diff.
- `npm test` passes except `test/docker-image.test.js`, which fails locally because the Docker daemon here rejects the buildx request; it is unrelated to this change and should pass in CI.

Drafted with AI assistance and reviewed before submitting.