### PR TITLE
feat: make the debug map link configurable per routing profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,4 @@ OSRM Frontend is the browser-based routing interface served at https://map.proje
 - Commit generated artifacts (`bundle.js`, `bundle.js.map`, `dist/`) only when necessary.
 - When adding routing backends, prefer `OSRM_MODES` env var over editing `src/leaflet_options.js`.
 - The debug tile viewer at `/debug` has its own `index.html` — keep it in sync if tile sources change.
+- The "Open in Debug Map" link is per routing mode (`debugUrl` in `OSRM_MODES`), applied via `toolsControl.setDebugUrl()` on every profile change.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,16 @@ By default Docker uses a single routing profile named `default` and sends reques
 
 ### Recommended: multiple profiles with `OSRM_MODES`
 
-`OSRM_MODES` is the current Docker runtime configuration interface. It accepts a JSON array of objects with `name` and `url` fields.
+`OSRM_MODES` is the current Docker runtime configuration interface. It accepts a JSON array of objects
+with the following fields:
+
+| Field      | Required | Purpose |
+|------------|----------|---------|
+| `name`     | yes      | Label shown in the mode selector. |
+| `url`      | yes      | Backend base URL. `/route/v1` is appended unless `path` is set. |
+| `path`     | no       | Explicit routing path, e.g. `https://routing.openstreetmap.de/routed-bike/route/v1`. |
+| `profile`  | no       | Internal profile (`driving`, `bike`, `foot`). Defaults by position: 0 → driving, 1 → bike, 2 → foot. |
+| `debugUrl` | no       | Debug map opened by the "Open in Debug Map" tool button while this mode is active. Defaults to the bundled `debug/`. |
 
 ```bash
 docker run -p 9966:9966 \
@@ -189,3 +198,21 @@ For debug tiles showing speeds and small components available at `/debug` adjust
   "tiles" : ["http://localhost:5000/tile/v1/car/tile({x},{y},{z}).mvt"]
 }
 ```
+
+The bundled debug map serves a single tile source, so it can only ever match one profile. Since each
+routing mode usually needs its own debug view, the link behind the "Open in Debug Map" button is
+configurable per mode via `debugUrl`. Deploy one debug map per profile and point each mode at its own:
+
+```bash
+docker run -p 9966:9966 \
+  -e 'OSRM_MODES=[
+        {"name":"car","url":"http://localhost:5000","debugUrl":"debug-car/"},
+        {"name":"bike","url":"http://localhost:5001","debugUrl":"https://debug.example.com/bike/"}
+      ]' \
+  ghcr.io/project-osrm/osrm-frontend:latest
+```
+
+Relative URLs resolve against the frontend origin (so `debug-car/` under a `/osrm-frontend/` deployment
+becomes `/osrm-frontend/debug-car/`); absolute URLs are used as-is. In both cases the current map
+position is appended as a `#zoom/lat/lng` hash, exactly as with the bundled debug map. A mode without
+`debugUrl` keeps opening the bundled `debug/`.

--- a/src/index.js
+++ b/src/index.js
@@ -423,6 +423,21 @@ if (L && L.DomEvent && typeof L.DomEvent.disableScrollPropagation === 'function'
 
 var toolsControl = tools.control(localization.get(mergedOptions.language), localization.getLanguages(), Object.assign({}, options.tools, { initialUnits: mergedOptions.units })).addTo(map);
 
+/**
+ * Point the tools control's debug map button at the debug map configured for a
+ * routing mode. Modes without an explicit `debugUrl` fall back to the bundled
+ * debug map at `debug/`.
+ *
+ * @param {number} profileIndex — Index into `services`.
+ */
+function applyDebugUrlForProfile(profileIndex) {
+  var service = services[profileIndex];
+  if (!toolsControl || typeof toolsControl.setDebugUrl !== 'function') return;
+  toolsControl.setDebugUrl(service && service.debugUrl);
+}
+
+applyDebugUrlForProfile(activeProfileIndex);
+
 var state = state(map, lrmControl, toolsControl, modeSelector, mergedOptions);
 
 // Listen for browser navigation (back/forward) and restore app state
@@ -474,6 +489,7 @@ if (urlState && urlState.listen) {
         if (!isNaN(profileIndex)) {
           try {
             routerPatches.setActiveService(router, profileIndex, services);
+            applyDebugUrlForProfile(profileIndex);
             ls.set('profile', profileIndex);
             if (modeSelector && modeSelector.select) modeSelector.select.value = profileIndex;
             state.options.profile = profileIndex;
@@ -567,6 +583,7 @@ if (toolsControl && toolsControl.on) {
       var profileIndex = parseInt(event.target.value, 10);
       clearProfileSelectorSelection(event.target);
       routerPatches.setActiveService(router, profileIndex, services);
+      applyDebugUrlForProfile(profileIndex);
       ls.set('profile', profileIndex);
       
       // Also update the state object so profile is preserved on language change

--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -83,7 +83,7 @@ function getLabel() {
  * Parse routing modes from the runtime config.
  *
  * **Precedence (highest to lowest):**
- * 1. `OSRM_MODES` — preferred JSON array of `{name, url, path?, profile?}` objects.
+ * 1. `OSRM_MODES` — preferred JSON array of `{name, url, path?, profile?, debugUrl?}` objects.
  *    Also accepts a plain array of URL strings (auto-named "Mode 1", "Mode 2", …).
  *    When `profile` is not specified it defaults by position: index 0 → `'driving'`,
  *    index 1 → `'bike'`, index 2 → `'foot'`, index ≥ 3 → `'driving'`.
@@ -94,9 +94,10 @@ function getLabel() {
  * If both `OSRM_MODES` and `OSRM_BACKEND` are set, `OSRM_MODES` wins and a
  * deprecation warning is emitted.
  *
- * @returns {Array<{name: string, url: string, path?: string, profile: string}>}
+ * @returns {Array<{name: string, url: string, path?: string, profile: string, debugUrl?: string}>}
  *   An array of mode objects, each with a display name, backend URL, optional
- *   explicit routing path, and an internal routing profile (`driving`, `bike`, `foot`).
+ *   explicit routing path, an internal routing profile (`driving`, `bike`, `foot`),
+ *   and an optional debug map URL for the “Open in Debug Map” tool button.
  */
 function parseModes() {
   // Read config fresh from window each time, not the captured config variable
@@ -162,6 +163,7 @@ function parseModes() {
             profile: mode.profile || profileNames[index] || 'driving'  // Honor explicit profile, fall back to positional
           };
           if (mode.path) result.path = mode.path;  // preserve explicit path (e.g. routed-bike/route/v1)
+          if (mode.debugUrl) result.debugUrl = mode.debugUrl;  // preserve per-mode debug map link
           return result;
         });
       }
@@ -395,9 +397,10 @@ var defaultLayer = layerMap[getDefaultLayer()] || streets;
  *
  * Each entry exposes a human-readable `label`, a `labelKey` for localization,
  * the `path` used for routing requests (`/route/v1` appended to the backend URL
- * by default), and an internal `profile` identifier (`driving`, `bike`, `foot`).
+ * by default), an internal `profile` identifier (`driving`, `bike`, `foot`), and
+ * an optional `debugUrl` pointing at the debug map for that mode.
  *
- * @returns {Array<{label: string, labelKey: string, path: string, profile: string}>}
+ * @returns {Array<{label: string, labelKey: string, path: string, profile: string, debugUrl?: string}>}
  *   An array of service descriptors, one per configured routing mode.
  */
 function buildServices() {
@@ -412,12 +415,14 @@ function buildServices() {
     var name = mode.name;
     var label = mode.label || name;
     var labelKey = mode.labelKey || defaultLabelMapping[name] || label;
-    return {
+    var service = {
       label: label,
       labelKey: labelKey,
       path: mode.path || (mode.url + '/route/v1'),
       profile: mode.profile
     };
+    if (mode.debugUrl) service.debugUrl = mode.debugUrl;
+    return service;
   });
 }
 
@@ -442,7 +447,7 @@ function buildServices() {
  *
  * | Variable               | Default                          | Description |
  * |------------------------|----------------------------------|-------------|
- * | `OSRM_MODES`           | (public OSRM services)           | JSON array of `{name, url, path?, profile?}` routing backends. `profile` defaults by position (driving → bike → foot). |
+ * | `OSRM_MODES`           | (public OSRM services)           | JSON array of `{name, url, path?, profile?, debugUrl?}` routing backends. `profile` defaults by position (driving → bike → foot). `debugUrl` overrides the debug map link for that mode. |
  * | `OSRM_BACKEND`         | —                                | **Deprecated.** Single backend URL. Use `OSRM_MODES` instead. |
  * | `OSRM_CENTER`          | `38.8995,-77.0269`               | Comma-separated "lat,lng" for the initial map center. |
  * | `OSRM_ZOOM`            | `13`                             | Initial zoom level (0–18). |

--- a/src/tools.js
+++ b/src/tools.js
@@ -30,6 +30,9 @@ var Control = L.Control.extend({
     editorButtonClass: "",
     josmButtonClass: "",
     debugButtonClass: "",
+    // Debug map link. Relative URLs resolve against the frontend origin.
+    // Overridden per routing mode via the mode's `debugUrl` property.
+    debugUrl: "debug/",
     mapillaryButtonClass: "",
     shareButtonClass: "",
     gpxButtonClass: "",
@@ -116,11 +119,27 @@ var Control = L.Control.extend({
     window.open(url);
   },
 
+  /**
+   * Point the debug map button at a different debug map, e.g. when the active
+   * routing mode carries its own `debugUrl`. Falsy values restore the default.
+   *
+   * @param {string} url — Absolute or frontend-relative debug map URL.
+   */
+  setDebugUrl: function(url) {
+    this.options.debugUrl = url || 'debug/';
+  },
+
   _openDebug: function() {
     var position = this._map.getCenter(),
       zoom = this._map.getZoom(),
       prec = 6,
+      debugUrl;
+    try {
+      debugUrl = new URL(this.options.debugUrl || 'debug/', window.location.href);
+    } catch (e) {
+      console.warn('Invalid debug map URL, falling back to the bundled debug map:', e);
       debugUrl = new URL('debug/', window.location.href);
+    }
     debugUrl.hash = zoom + "/" + position.lat.toFixed(prec) + "/" + position.lng.toFixed(prec);
     window.open(debugUrl.href);
   },

--- a/test/leaflet_options.test.js
+++ b/test/leaflet_options.test.js
@@ -332,6 +332,22 @@ describe('leaflet_options — runtime configuration overrides', () => {
       delete global.window;
     });
 
+    test('preserves a per-mode debugUrl from OSRM_MODES', () => {
+      const modesJSON = JSON.stringify([
+        { name: 'Car', url: 'http://localhost:5000', debugUrl: 'https://debug.example.com/car/' },
+        { name: 'Bike', url: 'http://localhost:5001' }
+      ]);
+      global.window = {
+        osrmConfig: {
+          OSRM_MODES: modesJSON
+        }
+      };
+      const leafletOptions = require('../src/leaflet_options');
+      expect(leafletOptions.services[0].debugUrl).toBe('https://debug.example.com/car/');
+      expect(leafletOptions.services[1].debugUrl).toBeUndefined();
+      delete global.window;
+    });
+
     test('preserves explicit path from OSRM_MODES (e.g. routed-bike subdirectory)', () => {
       const modesJSON = JSON.stringify([
         { name: 'driving', url: 'https://router.project-osrm.org', path: 'https://router.project-osrm.org/route/v1' },

--- a/test/tools.test.js
+++ b/test/tools.test.js
@@ -138,6 +138,40 @@ describe('tools debug map link', () => {
     );
   });
 
+  test('uses a configured debug map URL for the active routing mode', () => {
+    window.history.replaceState({}, '', '/?z=13');
+
+    control.setDebugUrl('https://debug.example.com/bike/');
+    control._openDebug();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://debug.example.com/bike/#13/38.899500/-77.026900'
+    );
+  });
+
+  test('resolves a relative debug map URL against the frontend origin', () => {
+    window.history.replaceState({}, '', '/osrm-frontend/index.html?z=13');
+
+    control.setDebugUrl('debug-bike/');
+    control._openDebug();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'http://localhost/osrm-frontend/debug-bike/#13/38.899500/-77.026900'
+    );
+  });
+
+  test('falls back to the bundled debug map when a mode has no debug URL', () => {
+    window.history.replaceState({}, '', '/?z=13');
+
+    control.setDebugUrl('https://debug.example.com/bike/');
+    control.setDebugUrl(undefined);
+    control._openDebug();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'http://localhost/debug/#13/38.899500/-77.026900'
+    );
+  });
+
   test('keeps the Leaflet event API on the control', () => {
     var handler = jest.fn();
 


### PR DESCRIPTION
## Problem

The "Open in Debug Map" tool button always opens the bundled debug map at `debug/`. That page has a single hardcoded vector tile source (`router.project-osrm.org/tile/v1/car/…`), so it can only ever match one profile. A deployment configured with car/bike/foot modes has no way to send each mode to its own debug view.

## Change

Routing modes accept an optional `debugUrl`:

```json
[
  {"name":"car","url":"http://localhost:5000","debugUrl":"debug-car/"},
  {"name":"bike","url":"http://localhost:5001","debugUrl":"https://debug.example.com/bike/"}
]
```

- `src/leaflet_options.js` — `parseModes()` preserves `debugUrl` from the mode config (alongside `path`); `buildServices()` carries it onto the service descriptor.
- `src/tools.js` — `debugUrl` becomes a control option (default `"debug/"`) with a `setDebugUrl()` setter. `_openDebug()` reads it and falls back to the bundled map if the URL is unparseable.
- `src/index.js` — new `applyDebugUrlForProfile()`, called at startup and from both places a profile switch lands: the mode-selector `change` handler and the back/forward history restore. Without the second call the button goes stale after a browser back.

Relative URLs resolve against the frontend origin (`debug-car/` under `/osrm-frontend/` becomes `/osrm-frontend/debug-car/`), absolute URLs are used as-is, and the `#zoom/lat/lng` hash is appended either way. A mode without `debugUrl` keeps opening the bundled `debug/`, so existing deployments are unchanged.

Works the same for non-Docker deployments, where modes are set in the inline `window.osrmConfig` block in `index.html`.

## Tests

Three cases in `test/tools.test.js` (absolute URL, relative URL under a subpath, fallback when a mode has no debug URL) and one in `test/leaflet_options.test.js` (`debugUrl` surfaces on the service, absent when unset). Full suite: 273 passed. Lint clean.

`bundle.js` / `dist/` are not rebuilt here — `npm run build` also runs `scripts/replace.js`, which rewrites sources in place.

## Follow-ups, not in this PR

- The bundled `debug/index.html` could take its tile source from a query param, which would let one deployed debug map serve every profile.
- `buildServices()` reads `mode.label` / `mode.labelKey`, but `parseModes()` drops those fields, so they can never arrive and labels always fall back to `name`. Pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)