### PR TITLE
feat: offer Nominatim entrance nodes as routing targets

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -1224,12 +1224,6 @@ td.distance {
     background-color: #7fb2e5;
 }
 
-/* The centroid the geocoder originally returned, kept as a choice so a waypoint
-   moved to an entrance can always be moved back. */
-.osrm-entrance-marker-centre {
-    background-color: #8b8b8b;
-}
-
 /* The door the route currently runs to. Filled dark and ringed, so it reads as
    chosen while every other door stays on the map and one click away. */
 .osrm-entrance-marker-selected {

--- a/css/site.css
+++ b/css/site.css
@@ -1260,10 +1260,12 @@ td.distance {
 }
 
 /* A merged label lists one door per line, so it cannot stay on one. */
-/* Marks a door tagged wheelchair=yes or wheelchair=designated in OSM. A mark
-   only, never a filter: most doors carry no wheelchair tag at all, so its
-   absence says nothing about the door. */
-.osrm-entrance-wheelchair {
+/* Marks something about a door worth knowing in the current travel mode:
+   step-free access on foot, a way in for a car when driving. A mark only, never
+   a filter — most doors carry neither tag, so an absent one says nothing about
+   the door. The per-mark classes carry no styling of their own yet; they exist
+   so a mark can be restyled without touching the others. */
+.osrm-entrance-mark {
     margin-left: 5px;
     font-size: 11px;
     line-height: 1;

--- a/css/site.css
+++ b/css/site.css
@@ -1255,8 +1255,21 @@ td.distance {
     font-size: 12px;
     line-height: 1.35;
     padding: 3px 7px;
-    pointer-events: none;
+    /* Clickable, standing in for the door it names; a merged label is the only
+       way to pick apart doors too close together to aim at. */
+    pointer-events: auto;
+    cursor: pointer;
     white-space: nowrap;
+}
+
+.osrm-entrance-label-inner div:hover {
+    color: #2b7ac9;
+}
+
+/* The line for the door the route runs to, matching its filled dot. */
+.osrm-entrance-label-selected {
+    font-weight: bold;
+    color: #022bb1;
 }
 
 /* A merged label lists one door per line, so it cannot stay on one. */

--- a/css/site.css
+++ b/css/site.css
@@ -1193,3 +1193,81 @@ td.distance {
     pointer-events: none;
     z-index: 1000;
 }
+
+/* Entrance picker — alternative positions offered for a geocoded place.
+   Nominatim gives entrance nodes no name or ref, so the dot's position on the
+   map is the only thing that tells one apart from another. They are deliberately
+   smaller and flatter than the A/B waypoint pins: the pin shows where the route
+   actually starts, these only show where it could be moved to. */
+.osrm-entrance-marker {
+    box-sizing: border-box;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 3px solid #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+    transition: transform 0.1s ease-out;
+}
+
+.osrm-entrance-marker:hover {
+    transform: scale(1.35);
+}
+
+/* A door tagged entrance=main — the one most travellers are looking for. */
+.osrm-entrance-marker-main {
+    background-color: #2b7ac9;
+}
+
+/* Any other public entrance. */
+.osrm-entrance-marker-other {
+    background-color: #7fb2e5;
+}
+
+/* The centroid the geocoder originally returned, kept as a choice so a waypoint
+   moved to an entrance can always be moved back. */
+.osrm-entrance-marker-centre {
+    background-color: #8b8b8b;
+}
+
+/* The door the route currently runs to. Filled dark and ringed, so it reads as
+   chosen while every other door stays on the map and one click away. */
+.osrm-entrance-marker-selected {
+    background-color: #022bb1;
+    border-color: #fff;
+    box-shadow: 0 0 0 3px rgba(2, 43, 177, 0.35), 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+/* Entrance labels. Permanent, so every door names itself without being
+   hovered. Owned by the picker rather than drawn as Leaflet tooltips: the
+   tooltip pane sits above the marker pane, which would put a label over the dot
+   it names. As markers they share the pane with the dots, and a lower
+   zIndexOffset keeps every dot on top. */
+.osrm-entrance-label {
+    /* Zero-sized, so the anchor is the door itself. */
+    width: 0;
+    height: 0;
+}
+
+.osrm-entrance-label-inner {
+    position: absolute;
+    left: 0;
+    bottom: 14px;
+    transform: translateX(-50%);
+    background-color: rgba(255, 255, 255, 0.94);
+    border-radius: 3px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+    color: #14243f;
+    font-size: 12px;
+    line-height: 1.35;
+    padding: 3px 7px;
+    pointer-events: none;
+    white-space: nowrap;
+}
+
+/* A merged label lists one door per line, so it cannot stay on one. */
+.osrm-entrance-label-merged .osrm-entrance-label-inner div + div {
+    border-top: 1px solid rgba(20, 36, 63, 0.12);
+    margin-top: 2px;
+    padding-top: 2px;
+}

--- a/css/site.css
+++ b/css/site.css
@@ -1266,6 +1266,16 @@ td.distance {
 }
 
 /* A merged label lists one door per line, so it cannot stay on one. */
+/* Marks a door tagged wheelchair=yes or wheelchair=designated in OSM. A mark
+   only, never a filter: most doors carry no wheelchair tag at all, so its
+   absence says nothing about the door. */
+.osrm-entrance-wheelchair {
+    margin-left: 5px;
+    font-size: 11px;
+    line-height: 1;
+    vertical-align: baseline;
+}
+
 .osrm-entrance-label-merged .osrm-entrance-label-inner div + div {
     border-top: 1px solid rgba(20, 36, 63, 0.12);
     margin-top: 2px;

--- a/i18n/de.js
+++ b/i18n/de.js
@@ -20,7 +20,6 @@ module.exports = {
   'Main entrance': 'Haupteingang',
   'Entrance': 'Eingang',
   'Wheelchair accessible': 'Rollstuhlgerecht',
-  'Centre of place': 'Ortsmitte',
   'main entrance': 'Haupteingang',
   'entrance': 'Eingang',
   'Exit': 'Ausgang',

--- a/i18n/de.js
+++ b/i18n/de.js
@@ -20,6 +20,7 @@ module.exports = {
   'Main entrance': 'Haupteingang',
   'Entrance': 'Eingang',
   'Wheelchair accessible': 'Rollstuhlgerecht',
+  'Parking entrance': 'Parkhauseinfahrt',
   'main entrance': 'Haupteingang',
   'entrance': 'Eingang',
   'Exit': 'Ausgang',

--- a/i18n/de.js
+++ b/i18n/de.js
@@ -17,5 +17,12 @@ module.exports = {
   'Bike': 'Fahrrad',
   'Car': 'Auto',
   'Foot': 'Fussgänger',
+  'Main entrance': 'Haupteingang',
+  'Entrance': 'Eingang',
+  'Centre of place': 'Ortsmitte',
+  'main entrance': 'Haupteingang',
+  'entrance': 'Eingang',
+  'Exit': 'Ausgang',
+  'exit': 'Ausgang',
   'Build': 'Build: '
 };

--- a/i18n/de.js
+++ b/i18n/de.js
@@ -19,6 +19,7 @@ module.exports = {
   'Foot': 'Fussgänger',
   'Main entrance': 'Haupteingang',
   'Entrance': 'Eingang',
+  'Wheelchair accessible': 'Rollstuhlgerecht',
   'Centre of place': 'Ortsmitte',
   'main entrance': 'Haupteingang',
   'entrance': 'Eingang',

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -20,6 +20,7 @@ module.exports = {
   'Main entrance': 'Main entrance',
   'Entrance': 'Entrance',
   'Wheelchair accessible': 'Wheelchair accessible',
+  'Parking entrance': 'Parking entrance',
   'main entrance': 'main entrance',
   'entrance': 'entrance',
   'Exit': 'Exit',

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -19,6 +19,7 @@ module.exports = {
   'Foot': 'Foot',
   'Main entrance': 'Main entrance',
   'Entrance': 'Entrance',
+  'Wheelchair accessible': 'Wheelchair accessible',
   'Centre of place': 'Centre of place',
   'main entrance': 'main entrance',
   'entrance': 'entrance',

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -20,7 +20,6 @@ module.exports = {
   'Main entrance': 'Main entrance',
   'Entrance': 'Entrance',
   'Wheelchair accessible': 'Wheelchair accessible',
-  'Centre of place': 'Centre of place',
   'main entrance': 'main entrance',
   'entrance': 'entrance',
   'Exit': 'Exit',

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -17,5 +17,12 @@ module.exports = {
   'Bike': 'Bike',
   'Car': 'Car',
   'Foot': 'Foot',
+  'Main entrance': 'Main entrance',
+  'Entrance': 'Entrance',
+  'Centre of place': 'Centre of place',
+  'main entrance': 'main entrance',
+  'entrance': 'entrance',
+  'Exit': 'Exit',
+  'exit': 'exit',
   'Build': 'Build: '
 };

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -778,6 +778,49 @@ function createEntrancePicker(map, options) {
     return true;
   }
 
+  /**
+   * Follows a splice of the waypoint list.
+   *
+   * Offers are keyed by waypoint index, so inserting or removing a waypoint
+   * renumbers the ones after it. Dropping every offer instead — which is what
+   * this used to do — meant that placing a destination by clicking the map took
+   * away the doors the start was already showing.
+   *
+   * @param {number} index — where the splice happened
+   * @param {number} nRemoved — waypoints deleted there
+   * @param {number} nAdded — waypoints inserted there
+   */
+  function spliceOffers(index, nRemoved, nAdded) {
+    var removed = nRemoved || 0;
+    var delta = (nAdded || 0) - removed;
+    var kept = [];
+    offers.forEach(function(offer) {
+      // Untouched: it sits before the splice.
+      if (offer.waypointIndex < index) {
+        kept.push(offer);
+        return;
+      }
+      // Its waypoint is gone, and so is the place it belonged to.
+      if (offer.waypointIndex < index + removed) {
+        if (activeWaypointIndex === offer.waypointIndex) activeWaypointIndex = null;
+        return;
+      }
+      if (activeWaypointIndex === offer.waypointIndex) activeWaypointIndex += delta;
+      offer.waypointIndex += delta;
+      kept.push(offer);
+    });
+    if (kept.length === offers.length && !delta) return;
+    offers = kept;
+    if (!offers.length) {
+      hide();
+      return;
+    }
+    if (activeWaypointIndex === null) {
+      activeWaypointIndex = offers[offers.length - 1].waypointIndex;
+    }
+    render();
+  }
+
   // Withdraws one waypoint's offer, leaving every other one on the map.
   function hideWaypoint(waypointIndex) {
     var offer = offerAt(waypointIndex);
@@ -817,6 +860,7 @@ function createEntrancePicker(map, options) {
     show: show,
     hide: hide,
     hideWaypoint: hideWaypoint,
+    spliceOffers: spliceOffers,
     focusView: focusViewWhenSettled,
     layoutLabels: layoutLabels,
     isOpen: function() {

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -1,0 +1,676 @@
+'use strict';
+
+var L = require('leaflet');
+
+// Which OSM `entrance=*` values can serve as a routing endpoint, and in which
+// direction. Two of them are one-way, per the wiki's own definitions:
+//
+//   entrance=exit      "it is a one-way out of a building or enclosed area"
+//   entrance=entrance  "it is an entrance only, a one-way in"
+//
+// so an exit is a legitimate place to *start* a route and a useless place to end
+// one, and vice versa. Values absent from this table are never offered:
+// `service` (staff and deliveries), `emergency` (fire escape), `staircase` and
+// `garage` (interior doors), and `no` — which the wiki defines as looking like a
+// door but not being usable at all.
+var ENTRANCE_USE = {
+  main:      {enter: true, leave: true},
+  yes:       {enter: true, leave: true},
+  secondary: {enter: true, leave: true},
+  shop:      {enter: true, leave: true},
+  home:      {enter: true, leave: true},
+  entrance:  {enter: true, leave: false},
+  exit:      {enter: false, leave: true}
+};
+
+// The area has to fill at least this share of the free viewport to count as
+// framed. Below it the site reads as a blob somewhere on the map rather than as
+// the place the user is choosing a door into.
+var MIN_EXTENT_FILL = 0.35;
+
+var MAX_PICKER_ZOOM = 18;
+
+// Ties the chosen door back to the pin that stayed on the place. Dashed
+// throughout, and thinner than the route, so it never reads as something you can
+// travel along.
+var ENTRANCE_LINK_STYLE = {
+  color: '#2b7ac9',
+  weight: 3,
+  opacity: 0.9,
+  dashArray: '3,7',
+  lineCap: 'round',
+  interactive: false
+};
+
+// Breathing room between the framed area and the edges of the free viewport.
+var FIT_PADDING = 24;
+
+// Two entrance dots closer together than this on screen cannot be aimed at
+// separately. The dots are 18 px across, so this leaves a clear gap between them.
+var MIN_DOT_SEPARATION_PX = 32;
+
+// Long enough to outlast Leaflet's default 250 ms pan/zoom animation.
+var SETTLE_TIMEOUT_MS = 450;
+
+// Labels live in their own pane, kept just below Leaflet's marker pane (600).
+// A zIndexOffset cannot do this job: Leaflet derives a marker's z-index from its
+// latitude, so a label on a northerly door still outranks a dot on a southerly
+// one however the offsets are set. A pane settles it for every marker at once.
+var LABEL_PANE = 'osrmEntranceLabels';
+var LABEL_PANE_Z_INDEX = 590;
+
+// The site the entrances belong to. Muted and non-interactive: it is context for
+// the dots, not a thing to click, and it must never obscure the route line.
+var OUTLINE_STYLE = {
+  color: '#2b7ac9',
+  weight: 2,
+  opacity: 0.7,
+  dashArray: '6 4',
+  fill: true,
+  fillColor: '#2b7ac9',
+  fillOpacity: 0.07,
+  interactive: false
+};
+
+// The OSM access keys that govern each routing mode, most specific first. The
+// general `access` key is the fallback for all of them, and `vehicle` covers
+// both wheeled modes. This is the ordering OSM's access documentation
+// prescribes: the most specific tag present wins.
+var MODE_ACCESS_KEYS = {
+  foot: ['foot', 'access'],
+  bike: ['bicycle', 'vehicle', 'access'],
+  bicycle: ['bicycle', 'vehicle', 'access'],
+  driving: ['motor_vehicle', 'vehicle', 'access'],
+  car: ['motor_vehicle', 'vehicle', 'access']
+};
+
+// Values that put a door out of bounds. Everything else — `yes`, `permissive`,
+// `designated`, `destination`, `customers`, `permit` — is treated as usable:
+// somebody routing to a shop's door is the customer it is tagged for. An
+// unrecognised value is not read as a prohibition.
+var FORBIDDEN_ACCESS = {no: true, private: true};
+
+/**
+ * Whether a door's own tags permit the given travel mode. A door with nothing
+ * to say on the subject is allowed: absence of a tag is not a prohibition.
+ *
+ * @param {object} entrance — with an optional `tags` map from OSM
+ * @param {string} [mode] — 'foot', 'bike'/'bicycle', or 'driving'/'car'
+ */
+function allowsMode(entrance, mode) {
+  if (!mode) return true;
+  var keys = MODE_ACCESS_KEYS[mode];
+  if (!keys) return true;
+  var tags = entrance && entrance.tags;
+  if (!tags) return true;
+  for (var i = 0; i < keys.length; i++) {
+    var value = tags[keys[i]];
+    // The most specific tag present settles it; a broader one cannot override.
+    if (typeof value === 'string') return !FORBIDDEN_ACCESS[value.toLowerCase()];
+  }
+  return true;
+}
+
+/**
+ * The entrances usable at one end of a route, for one travel mode.
+ *
+ * @param {Array} entrances
+ * @param {string} [role] — 'origin' (the traveller leaves the building here),
+ *   'destination' (arrives), or 'via' (both, and so the strictest). Defaults to
+ *   'via', which offers only doors that work in either direction.
+ * @param {string} [mode] — the routing profile. Omitted, no access filtering is
+ *   applied.
+ */
+function routableEntrances(entrances, role, mode) {
+  if (!Array.isArray(entrances)) return [];
+  // A via point is both arrived at and left from, so it needs both directions.
+  var needsEnter = role !== 'origin';
+  var needsLeave = role !== 'destination';
+  return entrances.filter(function(entrance) {
+    if (!entrance || !entrance.center) return false;
+    var use = ENTRANCE_USE[entrance.type];
+    if (!use) return false;
+    if (!((!needsEnter || use.enter) && (!needsLeave || use.leave))) return false;
+    return allowsMode(entrance, mode);
+  });
+}
+
+/**
+ * The name a door carries in OSM, if any. Most entrances have none — which is
+ * why the picker is a map rather than a list — but the ones that do are named
+ * exactly as the signage reads ("Haupteingang Alexanderplatz", "Eingang
+ * Ravelinplatz"), and that beats any label this app could invent. `ref` is the
+ * fallback for doors numbered rather than named.
+ *
+ * @param {object} entrance
+ * @returns {string|null}
+ */
+function entranceName(entrance) {
+  var tags = entrance && entrance.tags;
+  if (!tags) return null;
+  var name = tags.name || tags.ref;
+  if (typeof name !== 'string') return null;
+  name = name.trim();
+  return name.length ? name : null;
+}
+
+// Two label boxes touching edge-to-edge are not overlapping; only real overlap
+// counts, so labels may sit flush against each other.
+function boxesOverlap(a, b) {
+  return !(a.right <= b.left || b.right <= a.left || a.bottom <= b.top || b.bottom <= a.top);
+}
+
+/**
+ * Groups labels that cannot all be shown at once.
+ *
+ * Overlap is transitive here: if A overlaps B and B overlaps C then all three
+ * become one group, even where A and C are clear of each other. Showing A and C
+ * but not B would be arbitrary, and the whole run has to collapse into one label
+ * for the result to be readable.
+ *
+ * @param {Array<{left: number, right: number, top: number, bottom: number}>} boxes
+ * @returns {Array<Array<number>>} indices, grouped; singletons are groups of one
+ */
+function clusterOverlappingLabels(boxes) {
+  if (!Array.isArray(boxes) || boxes.length === 0) return [];
+  // Union-find over the boxes.
+  var parent = boxes.map(function(_, i) {
+    return i; 
+  });
+  function find(i) {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]];
+      i = parent[i];
+    }
+    return i;
+  }
+  function union(a, b) {
+    var ra = find(a);
+    var rb = find(b);
+    if (ra !== rb) parent[rb] = ra;
+  }
+  for (var i = 0; i < boxes.length - 1; i++) {
+    for (var j = i + 1; j < boxes.length; j++) {
+      if (boxes[i] && boxes[j] && boxesOverlap(boxes[i], boxes[j])) union(i, j);
+    }
+  }
+  // Preserve the original order, both of the groups and within them.
+  var groups = [];
+  var indexOfRoot = {};
+  boxes.forEach(function(_, k) {
+    var root = find(k);
+    if (indexOfRoot[root] === undefined) {
+      indexOfRoot[root] = groups.length;
+      groups.push([]);
+    }
+    groups[indexOfRoot[root]].push(k);
+  });
+  return groups;
+}
+
+// Where a waypoint sits in the route, which is what decides the direction a door
+// has to work in.
+function waypointRole(index, count) {
+  if (index === 0) return 'origin';
+  if (index === count - 1) return 'destination';
+  return 'via';
+}
+
+// The doors the picker offers. The place centre is not among them: the
+// waypoint's own pin never leaves it, so it is already marked on the map, and
+// clicking the selected door again is what routes back to it.
+//
+// The entrances are expected to have been through routableEntrances already;
+// filtering again here would apply the default role and quietly drop the
+// one-way doors the caller deliberately allowed.
+function buildChoices(placeCenter, entrances) {
+  return (Array.isArray(entrances) ? entrances : []).filter(function(e) {
+    return !!(e && e.center);
+  }).map(function(entrance) {
+    return {
+      id: 'osm:' + entrance.osmId,
+      kind: entrance.type === 'main' ? 'main' : 'other',
+      center: entrance.center,
+      entrance: entrance
+    };
+  });
+}
+
+// Zooming is worth the disruption unless the area already sits clear of the pane
+// and fills enough of the free viewport to be legible. Both are measured in
+// container pixels.
+function shouldZoomToExtent(extent, viewport, clear) {
+  if (!clear) return true;
+  if (!viewport || viewport.width <= 0 || viewport.height <= 0) return true;
+  var fill = Math.max(extent.width / viewport.width, extent.height / viewport.height);
+  return fill < MIN_EXTENT_FILL;
+}
+
+// Whether an extent, already projected to container pixels, sits inside the part
+// of the map the directions pane does not cover. Anything under the pane is as
+// good as off screen.
+function isExtentClear(sw, ne, mapSize, paneWidth) {
+  var usableWidth = mapSize.x - (paneWidth || 0);
+  return Math.min(sw.x, ne.x) >= 0 && Math.max(sw.x, ne.x) <= usableWidth &&
+    Math.min(sw.y, ne.y) >= 0 && Math.max(sw.y, ne.y) <= mapSize.y;
+}
+
+// The points to frame when the place has no bounding box of its own — a node,
+// or an endpoint that did not return one. The centre is included because the
+// waypoint's pin sits there and has to stay in view alongside the doors.
+function choicePoints(choices, placeCenter) {
+  var points = choices.map(function(choice) {
+    return choice.center;
+  });
+  if (placeCenter) points.push(placeCenter);
+  return points;
+}
+
+// The door positions, which is all the choices now are.
+function entranceCenters(choices) {
+  return choices.map(function(choice) {
+    return choice.center;
+  });
+}
+
+// Smallest gap between any two of the projected dots, in pixels. This is what
+// decides whether a framing leaves the entrances separately clickable.
+function minPairSeparation(points) {
+  if (!points || points.length < 2) return Infinity;
+  var min = Infinity;
+  for (var i = 0; i < points.length - 1; i++) {
+    for (var j = i + 1; j < points.length; j++) {
+      var dx = points[i].x - points[j].x;
+      var dy = points[i].y - points[j].y;
+      var d = Math.sqrt(dx * dx + dy * dy);
+      if (d < min) min = d;
+    }
+  }
+  return min;
+}
+
+/**
+ * Map-based picker for the entrance nodes Nominatim returns alongside a place.
+ *
+ * A geocoded place drops its waypoint on the centroid, which for large sites
+ * (airports, campuses, parks) is nowhere a vehicle can reach. This surfaces the
+ * alternatives as small clickable dots on the map rather than as list rows:
+ * Nominatim gives entrances no name or ref, only a type and coordinates, so
+ * position on the map is the only thing that distinguishes one from another.
+ *
+ * The picker never chooses for the user. `entrance=main` records how a building
+ * is laid out, not which door a route can reach — the Pergamonmuseum tags a main
+ * door that the walking network stops 90 m short of — so acting on the tag would
+ * confidently place the waypoint somewhere unreachable. Every entrance is
+ * offered and the waypoint stays on the centre until a dot is clicked.
+ *
+ * @param {L.Map} map
+ * @param {object} options
+ * @param {function} options.onSelect  — called with {waypointIndex, placeName, latLng, entrance}
+ * @param {function} [options.translate] — (key) => localized string
+ * @param {function} [options.fetchOutline] — (place) => Promise<GeoJSON geometry|null>
+ * @param {function} [options.paneWidth] — () => width in px of the directions pane
+ * @returns {{show: function, hide: function, isOpen: function, getActiveId: function}}
+ */
+function createEntrancePicker(map, options) {
+  options = options || {};
+  var translate = typeof options.translate === 'function' ? options.translate : function(key) {
+    return key; 
+  };
+  var onSelect = typeof options.onSelect === 'function' ? options.onSelect : function() {};
+  var fetchOutline = typeof options.fetchOutline === 'function' ? options.fetchOutline : null;
+  // Read live rather than captured once: the directions pane is still hidden
+  // when the picker opens and slides in when the route arrives.
+  var paneWidth = typeof options.paneWidth === 'function' ? options.paneWidth : function() {
+    return 0;
+  };
+  // Two groups so redrawing the dots on every selection does not discard an
+  // outline that took a network round-trip to get. Markers sit in Leaflet's
+  // marker pane and paths in the overlay pane, so the dots stay on top.
+  var outlineLayer = L.layerGroup();
+  // The dashed link from the chosen door back to the pin, which never moves.
+  var linkLayer = L.layerGroup();
+  // Labels are markers of our own rather than Leaflet tooltips, for two
+  // reasons. The tooltip pane sits above the marker pane, so a label would be
+  // drawn over the very dot it names; as markers they share a pane with the
+  // dots, and a lower zIndexOffset puts every dot on top. And rebinding a
+  // permanent tooltip to re-measure it leaves the old element orphaned in the
+  // pane, whereas clearing a layer group really does remove what is in it.
+  var labelLayer = L.layerGroup();
+  var markerLayer = L.layerGroup();
+  var layer = L.layerGroup([outlineLayer, linkLayer, labelLayer, markerLayer]);
+  var state = null;
+  // Guards against a slow outline arriving after the user has moved on.
+  var outlineToken = 0;
+
+  function label(choice) {
+    // A door that names itself needs no description from us.
+    var named = entranceName(choice.entrance);
+    if (named) return named;
+    var type = choice.entrance && choice.entrance.type;
+    // An exit is only ever offered at an origin, and calling it an entrance
+    // there would contradict the reason it is on offer.
+    if (type === 'exit') return translate('Exit');
+    if (choice.kind === 'main') return translate('Main entrance');
+    return translate('Entrance');
+  }
+
+  function onKeyDown(e) {
+    if (e && (e.key === 'Escape' || e.keyCode === 27)) hide();
+  }
+
+  // Every door stays on the map for as long as the picker is open, chosen or
+  // not, so the alternatives are always one click away. The chosen one is marked
+  // rather than removed.
+  function render() {
+    markerLayer.clearLayers();
+    linkLayer.clearLayers();
+    if (!state) return;
+    var drawn = [];
+
+    state.choices.forEach(function(choice) {
+      var text = label(choice);
+      var chosen = choice.id === state.selectedId;
+      var className = 'osrm-entrance-marker osrm-entrance-marker-' + choice.kind +
+        (chosen ? ' osrm-entrance-marker-selected' : '');
+      var marker = L.marker(choice.center, {
+        icon: L.divIcon({className: className, iconSize: [18, 18], iconAnchor: [9, 9], html: ''}),
+        alt: text,
+        keyboard: true,
+        zIndexOffset: chosen ? 500 : 400
+      });
+      // The name travels with the dot; layoutLabels turns it into a label the
+      // user can read without hovering.
+      marker.__entranceLabel = text;
+      marker.on('click', function(e) {
+        // Without this the click also lands on the map, which would drop a new
+        // waypoint on top of the place being chosen for.
+        L.DomEvent.stopPropagation(e);
+        select(choice);
+      });
+      markerLayer.addLayer(marker);
+      drawn.push(marker);
+
+      // The pin stays on the place, so the chosen door is tied back to it with a
+      // dashed line: the route runs to the door, and this is the last bit on
+      // foot that no router can describe.
+      if (chosen && state.placeCenter) {
+        linkLayer.addLayer(L.polyline([choice.center, state.placeCenter], ENTRANCE_LINK_STYLE));
+      }
+    });
+
+    state.markers = drawn;
+    layoutLabels();
+  }
+
+  // Clicking the chosen door again releases it, which is how the route goes back
+  // to the place itself. There is no separate dot for that: the pin is already
+  // sitting on it.
+  function select(choice) {
+    if (!state) return;
+    var release = choice.id === state.selectedId;
+    state.selectedId = release ? null : choice.id;
+    render();
+    onSelect({
+      waypointIndex: state.waypointIndex,
+      placeName: state.placeName,
+      // Where the route should run to; the pin does not follow it.
+      latLng: release ? state.placeCenter : choice.center,
+      markerLatLng: state.placeCenter,
+      entrance: release ? null : choice.entrance
+    });
+  }
+
+  // Created lazily, because the picker may be built before the map has panes.
+  function ensureLabelPane() {
+    if (typeof map.createPane !== 'function' || typeof map.getPane !== 'function') return null;
+    var pane = map.getPane(LABEL_PANE);
+    if (!pane) {
+      pane = map.createPane(LABEL_PANE);
+      if (pane && pane.style) pane.style.zIndex = LABEL_PANE_Z_INDEX;
+    }
+    return LABEL_PANE;
+  }
+
+  // A label sits above the door it names, anchored on it. Zero-sized so the
+  // anchor is the door itself; the inner element does the drawing and is what
+  // gets measured.
+  function addLabel(latLng, names, merged) {
+    var options = {
+      icon: L.divIcon({
+        className: 'osrm-entrance-label' + (merged ? ' osrm-entrance-label-merged' : ''),
+        iconSize: null,
+        html: '<span class="osrm-entrance-label-inner">' +
+          names.map(labelLine).join('') + '</span>'
+      }),
+      // Never in the way of a click on a door, and always drawn beneath one.
+      interactive: false,
+      zIndexOffset: 100
+    };
+    var pane = ensureLabelPane();
+    if (pane) options.pane = pane;
+    var marker = L.marker(latLng, options);
+    labelLayer.addLayer(marker);
+    return marker;
+  }
+
+  // These names come from OSM and would otherwise be read as markup.
+  function labelLine(name) {
+    var div = document.createElement('div');
+    div.textContent = name;
+    return '<div>' + div.innerHTML + '</div>';
+  }
+
+  function labelBox(marker) {
+    var el = marker.getElement && marker.getElement();
+    var inner = el && el.querySelector && el.querySelector('.osrm-entrance-label-inner');
+    if (!inner || !inner.getBoundingClientRect) return null;
+    var r = inner.getBoundingClientRect();
+    return {left: r.left, right: r.right, top: r.top, bottom: r.bottom};
+  }
+
+  function markerLatLng(marker) {
+    return marker.getLatLng ? marker.getLatLng() : marker.latLng;
+  }
+
+  // Names are only worth showing permanently while they can be read. Where the
+  // boxes collide — which is a question of zoom, not of the data — the whole
+  // colliding run is replaced by one label listing every door in it, anchored on
+  // the first. Zooming in separates them and they come back individually.
+  function layoutLabels() {
+    if (!state || !state.markers) return null;
+    var markers = state.markers;
+
+    // One label per door first, because their boxes are what the grouping is
+    // decided from.
+    labelLayer.clearLayers();
+    var labels = markers.map(function(marker) {
+      return addLabel(markerLatLng(marker), [marker.__entranceLabel], false);
+    });
+
+    var boxes = labels.map(labelBox);
+    if (boxes.some(function(b) {
+      return !b;
+    })) return null;
+
+    var groups = clusterOverlappingLabels(boxes);
+    if (groups.every(function(g) {
+      return g.length === 1;
+    })) return groups;
+
+    // At least one run collides, so the whole set is laid out again with those
+    // runs collapsed onto their first door.
+    labelLayer.clearLayers();
+    groups.forEach(function(group) {
+      addLabel(markerLatLng(markers[group[0]]),
+        group.map(function(i) {
+          return markers[i].__entranceLabel;
+        }),
+        group.length > 1);
+    });
+    return groups;
+  }
+
+  // What to frame. The place's own bounding box is preferred — it shows the site
+  // the doors belong to — but only while that framing leaves the doors far
+  // enough apart to aim at. BER's five entrances sit ~36 m apart on a 5 km site,
+  // which is about 3 px at the zoom its bbox implies, so there the entrances win
+  // and the site outline simply runs off the edges.
+  function framingBounds(padRight) {
+    var area = state.placeBounds;
+    var doors = entranceCenters(state.choices);
+
+    if (!area || !area.isValid()) {
+      // The pin stays on the centre, so it belongs in the frame alongside the
+      // doors unless the doors alone already span enough to aim at.
+      var points = doors.length > 1 ? doors : choicePoints(state.choices, state.placeCenter);
+      return points.length > 1 ? L.latLngBounds(points) : null;
+    }
+    if (doors.length < 2) return area;
+
+    // The zoom fitting the area would settle on, and the dots as they would land
+    // at it.
+    var areaZoom = map.getBoundsZoom(area, false,
+      L.point(padRight + 2 * FIT_PADDING, 2 * FIT_PADDING));
+    var projected = doors.map(function(latLng) {
+      return map.project(latLng, areaZoom);
+    });
+    if (minPairSeparation(projected) >= MIN_DOT_SEPARATION_PX) return area;
+    return L.latLngBounds(doors);
+  }
+
+  // Frames whatever framingBounds picked into the part of the map the directions
+  // pane does not cover, rather than merely centring it, so the pane never sits
+  // over the thing being picked from.
+  function focusView() {
+    if (!state) return false;
+    var padRight = paneWidth();
+    var bounds = framingBounds(padRight);
+    if (!bounds || !bounds.isValid()) return false;
+
+    var sw = map.latLngToContainerPoint(bounds.getSouthWest());
+    var ne = map.latLngToContainerPoint(bounds.getNorthEast());
+    var mapSize = map.getSize();
+    var extent = {width: Math.abs(ne.x - sw.x), height: Math.abs(sw.y - ne.y)};
+    var viewport = {
+      width: mapSize.x - padRight - 2 * FIT_PADDING,
+      height: mapSize.y - 2 * FIT_PADDING
+    };
+    var clear = isExtentClear(sw, ne, mapSize, padRight);
+    if (!shouldZoomToExtent(extent, viewport, clear)) return false;
+
+    map.fitBounds(bounds, {
+      maxZoom: MAX_PICKER_ZOOM,
+      paddingTopLeft: L.point(FIT_PADDING, FIT_PADDING),
+      paddingBottomRight: L.point(padRight + FIT_PADDING, FIT_PADDING)
+    });
+    return true;
+  }
+
+  // A route fit is an animated move, and a fitBounds issued on top of one is
+  // either ignored outright or undone when that animation ends. Wait for the map
+  // to settle before re-framing, with a timer as the backstop for the case where
+  // nothing moved and no moveend ever arrives.
+  function focusViewWhenSettled() {
+    if (!state) return;
+    var timer = null;
+    function run() {
+      map.off('moveend', run);
+      if (timer) clearTimeout(timer);
+      timer = null;
+      focusView();
+    }
+    timer = setTimeout(run, SETTLE_TIMEOUT_MS);
+    map.on('moveend', run);
+  }
+
+  // The outline is best-effort context: a failed or absent one simply means the
+  // picker shows dots without a site boundary.
+  function loadOutline(place) {
+    var token = ++outlineToken;
+    outlineLayer.clearLayers();
+    if (!fetchOutline || !place) return;
+    fetchOutline(place).then(function(geometry) {
+      if (token !== outlineToken || !state || !geometry) return;
+      outlineLayer.addLayer(L.geoJSON(geometry, {style: OUTLINE_STYLE}));
+    });
+  }
+
+  function show(opts) {
+    var choices = buildChoices(opts.placeCenter, opts.entrances);
+    // One door is still worth offering now that the centre is not a dot: the
+    // pin marks it already.
+    if (choices.length < 1) {
+      hide();
+      return false;
+    }
+    state = {
+      waypointIndex: opts.waypointIndex,
+      placeName: opts.placeName,
+      placeCenter: opts.placeCenter || null,
+      choices: choices,
+      selectedId: opts.selectedId || null,
+      placeBounds: opts.placeBounds || null
+    };
+    if (!map.hasLayer(layer)) layer.addTo(map);
+    loadOutline(opts.place);
+    focusViewWhenSettled();
+    render();
+    // Which labels fit is a question of zoom, so the layout is redone after
+    // every one.
+    map.on('zoomend', layoutLabels);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('keydown', onKeyDown);
+    }
+    return true;
+  }
+
+  function hide() {
+    if (!state) return;
+    state = null;
+    map.off('zoomend', layoutLabels);
+    outlineToken++;
+    outlineLayer.clearLayers();
+    linkLayer.clearLayers();
+    labelLayer.clearLayers();
+    markerLayer.clearLayers();
+    if (map.hasLayer(layer)) map.removeLayer(layer);
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('keydown', onKeyDown);
+    }
+  }
+
+  return {
+    show: show,
+    hide: hide,
+    focusView: focusViewWhenSettled,
+    layoutLabels: layoutLabels,
+    isOpen: function() {
+      return !!state; 
+    },
+    getWaypointIndex: function() {
+      return state ? state.waypointIndex : null; 
+    },
+    getSelectedId: function() {
+      return state ? state.selectedId : null;
+    }
+  };
+}
+
+module.exports = {
+  routableEntrances: routableEntrances,
+  allowsMode: allowsMode,
+  entranceName: entranceName,
+  boxesOverlap: boxesOverlap,
+  clusterOverlappingLabels: clusterOverlappingLabels,
+  waypointRole: waypointRole,
+  buildChoices: buildChoices,
+  shouldZoomToExtent: shouldZoomToExtent,
+  isExtentClear: isExtentClear,
+  choicePoints: choicePoints,
+  entranceCenters: entranceCenters,
+  minPairSeparation: minPairSeparation,
+  MIN_DOT_SEPARATION_PX: MIN_DOT_SEPARATION_PX,
+  createEntrancePicker: createEntrancePicker,
+  MIN_EXTENT_FILL: MIN_EXTENT_FILL
+};

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -9,16 +9,20 @@ var L = require('leaflet');
 //   entrance=entrance  "it is an entrance only, a one-way in"
 //
 // so an exit is a legitimate place to *start* a route and a useless place to end
-// one, and vice versa. Values absent from this table are never offered:
-// `service` (staff and deliveries), `emergency` (fire escape), `staircase` and
-// `garage` (interior doors), and `no` — which the wiki defines as looking like a
-// door but not being usable at all.
+// one, and vice versa. `staircase` — "Door to staircase" — belongs with `home`
+// rather than with the interior doors: it is the door of a stairwell, which is
+// how residents and visitors of an apartment building get in, and it is the
+// third most common value on entrance nodes after `yes` and `main`. Values
+// absent from this table are never offered: `service` (staff and deliveries),
+// `emergency` (fire escape), `garage` (an interior door), and `no` — which the
+// wiki defines as looking like a door but not being usable at all.
 var ENTRANCE_USE = {
   main:      {enter: true, leave: true},
   yes:       {enter: true, leave: true},
   secondary: {enter: true, leave: true},
   shop:      {enter: true, leave: true},
   home:      {enter: true, leave: true},
+  staircase: {enter: true, leave: true},
   entrance:  {enter: true, leave: false},
   exit:      {enter: false, leave: true}
 };
@@ -197,7 +201,7 @@ function clusterOverlappingLabels(boxes) {
   if (!Array.isArray(boxes) || boxes.length === 0) return [];
   // Union-find over the boxes.
   var parent = boxes.map(function(_, i) {
-    return i; 
+    return i;
   });
   function find(i) {
     while (parent[i] !== i) {
@@ -337,7 +341,7 @@ function minPairSeparation(points) {
 function createEntrancePicker(map, options) {
   options = options || {};
   var translate = typeof options.translate === 'function' ? options.translate : function(key) {
-    return key; 
+    return key;
   };
   var onSelect = typeof options.onSelect === 'function' ? options.onSelect : function() {};
   var fetchOutline = typeof options.fetchOutline === 'function' ? options.fetchOutline : null;
@@ -655,8 +659,16 @@ function createEntrancePicker(map, options) {
     render();
     // Which labels fit is a question of zoom, so the layout is redone after
     // every one.
+    //
+    // Detached first because show() runs again on an already-open picker when
+    // the travel mode changes. Leaflet and the DOM both ignore a repeat
+    // registration of the same handler, but relying on that makes correctness
+    // here depend on someone else's de-duplication; removing first makes it
+    // ours.
+    map.off('zoomend', layoutLabels);
     map.on('zoomend', layoutLabels);
     if (typeof document !== 'undefined') {
+      document.removeEventListener('keydown', onKeyDown);
       document.addEventListener('keydown', onKeyDown);
     }
     return true;
@@ -683,10 +695,10 @@ function createEntrancePicker(map, options) {
     focusView: focusViewWhenSettled,
     layoutLabels: layoutLabels,
     isOpen: function() {
-      return !!state; 
+      return !!state;
     },
     getWaypointIndex: function() {
-      return state ? state.waypointIndex : null; 
+      return state ? state.waypointIndex : null;
     },
     getSelectedId: function() {
       return state ? state.selectedId : null;

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -165,19 +165,64 @@ function entranceName(entrance) {
 // promising step-free access there would be worse than no mark at all.
 var WHEELCHAIR_ACCESSIBLE = {yes: true, designated: true};
 
+// What is worth pointing out about a door depends entirely on how the traveller
+// is arriving, so each mark belongs to one travel mode and appears in no other.
+// Step-free access matters to someone on foot and says nothing to a driver;
+// which door swallows cars matters to a driver and is noise to everyone else.
+//
+// There is deliberately no mark for cycling. Its natural candidate, `bicycle`
+// on an entrance node, does not reach even 0.05% of them globally — far below
+// `wheelchair` at 4.7% — so a cycling mark would be an icon nobody ever sees.
+var MARKS = {
+  wheelchair: {
+    className: 'osrm-entrance-mark-wheelchair',
+    // U+267F. Written as a surrogate pair rather than an escape this file's
+    // ES5 syntax cannot express.
+    glyph: '\u267F',
+    label: 'Wheelchair accessible',
+    applies: function(tags) {
+      var value = tags.wheelchair;
+      if (typeof value !== 'string') return false;
+      return WHEELCHAIR_ACCESSIBLE[value.trim().toLowerCase()] === true;
+    }
+  },
+  parking: {
+    className: 'osrm-entrance-mark-parking',
+    // U+1F17F, negative squared latin capital letter P.
+    glyph: '\uD83C\uDD7F',
+    label: 'Parking entrance',
+    applies: function(tags) {
+      return tags.amenity === 'parking_entrance';
+    }
+  }
+};
+
+// Keyed by the same profile names as MODE_ACCESS_KEYS, so both tables agree on
+// what a mode is called.
+var MODE_MARK = {
+  foot: 'wheelchair',
+  driving: 'parking',
+  car: 'parking'
+};
+
 /**
- * Whether a door is tagged wheelchair accessible in OSM.
+ * The mark a door earns for one travel mode, or null.
  *
- * Only about an eighth of entrance nodes carry the tag at all, so its absence
- * means nobody surveyed the door, not that the door has a step. This therefore
- * only ever adds a mark to a door; it never filters one out, and
- * `routableEntrances` stays untouched by it.
+ * A mark never filters. Roughly seven in eight entrance nodes carry no
+ * wheelchair tag and far fewer carry parking tags, so an absent value means
+ * nobody surveyed the door rather than that the door lacks the property, and
+ * `routableEntrances` stays untouched by any of this.
+ *
+ * @param {object} entrance
+ * @param {string} [mode] — the routing profile. A mode with no mark of its own,
+ *   or none at all, marks nothing.
+ * @returns {?{className: string, glyph: string, label: string}}
  */
-function isWheelchairAccessible(entrance) {
+function entranceMark(entrance, mode) {
+  var mark = MARKS[MODE_MARK[mode]];
   var tags = entrance && entrance.tags;
-  var value = tags && tags.wheelchair;
-  if (typeof value !== 'string') return false;
-  return WHEELCHAIR_ACCESSIBLE[value.trim().toLowerCase()] === true;
+  if (!mark || !tags) return null;
+  return mark.applies(tags) ? mark : null;
 }
 
 // Two label boxes touching edge-to-edge are not overlapping; only real overlap
@@ -396,7 +441,7 @@ function createEntrancePicker(map, options) {
 
     state.choices.forEach(function(choice) {
       var text = label(choice);
-      var accessible = isWheelchairAccessible(choice.entrance);
+      var mark = entranceMark(choice.entrance, state.mode);
       var chosen = choice.id === state.selectedId;
       var className = 'osrm-entrance-marker osrm-entrance-marker-' + choice.kind +
         (chosen ? ' osrm-entrance-marker-selected' : '');
@@ -405,14 +450,14 @@ function createEntrancePicker(map, options) {
         // The label shows this as an icon; the alt spells it out, because the
         // icon is marked aria-hidden and would otherwise be announced as
         // nothing at all.
-        alt: accessible ? text + ' (' + translate('Wheelchair accessible') + ')' : text,
+        alt: mark ? text + ' (' + translate(mark.label) + ')' : text,
         keyboard: true,
         zIndexOffset: chosen ? 500 : 400
       });
       // The name travels with the dot; layoutLabels turns it into a label the
       // user can read without hovering.
       marker.__entranceLabel = text;
-      marker.__entranceWheelchair = accessible;
+      marker.__entranceMark = mark;
       marker.on('click', function(e) {
         // Without this the click also lands on the map, which would drop a new
         // waypoint on top of the place being chosen for.
@@ -467,7 +512,7 @@ function createEntrancePicker(map, options) {
   // anchor is the door itself; the inner element does the drawing and is what
   // gets measured.
   function labelEntry(marker) {
-    return {text: marker.__entranceLabel, wheelchair: !!marker.__entranceWheelchair};
+    return {text: marker.__entranceLabel, mark: marker.__entranceMark || null};
   }
 
   function addLabel(latLng, entries, merged) {
@@ -493,11 +538,11 @@ function createEntrancePicker(map, options) {
   function labelLine(entry) {
     var div = document.createElement('div');
     div.textContent = entry.text;
-    // Hidden from assistive tech on purpose: the dot's alt already says
-    // "wheelchair accessible" in words, and announcing the symbol too would
-    // repeat it.
-    var mark = entry.wheelchair
-      ? '<span class="osrm-entrance-wheelchair" aria-hidden="true">\u267F</span>'
+    // Hidden from assistive tech on purpose: the dot's alt already says what the
+    // mark means in words, and announcing the symbol too would repeat it.
+    var mark = entry.mark
+      ? '<span class="osrm-entrance-mark ' + entry.mark.className +
+        '" aria-hidden="true">' + entry.mark.glyph + '</span>'
       : '';
     return '<div>' + div.innerHTML + mark + '</div>';
   }
@@ -650,6 +695,9 @@ function createEntrancePicker(map, options) {
       placeName: opts.placeName,
       placeCenter: opts.placeCenter || null,
       choices: choices,
+      // Which mark a door earns depends on it, and refresh() re-shows the
+      // picker with a new one whenever the travel mode changes.
+      mode: opts.mode || null,
       selectedId: opts.selectedId || null,
       placeBounds: opts.placeBounds || null
     };
@@ -710,7 +758,7 @@ module.exports = {
   routableEntrances: routableEntrances,
   allowsMode: allowsMode,
   entranceName: entranceName,
-  isWheelchairAccessible: isWheelchairAccessible,
+  entranceMark: entranceMark,
   boxesOverlap: boxesOverlap,
   clusterOverlappingLabels: clusterOverlappingLabels,
   waypointRole: waypointRole,

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -415,9 +415,33 @@ function createEntrancePicker(map, options) {
   var labelLayer = L.layerGroup();
   var markerLayer = L.layerGroup();
   var layer = L.layerGroup([outlineLayer, linkLayer, labelLayer, markerLayer]);
-  var state = null;
+  // One offer per waypoint. More than one waypoint can be showing its doors at
+  // once: naming a start must not withdraw the destination's, which is what a
+  // single shared state did.
+  var offers = [];
+  // The offer the view frames and Escape acts on — the one shown most recently,
+  // which is the one the user is looking at.
+  var activeWaypointIndex = null;
+  // Every dot currently drawn, across all offers, in draw order. Label layout
+  // groups purely by overlap and does not care which waypoint a dot belongs to.
+  var renderedMarkers = [];
+  // Whether the layer and the map/document listeners are in place. Tracked
+  // rather than inferred from `offers`, because the last offer is removed from
+  // that list before the teardown runs.
+  var attached = false;
   // Guards against a slow outline arriving after the user has moved on.
   var outlineToken = 0;
+
+  function offerAt(waypointIndex) {
+    for (var i = 0; i < offers.length; i++) {
+      if (offers[i].waypointIndex === waypointIndex) return offers[i];
+    }
+    return null;
+  }
+
+  function activeOffer() {
+    return activeWaypointIndex === null ? null : offerAt(activeWaypointIndex);
+  }
 
   function label(choice) {
     // A door that names itself needs no description from us.
@@ -441,63 +465,72 @@ function createEntrancePicker(map, options) {
   function render() {
     markerLayer.clearLayers();
     linkLayer.clearLayers();
-    if (!state) return;
-    var drawn = [];
+    outlineLayer.clearLayers();
+    renderedMarkers = [];
 
-    state.choices.forEach(function(choice) {
-      var text = label(choice);
-      var mark = entranceMark(choice.entrance, state.mode);
-      var chosen = choice.id === state.selectedId;
-      var className = 'osrm-entrance-marker osrm-entrance-marker-' + choice.kind +
+    offers.forEach(function(offer) {
+      // Redrawn from the geometry each time rather than left in place, so one
+      // waypoint's outline can be removed without disturbing another's.
+      if (offer.outline) {
+        outlineLayer.addLayer(L.geoJSON(offer.outline, {style: OUTLINE_STYLE}));
+      }
+      offer.choices.forEach(function(choice) {
+        var text = label(choice);
+        var mark = entranceMark(choice.entrance, offer.mode);
+        var chosen = choice.id === offer.selectedId;
+        var className = 'osrm-entrance-marker osrm-entrance-marker-' + choice.kind +
         (chosen ? ' osrm-entrance-marker-selected' : '');
-      var marker = L.marker(choice.center, {
-        icon: L.divIcon({className: className, iconSize: [18, 18], iconAnchor: [9, 9], html: ''}),
-        // The label shows this as an icon; the alt spells it out, because the
-        // icon is marked aria-hidden and would otherwise be announced as
-        // nothing at all.
-        alt: mark ? text + ' (' + translate(mark.label) + ')' : text,
-        keyboard: true,
-        zIndexOffset: chosen ? 500 : 400
-      });
-      // The name travels with the dot; layoutLabels turns it into a label the
-      // user can read without hovering.
-      marker.__entranceLabel = text;
-      marker.__entranceMark = mark;
-      marker.on('click', function(e) {
+        var marker = L.marker(choice.center, {
+          icon: L.divIcon({className: className, iconSize: [18, 18], iconAnchor: [9, 9], html: ''}),
+          // The label shows this as an icon; the alt spells it out, because the
+          // icon is marked aria-hidden and would otherwise be announced as
+          // nothing at all.
+          alt: mark ? text + ' (' + translate(mark.label) + ')' : text,
+          keyboard: true,
+          zIndexOffset: chosen ? 500 : 400
+        });
+        // The name travels with the dot; layoutLabels turns it into a label the
+        // user can read without hovering.
+        marker.__entranceLabel = text;
+        marker.__entranceMark = mark;
+        marker.on('click', function(e) {
         // Without this the click also lands on the map, which would drop a new
         // waypoint on top of the place being chosen for.
-        L.DomEvent.stopPropagation(e);
-        select(choice);
-      });
-      markerLayer.addLayer(marker);
-      drawn.push(marker);
+          L.DomEvent.stopPropagation(e);
+          select(offer, choice);
+        });
+        markerLayer.addLayer(marker);
+        renderedMarkers.push(marker);
 
-      // The pin stays on the place, so the chosen door is tied back to it with a
-      // dashed line: the route runs to the door, and this is the last bit on
-      // foot that no router can describe.
-      if (chosen && state.placeCenter) {
-        linkLayer.addLayer(L.polyline([choice.center, state.placeCenter], ENTRANCE_LINK_STYLE));
-      }
+        // The pin stays on the place, so the chosen door is tied back to it with a
+        // dashed line: the route runs to the door, and this is the last bit on
+        // foot that no router can describe.
+        if (chosen && offer.placeCenter) {
+          linkLayer.addLayer(L.polyline([choice.center, offer.placeCenter], ENTRANCE_LINK_STYLE));
+        }
+      });
     });
 
-    state.markers = drawn;
     layoutLabels();
   }
 
   // Clicking the chosen door again releases it, which is how the route goes back
   // to the place itself. There is no separate dot for that: the pin is already
   // sitting on it.
-  function select(choice) {
-    if (!state) return;
-    var release = choice.id === state.selectedId;
-    state.selectedId = release ? null : choice.id;
+  function select(offer, choice) {
+    // The dot's handler closes over its offer, so a click arriving after that
+    // offer was withdrawn — hidden, or replaced by a newer one for the same
+    // waypoint — must do nothing.
+    if (!offer || offerAt(offer.waypointIndex) !== offer) return;
+    var release = choice.id === offer.selectedId;
+    offer.selectedId = release ? null : choice.id;
     render();
     onSelect({
-      waypointIndex: state.waypointIndex,
-      placeName: state.placeName,
+      waypointIndex: offer.waypointIndex,
+      placeName: offer.placeName,
       // Where the route should run to; the pin does not follow it.
-      latLng: release ? state.placeCenter : choice.center,
-      markerLatLng: state.placeCenter,
+      latLng: release ? offer.placeCenter : choice.center,
+      markerLatLng: offer.placeCenter,
       entrance: release ? null : choice.entrance
     });
   }
@@ -569,8 +602,8 @@ function createEntrancePicker(map, options) {
   // colliding run is replaced by one label listing every door in it, anchored on
   // the first. Zooming in separates them and they come back individually.
   function layoutLabels() {
-    if (!state || !state.markers) return null;
-    var markers = state.markers;
+    if (!offers.length) return null;
+    var markers = renderedMarkers;
 
     // One label per door first, because their boxes are what the grouping is
     // decided from.
@@ -607,14 +640,14 @@ function createEntrancePicker(map, options) {
   // enough apart to aim at. BER's five entrances sit ~36 m apart on a 5 km site,
   // which is about 3 px at the zoom its bbox implies, so there the entrances win
   // and the site outline simply runs off the edges.
-  function framingBounds(padRight) {
-    var area = state.placeBounds;
-    var doors = entranceCenters(state.choices);
+  function framingBounds(padRight, offer) {
+    var area = offer.placeBounds;
+    var doors = entranceCenters(offer.choices);
 
     if (!area || !area.isValid()) {
       // The pin stays on the centre, so it belongs in the frame alongside the
       // doors unless the doors alone already span enough to aim at.
-      var points = doors.length > 1 ? doors : choicePoints(state.choices, state.placeCenter);
+      var points = doors.length > 1 ? doors : choicePoints(offer.choices, offer.placeCenter);
       return points.length > 1 ? L.latLngBounds(points) : null;
     }
     if (doors.length < 2) return area;
@@ -634,9 +667,12 @@ function createEntrancePicker(map, options) {
   // pane does not cover, rather than merely centring it, so the pane never sits
   // over the thing being picked from.
   function focusView() {
-    if (!state) return false;
+    // The newest offer is framed: it is the one the user just asked for. The
+    // others stay on the map, they simply do not pull the view around.
+    var offer = activeOffer();
+    if (!offer) return false;
     var padRight = paneWidth();
-    var bounds = framingBounds(padRight);
+    var bounds = framingBounds(padRight, offer);
     if (!bounds || !bounds.isValid()) return false;
 
     var sw = map.latLngToContainerPoint(bounds.getSouthWest());
@@ -663,7 +699,7 @@ function createEntrancePicker(map, options) {
   // to settle before re-framing, with a timer as the backstop for the case where
   // nothing moved and no moveend ever arrives.
   function focusViewWhenSettled() {
-    if (!state) return;
+    if (!activeOffer()) return;
     var timer = null;
     function run() {
       map.off('moveend', run);
@@ -677,13 +713,17 @@ function createEntrancePicker(map, options) {
 
   // The outline is best-effort context: a failed or absent one simply means the
   // picker shows dots without a site boundary.
-  function loadOutline(place) {
+  function loadOutline(offer, place) {
     var token = ++outlineToken;
-    outlineLayer.clearLayers();
+    offer.outline = null;
     if (!fetchOutline || !place) return;
     fetchOutline(place).then(function(geometry) {
-      if (token !== outlineToken || !state || !geometry) return;
-      outlineLayer.addLayer(L.geoJSON(geometry, {style: OUTLINE_STYLE}));
+      // The offer may have been withdrawn, or replaced by a later one for the
+      // same waypoint, while the request was in flight.
+      if (token !== outlineToken || !geometry) return;
+      if (offerAt(offer.waypointIndex) !== offer) return;
+      offer.outline = geometry;
+      render();
     });
   }
 
@@ -692,10 +732,12 @@ function createEntrancePicker(map, options) {
     // One door is still worth offering now that the centre is not a dot: the
     // pin marks it already.
     if (choices.length < 1) {
-      hide();
+      // Only this waypoint's offer goes. A place with no doors of its own says
+      // nothing about the doors another waypoint is showing.
+      hideWaypoint(opts.waypointIndex);
       return false;
     }
-    state = {
+    var offer = {
       waypointIndex: opts.waypointIndex,
       placeName: opts.placeName,
       placeCenter: opts.placeCenter || null,
@@ -704,10 +746,21 @@ function createEntrancePicker(map, options) {
       // picker with a new one whenever the travel mode changes.
       mode: opts.mode || null,
       selectedId: opts.selectedId || null,
-      placeBounds: opts.placeBounds || null
+      placeBounds: opts.placeBounds || null,
+      outline: null
     };
+    var existing = offerAt(opts.waypointIndex);
+    if (existing) {
+      // Re-showing the same waypoint replaces its offer in place, so the order
+      // dots were drawn in does not jump around on a mode change.
+      offers[offers.indexOf(existing)] = offer;
+    } else {
+      offers.push(offer);
+    }
+    activeWaypointIndex = offer.waypointIndex;
+    attached = true;
     if (!map.hasLayer(layer)) layer.addTo(map);
-    loadOutline(opts.place);
+    loadOutline(offer, opts.place);
     focusViewWhenSettled();
     render();
     // Which labels fit is a question of zoom, so the layout is redone after
@@ -727,9 +780,30 @@ function createEntrancePicker(map, options) {
     return true;
   }
 
+  // Withdraws one waypoint's offer, leaving every other one on the map.
+  function hideWaypoint(waypointIndex) {
+    var offer = offerAt(waypointIndex);
+    if (!offer) return;
+    offers.splice(offers.indexOf(offer), 1);
+    if (activeWaypointIndex === waypointIndex) {
+      // Frame whatever is left, newest first, so the view still follows
+      // something the user can see.
+      activeWaypointIndex = offers.length
+        ? offers[offers.length - 1].waypointIndex : null;
+    }
+    if (!offers.length) {
+      hide();
+      return;
+    }
+    render();
+  }
+
   function hide() {
-    if (!state) return;
-    state = null;
+    if (!attached) return;
+    attached = false;
+    offers = [];
+    activeWaypointIndex = null;
+    renderedMarkers = [];
     map.off('zoomend', layoutLabels);
     outlineToken++;
     outlineLayer.clearLayers();
@@ -745,16 +819,23 @@ function createEntrancePicker(map, options) {
   return {
     show: show,
     hide: hide,
+    hideWaypoint: hideWaypoint,
     focusView: focusViewWhenSettled,
     layoutLabels: layoutLabels,
     isOpen: function() {
-      return !!state;
+      return offers.length > 0;
+    },
+    isOpenFor: function(waypointIndex) {
+      return !!offerAt(waypointIndex);
     },
     getWaypointIndex: function() {
-      return state ? state.waypointIndex : null;
+      var offer = activeOffer();
+      return offer ? offer.waypointIndex : null;
     },
-    getSelectedId: function() {
-      return state ? state.selectedId : null;
+    getSelectedId: function(waypointIndex) {
+      var offer = arguments.length
+        ? offerAt(waypointIndex) : activeOffer();
+      return offer ? offer.selectedId : null;
     }
   };
 }

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -342,7 +342,7 @@ function choicePoints(choices, placeCenter) {
   return points;
 }
 
-// The door positions, which is all the choices now are.
+// The door positions: every choice is a door.
 function entranceCenters(choices) {
   return choices.map(function(choice) {
     return choice.center;
@@ -400,9 +400,9 @@ function createEntrancePicker(map, options) {
   var paneWidth = typeof options.paneWidth === 'function' ? options.paneWidth : function() {
     return 0;
   };
-  // Two groups so redrawing the dots on every selection does not discard an
-  // outline that took a network round-trip to get. Markers sit in Leaflet's
-  // marker pane and paths in the overlay pane, so the dots stay on top.
+  // Four groups, so each can be cleared without disturbing the others. Markers
+  // sit in Leaflet's marker pane and paths in the overlay pane, so the dots and
+  // labels stay above the outline and the dashed link whatever the draw order.
   var outlineLayer = L.layerGroup();
   // The dashed link from the chosen door back to the pin, which never moves.
   var linkLayer = L.layerGroup();
@@ -419,8 +419,8 @@ function createEntrancePicker(map, options) {
   // once: naming a start must not withdraw the destination's, which is what a
   // single shared state did.
   var offers = [];
-  // The offer the view frames and Escape acts on — the one shown most recently,
-  // which is the one the user is looking at.
+  // The offer the view frames: the one shown most recently, which is the one the
+  // user is looking at. Escape is not scoped to it — that clears every offer.
   var activeWaypointIndex = null;
   // Every dot currently drawn, across all offers, in draw order. Label layout
   // groups purely by overlap and does not care which waypoint a dot belongs to.
@@ -429,8 +429,6 @@ function createEntrancePicker(map, options) {
   // rather than inferred from `offers`, because the last offer is removed from
   // that list before the teardown runs.
   var attached = false;
-  // Guards against a slow outline arriving after the user has moved on.
-  var outlineToken = 0;
 
   function offerAt(waypointIndex) {
     for (var i = 0; i < offers.length; i++) {
@@ -479,7 +477,7 @@ function createEntrancePicker(map, options) {
         var mark = entranceMark(choice.entrance, offer.mode);
         var chosen = choice.id === offer.selectedId;
         var className = 'osrm-entrance-marker osrm-entrance-marker-' + choice.kind +
-        (chosen ? ' osrm-entrance-marker-selected' : '');
+          (chosen ? ' osrm-entrance-marker-selected' : '');
         var marker = L.marker(choice.center, {
           icon: L.divIcon({className: className, iconSize: [18, 18], iconAnchor: [9, 9], html: ''}),
           // The label shows this as an icon; the alt spells it out, because the
@@ -494,8 +492,8 @@ function createEntrancePicker(map, options) {
         marker.__entranceLabel = text;
         marker.__entranceMark = mark;
         marker.on('click', function(e) {
-        // Without this the click also lands on the map, which would drop a new
-        // waypoint on top of the place being chosen for.
+          // Without this the click also lands on the map, which would drop a
+          // new waypoint on top of the place being chosen for.
           L.DomEvent.stopPropagation(e);
           select(offer, choice);
         });
@@ -714,14 +712,14 @@ function createEntrancePicker(map, options) {
   // The outline is best-effort context: a failed or absent one simply means the
   // picker shows dots without a site boundary.
   function loadOutline(offer, place) {
-    var token = ++outlineToken;
     offer.outline = null;
     if (!fetchOutline || !place) return;
     fetchOutline(place).then(function(geometry) {
-      // The offer may have been withdrawn, or replaced by a later one for the
-      // same waypoint, while the request was in flight.
-      if (token !== outlineToken || !geometry) return;
-      if (offerAt(offer.waypointIndex) !== offer) return;
+      // Guarded by the offer's own identity rather than a shared counter: the
+      // offer may have been withdrawn, or replaced by a later one for the same
+      // waypoint, while the request was in flight — but another waypoint being
+      // shown meanwhile must not cancel this one.
+      if (!geometry || offerAt(offer.waypointIndex) !== offer) return;
       offer.outline = geometry;
       render();
     });
@@ -729,8 +727,8 @@ function createEntrancePicker(map, options) {
 
   function show(opts) {
     var choices = buildChoices(opts.placeCenter, opts.entrances);
-    // One door is still worth offering now that the centre is not a dot: the
-    // pin marks it already.
+    // A single door is still worth offering: the pin already marks the place,
+    // so one dot is a real choice rather than a foregone one.
     if (choices.length < 1) {
       // Only this waypoint's offer goes. A place with no doors of its own says
       // nothing about the doors another waypoint is showing.
@@ -805,7 +803,6 @@ function createEntrancePicker(map, options) {
     activeWaypointIndex = null;
     renderedMarkers = [];
     map.off('zoomend', layoutLabels);
-    outlineToken++;
     outlineLayer.clearLayers();
     linkLayer.clearLayers();
     labelLayer.clearLayers();
@@ -852,8 +849,6 @@ module.exports = {
   shouldZoomToExtent: shouldZoomToExtent,
   isExtentClear: isExtentClear,
   choicePoints: choicePoints,
-  entranceCenters: entranceCenters,
-  minPairSeparation: minPairSeparation,
   MIN_DOT_SEPARATION_PX: MIN_DOT_SEPARATION_PX,
   createEntrancePicker: createEntrancePicker,
   MIN_EXTENT_FILL: MIN_EXTENT_FILL

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -176,9 +176,13 @@ var WHEELCHAIR_ACCESSIBLE = {yes: true, designated: true};
 var MARKS = {
   wheelchair: {
     className: 'osrm-entrance-mark-wheelchair',
-    // U+267F. Written as a surrogate pair rather than an escape this file's
-    // ES5 syntax cannot express.
-    glyph: '\u267F',
+    // U+267F, then U+FE0F. Both glyphs ask for the emoji form explicitly rather
+    // than relying on the font's default, because the two characters default
+    // differently: U+267F is Emoji_Presentation=Yes and renders in colour on its
+    // own, while U+1F17F below is No and falls back to a plain black-and-white
+    // glyph without the selector — which is how one mark ends up coloured and
+    // the other not.
+    glyph: '\u267F\uFE0F',
     label: 'Wheelchair accessible',
     applies: function(tags) {
       var value = tags.wheelchair;
@@ -188,8 +192,9 @@ var MARKS = {
   },
   parking: {
     className: 'osrm-entrance-mark-parking',
-    // U+1F17F, negative squared latin capital letter P.
-    glyph: '\uD83C\uDD7F',
+    // U+1F17F as a surrogate pair — an escape this file's ES5 syntax cannot
+    // write directly — then U+FE0F. See the note above.
+    glyph: '\uD83C\uDD7F\uFE0F',
     label: 'Parking entrance',
     applies: function(tags) {
       return tags.amenity === 'parking_entrance';

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -154,6 +154,28 @@ function entranceName(entrance) {
   return name.length ? name : null;
 }
 
+// OSM's wheelchair values that mean a door can actually be used. `designated`
+// marks one provided specifically for wheelchair users, so it qualifies at
+// least as much as `yes`. `limited` deliberately does not: it means passable
+// only with help, or under conditions the tag does not spell out, and a mark
+// promising step-free access there would be worse than no mark at all.
+var WHEELCHAIR_ACCESSIBLE = {yes: true, designated: true};
+
+/**
+ * Whether a door is tagged wheelchair accessible in OSM.
+ *
+ * Only about an eighth of entrance nodes carry the tag at all, so its absence
+ * means nobody surveyed the door, not that the door has a step. This therefore
+ * only ever adds a mark to a door; it never filters one out, and
+ * `routableEntrances` stays untouched by it.
+ */
+function isWheelchairAccessible(entrance) {
+  var tags = entrance && entrance.tags;
+  var value = tags && tags.wheelchair;
+  if (typeof value !== 'string') return false;
+  return WHEELCHAIR_ACCESSIBLE[value.trim().toLowerCase()] === true;
+}
+
 // Two label boxes touching edge-to-edge are not overlapping; only real overlap
 // counts, so labels may sit flush against each other.
 function boxesOverlap(a, b) {
@@ -370,18 +392,23 @@ function createEntrancePicker(map, options) {
 
     state.choices.forEach(function(choice) {
       var text = label(choice);
+      var accessible = isWheelchairAccessible(choice.entrance);
       var chosen = choice.id === state.selectedId;
       var className = 'osrm-entrance-marker osrm-entrance-marker-' + choice.kind +
         (chosen ? ' osrm-entrance-marker-selected' : '');
       var marker = L.marker(choice.center, {
         icon: L.divIcon({className: className, iconSize: [18, 18], iconAnchor: [9, 9], html: ''}),
-        alt: text,
+        // The label shows this as an icon; the alt spells it out, because the
+        // icon is marked aria-hidden and would otherwise be announced as
+        // nothing at all.
+        alt: accessible ? text + ' (' + translate('Wheelchair accessible') + ')' : text,
         keyboard: true,
         zIndexOffset: chosen ? 500 : 400
       });
       // The name travels with the dot; layoutLabels turns it into a label the
       // user can read without hovering.
       marker.__entranceLabel = text;
+      marker.__entranceWheelchair = accessible;
       marker.on('click', function(e) {
         // Without this the click also lands on the map, which would drop a new
         // waypoint on top of the place being chosen for.
@@ -435,13 +462,17 @@ function createEntrancePicker(map, options) {
   // A label sits above the door it names, anchored on it. Zero-sized so the
   // anchor is the door itself; the inner element does the drawing and is what
   // gets measured.
-  function addLabel(latLng, names, merged) {
+  function labelEntry(marker) {
+    return {text: marker.__entranceLabel, wheelchair: !!marker.__entranceWheelchair};
+  }
+
+  function addLabel(latLng, entries, merged) {
     var options = {
       icon: L.divIcon({
         className: 'osrm-entrance-label' + (merged ? ' osrm-entrance-label-merged' : ''),
         iconSize: null,
         html: '<span class="osrm-entrance-label-inner">' +
-          names.map(labelLine).join('') + '</span>'
+          entries.map(labelLine).join('') + '</span>'
       }),
       // Never in the way of a click on a door, and always drawn beneath one.
       interactive: false,
@@ -455,10 +486,16 @@ function createEntrancePicker(map, options) {
   }
 
   // These names come from OSM and would otherwise be read as markup.
-  function labelLine(name) {
+  function labelLine(entry) {
     var div = document.createElement('div');
-    div.textContent = name;
-    return '<div>' + div.innerHTML + '</div>';
+    div.textContent = entry.text;
+    // Hidden from assistive tech on purpose: the dot's alt already says
+    // "wheelchair accessible" in words, and announcing the symbol too would
+    // repeat it.
+    var mark = entry.wheelchair
+      ? '<span class="osrm-entrance-wheelchair" aria-hidden="true">\u267F</span>'
+      : '';
+    return '<div>' + div.innerHTML + mark + '</div>';
   }
 
   function labelBox(marker) {
@@ -485,7 +522,7 @@ function createEntrancePicker(map, options) {
     // decided from.
     labelLayer.clearLayers();
     var labels = markers.map(function(marker) {
-      return addLabel(markerLatLng(marker), [marker.__entranceLabel], false);
+      return addLabel(markerLatLng(marker), [labelEntry(marker)], false);
     });
 
     var boxes = labels.map(labelBox);
@@ -504,7 +541,7 @@ function createEntrancePicker(map, options) {
     groups.forEach(function(group) {
       addLabel(markerLatLng(markers[group[0]]),
         group.map(function(i) {
-          return markers[i].__entranceLabel;
+          return labelEntry(markers[i]);
         }),
         group.length > 1);
     });
@@ -661,6 +698,7 @@ module.exports = {
   routableEntrances: routableEntrances,
   allowsMode: allowsMode,
   entranceName: entranceName,
+  isWheelchairAccessible: isWheelchairAccessible,
   boxesOverlap: boxesOverlap,
   clusterOverlappingLabels: clusterOverlappingLabels,
   waypointRole: waypointRole,

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -383,6 +383,10 @@ function minPairSeparation(points) {
  * @param {L.Map} map
  * @param {object} options
  * @param {function} options.onSelect  — called with {waypointIndex, placeName, latLng, entrance}
+ *
+ * show() takes `frame: false` to redraw an offer without moving the view: a
+ * change of travel mode or of a waypoint's role re-filters the doors already
+ * on screen, and the user did not ask to be taken to them.
  * @param {function} [options.translate] — (key) => localized string
  * @param {function} [options.fetchOutline] — (place) => Promise<GeoJSON geometry|null>
  * @param {function} [options.paneWidth] — () => width in px of the directions pane
@@ -488,9 +492,13 @@ function createEntrancePicker(map, options) {
           zIndexOffset: chosen ? 500 : 400
         });
         // The name travels with the dot; layoutLabels turns it into a label the
-        // user can read without hovering.
+        // user can read without hovering, and click as a stand-in for the dot.
         marker.__entranceLabel = text;
         marker.__entranceMark = mark;
+        marker.__entranceSelected = chosen;
+        marker.__entranceSelect = function() {
+          select(offer, choice);
+        };
         marker.on('click', function(e) {
           // Without this the click also lands on the map, which would drop a
           // new waypoint on top of the place being chosen for.
@@ -548,9 +556,30 @@ function createEntrancePicker(map, options) {
   // anchor is the door itself; the inner element does the drawing and is what
   // gets measured.
   function labelEntry(marker) {
-    return {text: marker.__entranceLabel, mark: marker.__entranceMark || null};
+    return {
+      text: marker.__entranceLabel,
+      mark: marker.__entranceMark || null,
+      selected: !!marker.__entranceSelected,
+      select: marker.__entranceSelect
+    };
   }
 
+  // Which line of a label a click landed on, from the element under the
+  // pointer: the label's lines are its inner span's direct children, in the
+  // order of its entries. -1 when the click missed every line.
+  function clickedLineIndex(e) {
+    var target = e && e.originalEvent && e.originalEvent.target;
+    if (!target || !target.closest) return -1;
+    var line = target.closest('.osrm-entrance-label-inner > div');
+    if (!line || !line.parentNode) return -1;
+    return Array.prototype.indexOf.call(line.parentNode.children, line);
+  }
+
+  // A label is clickable, and clicking it does what clicking its door does.
+  // That is what makes a merged label usable: the doors it lists are the ones
+  // too close together to aim at, so their names are the only way to pick one
+  // apart. The label still sits beneath the dots, so a click that lands on a
+  // dot goes to the dot.
   function addLabel(latLng, entries, merged) {
     var options = {
       icon: L.divIcon({
@@ -559,13 +588,21 @@ function createEntrancePicker(map, options) {
         html: '<span class="osrm-entrance-label-inner">' +
           entries.map(labelLine).join('') + '</span>'
       }),
-      // Never in the way of a click on a door, and always drawn beneath one.
-      interactive: false,
+      interactive: true,
+      keyboard: false,
       zIndexOffset: 100
     };
     var pane = ensureLabelPane();
     if (pane) options.pane = pane;
     var marker = L.marker(latLng, options);
+    marker.on('click', function(e) {
+      // Same reason as on the dot: the map must not take this as a click.
+      L.DomEvent.stopPropagation(e);
+      // A single-door label is its door; a merged one picks the line clicked.
+      var index = entries.length === 1 ? 0 : clickedLineIndex(e);
+      var entry = entries[index];
+      if (entry && typeof entry.select === 'function') entry.select();
+    });
     labelLayer.addLayer(marker);
     return marker;
   }
@@ -580,7 +617,8 @@ function createEntrancePicker(map, options) {
       ? '<span class="osrm-entrance-mark ' + entry.mark.className +
         '" aria-hidden="true">' + entry.mark.glyph + '</span>'
       : '';
-    return '<div>' + div.innerHTML + mark + '</div>';
+    return '<div' + (entry.selected ? ' class="osrm-entrance-label-selected"' : '') + '>' +
+      div.innerHTML + mark + '</div>';
   }
 
   function labelBox(marker) {
@@ -759,7 +797,7 @@ function createEntrancePicker(map, options) {
     attached = true;
     if (!map.hasLayer(layer)) layer.addTo(map);
     loadOutline(offer, opts.place);
-    focusViewWhenSettled();
+    if (opts.frame !== false) focusViewWhenSettled();
     render();
     // Which labels fit is a question of zoom, so the layout is redone after
     // every one.

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -61,6 +61,98 @@ function entranceWaypointName(placeName, entrance, translate) {
   return placeName + ' (' + suffix + ')';
 }
 
+// LRM's own default for maxGeocoderTolerance, in metres. Beyond it LRM labels
+// the waypoint with bare coordinates instead of the place it found.
+var MAX_GEOCODER_TOLERANCE = 200;
+
+/**
+ * Wraps the geocoder handed to LRM's plan so a reverse-geocoded waypoint still
+ * reaches the picker.
+ *
+ * LRM fires `geocoded` only when the user picks from the autocomplete. A
+ * waypoint that arrives with coordinates and no name — restored from a shared
+ * URL, dropped by a click on the map, dragged somewhere new — is named by
+ * GeocoderElement.update() calling `geocoder.reverse` directly, and that result
+ * is discarded once the name has been taken out of it. The entrance list goes
+ * with it, so a place whose doors were on offer a moment ago has none after a
+ * reload, even though the answer is sitting in the cache.
+ *
+ * A reverse result has the same shape as a search result, so it is re-fired as
+ * `waypointgeocoderesult` against whichever waypoint the coordinates belong to.
+ *
+ * No guard against reopening the picker unbidden is needed: `update()` only
+ * reverse-geocodes when the waypoint has no name, and LRM's one forced call
+ * clears the name first, so every reverse arriving here is a waypoint being
+ * named for the first time.
+ *
+ * @param {object} options
+ * @param {object} options.geocoder — the geocoder LRM would otherwise be given
+ * @param {function} options.getPlan — () => the plan, read late because the plan
+ *   is built from the geocoder and cannot exist yet
+ * @param {number} [options.tolerance] — metres; beyond this LRM discards the
+ *   name, and offering that place's doors would offer doors of somewhere the
+ *   user did not pick
+ * @returns {object} a geocoder to hand to the plan
+ */
+function createReverseNotifier(options) {
+  options = options || {};
+  var geocoder = options.geocoder;
+  var getPlan = options.getPlan;
+  if (!geocoder || typeof geocoder.reverse !== 'function') return geocoder;
+  var tolerance = typeof options.tolerance === 'number'
+    ? options.tolerance : MAX_GEOCODER_TOLERANCE;
+
+  // Bound rather than copied, so the original keeps its own `this` whatever it
+  // closes over.
+  var wrapped = {};
+  for (var key in geocoder) {
+    wrapped[key] = typeof geocoder[key] === 'function'
+      ? geocoder[key].bind(geocoder) : geocoder[key];
+  }
+
+  function waypointIndexAt(latLng) {
+    var plan = typeof getPlan === 'function' ? getPlan() : null;
+    var waypoints = plan && plan._waypoints;
+    if (!waypoints || !latLng) return -1;
+    for (var i = 0; i < waypoints.length; i++) {
+      var wp = waypoints[i];
+      var at = wp && wp.latLng;
+      if (!at) continue;
+      if (at === latLng) return i;
+      if (at.lat === latLng.lat && at.lng === latLng.lng) return i;
+    }
+    return -1;
+  }
+
+  function notify(latLng, results) {
+    var result = results && results.length ? results[0] : null;
+    if (!result || !result.center) return;
+    if (typeof result.center.distanceTo === 'function' &&
+        result.center.distanceTo(latLng) >= tolerance) return;
+    var index = waypointIndexAt(latLng);
+    if (index === -1) return;
+    var plan = getPlan();
+    plan.fire('waypointgeocoderesult', {
+      waypointIndex: index,
+      waypoint: plan._waypoints[index],
+      value: result
+    });
+  }
+
+  wrapped.reverse = function(latLng, scale, cb, context) {
+    return geocoder.reverse(latLng, scale, function(results) {
+      // LRM's callback first: it sets the waypoint's name, and the picker's
+      // offer is built against a waypoint that has already been named.
+      if (typeof cb === 'function') cb.call(context, results);
+      try {
+        notify(latLng, results);
+      } catch (e) {}
+    }, context);
+  };
+
+  return wrapped;
+}
+
 /**
  * @param {object} options
  * @param {L.Map} options.map
@@ -86,9 +178,11 @@ function createEntranceWaypoints(options) {
   var mode = typeof options.mode === 'function' ? options.mode : function() {
     return null;
   };
-  // The result the picker is currently showing, kept so a change of travel mode
-  // can re-apply the access rules without a fresh geocode.
-  var lastEvent = null;
+  // The last geocoding result seen for each waypoint, kept so a change of travel
+  // mode can re-apply the access rules to everything on screen without a fresh
+  // geocode. Keyed by waypoint index, because several waypoints can be showing
+  // their doors at once.
+  var lastEvents = {};
 
   // Points one waypoint at a new location without going through
   // spliceWaypoints, which recreates the geocoder inputs and would steal the
@@ -138,7 +232,7 @@ function createEntranceWaypoints(options) {
 
   function onGeocodeResult(e) {
     var result = e && e.value;
-    lastEvent = e;
+    lastEvents[e.waypointIndex] = e;
     // Two independent filters. Which end of the route this waypoint is decides
     // the direction a door must work in — an entrance=exit can only be left
     // through, an entrance=entrance only entered. The travel mode then decides
@@ -150,7 +244,10 @@ function createEntranceWaypoints(options) {
       ? entrancePicker.routableEntrances(result.entrances, role, mode())
       : [];
     if (!entrances.length) {
-      picker.hide();
+      // Only this waypoint's dots go. Naming a start with no doors of its own
+      // must not withdraw the destination's — that is the whole reason offers
+      // are per-waypoint.
+      picker.hideWaypoint(e.waypointIndex);
       return false;
     }
 
@@ -167,12 +264,17 @@ function createEntranceWaypoints(options) {
     });
   }
 
-  // Re-applies the filters to the place already on screen. Switching from foot
-  // to car can forbid the very door the waypoint sits on, so the offer has to be
+  // Re-applies the filters to every place on screen. Switching from foot to car
+  // can forbid the very door a waypoint sits on, so each open offer is
   // recomputed rather than left stale.
   function refresh() {
-    if (!lastEvent || !picker.isOpen()) return false;
-    return onGeocodeResult(lastEvent);
+    if (!picker.isOpen()) return false;
+    var any = false;
+    Object.keys(lastEvents).forEach(function(key) {
+      if (!picker.isOpenFor(Number(key))) return;
+      if (onGeocodeResult(lastEvents[key])) any = true;
+    });
+    return any;
   }
 
   return {
@@ -180,7 +282,7 @@ function createEntranceWaypoints(options) {
     applySelection: applySelection,
     refresh: refresh,
     hide: function() {
-      lastEvent = null;
+      lastEvents = {};
       picker.hide();
     },
     isOpen: function() {
@@ -197,6 +299,7 @@ function createEntranceWaypoints(options) {
 
 module.exports = {
   waypointMarkerLatLng: waypointMarkerLatLng,
+  createReverseNotifier: createReverseNotifier,
   entranceWaypointName: entranceWaypointName,
   createEntranceWaypoints: createEntranceWaypoints
 };

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -1,0 +1,199 @@
+'use strict';
+
+var entrancePicker = require('./entrance_picker');
+
+/**
+ * Where a waypoint's pin belongs when it differs from where the route runs to.
+ * Stashed on LRM's own waypoint object because that is what createMarker is
+ * handed; exported so the map's createMarker can read it back.
+ */
+var MARKER_LATLNG = '_entranceMarkerLatLng';
+
+/**
+ * The position to draw a waypoint's pin at: the place it stands for, falling
+ * back to wherever the route runs to.
+ */
+function waypointMarkerLatLng(wp) {
+  return (wp && wp[MARKER_LATLNG]) || (wp && wp.latLng);
+}
+
+/**
+ * Wires the entrance picker to the routing plan.
+ *
+ * A geocoded place drops its waypoint on the centroid. For a large site that is
+ * nowhere reachable — BER's centroid sits on the airfield, 1.5 km from the
+ * terminal doors — so Nominatim's entrance nodes are offered as clickable dots
+ * on the map, together with the place centre so the move can always be undone.
+ *
+ * The choice is always the user's: nothing is applied automatically. Which door
+ * is usable depends on where the router can actually get to, and the tagging
+ * does not say — the Pergamonmuseum's `entrance=main` node sits 90 m from
+ * anything the walking network reaches while its `entrance=yes` node is on the
+ * path — so asserting a door would be confidently wrong about as often as right.
+ *
+ * Everything this module touches arrives through `options`, so the whole
+ * feature can be exercised against fakes rather than a live map.
+ *
+ * @module entrance_waypoints
+ */
+
+// The wording for a door with no name of its own. An exit is only offered at an
+// origin, where calling it an entrance would contradict why it is on offer.
+function entranceTypeKey(type) {
+  if (type === 'exit') return 'exit';
+  return type === 'main' ? 'main entrance' : 'entrance';
+}
+
+/**
+ * Appends the door to a place name, so the geocoder input says where the
+ * waypoint actually sits. Returns the name unchanged for the place centre.
+ *
+ * A door that names itself in OSM is named here too, matching what its tooltip
+ * says on the map — otherwise picking "Eingang Ravelinplatz" would leave an
+ * input reading "(entrance)", and the two would not obviously be the same thing.
+ */
+function entranceWaypointName(placeName, entrance, translate) {
+  if (!entrance) return placeName;
+  var t = typeof translate === 'function' ? translate : function(key) {
+    return key;
+  };
+  var suffix = entrancePicker.entranceName(entrance) || t(entranceTypeKey(entrance.type));
+  return placeName + ' (' + suffix + ')';
+}
+
+/**
+ * @param {object} options
+ * @param {L.Map} options.map
+ * @param {L.Routing.Plan} options.plan
+ * @param {object} options.routeFitTracker — from route_zoom
+ * @param {function} [options.translate] — (key) => localized string
+ * @param {function} [options.fetchOutline] — (place) => Promise<GeoJSON|null>
+ * @param {function} [options.paneWidth] — () => width of the directions pane
+ * @param {function} [options.mode] — () => the active routing profile, read live
+ *   so switching between car, bike and foot re-applies the access rules
+ * @param {function} [options.createPicker] — injection seam for tests
+ * @returns {{onGeocodeResult: function, hide: function, isOpen: function,
+ *   focusView: function, waypointName: function}}
+ */
+function createEntranceWaypoints(options) {
+  options = options || {};
+  var plan = options.plan;
+  var routeFitTracker = options.routeFitTracker;
+  var translate = typeof options.translate === 'function' ? options.translate : function(key) {
+    return key;
+  };
+  var createPicker = options.createPicker || entrancePicker.createEntrancePicker;
+  var mode = typeof options.mode === 'function' ? options.mode : function() {
+    return null;
+  };
+  // The result the picker is currently showing, kept so a change of travel mode
+  // can re-apply the access rules without a fresh geocode.
+  var lastEvent = null;
+
+  // Points one waypoint at a new location without going through
+  // spliceWaypoints, which recreates the geocoder inputs and would steal the
+  // focus LRM just handed to the next one. Reaches into the plan's internals
+  // because LRM offers no public way to move a single waypoint without that
+  // rebuild.
+  //
+  // `markerLatLng` is where the pin should be drawn, which is not where the
+  // route runs to: choosing a door routes to the door while the pin stays on
+  // the place the user actually searched for. createMarker reads it back off
+  // the waypoint.
+  function setWaypointInPlace(index, latLng, name, markerLatLng) {
+    var wp = plan && plan._waypoints && plan._waypoints[index];
+    if (!wp) return false;
+    wp.latLng = latLng;
+    wp.name = name;
+    if (markerLatLng && markerLatLng !== latLng) {
+      wp[MARKER_LATLNG] = markerLatLng;
+    } else {
+      delete wp[MARKER_LATLNG];
+    }
+    if (plan._geocoderElems && plan._geocoderElems[index]) {
+      plan._geocoderElems[index].setValue(name);
+    }
+    plan._updateMarkers();
+    // The user aimed at a point on the map, so the recomputed route must not
+    // drag the view off it. The route can still force a refit when it would
+    // otherwise run under the directions pane; the picker reclaims the view
+    // afterwards.
+    if (routeFitTracker) routeFitTracker.waypointDragStarted();
+    plan._fireChanged();
+    return true;
+  }
+
+  function applySelection(choice) {
+    return setWaypointInPlace(choice.waypointIndex, choice.latLng,
+      entranceWaypointName(choice.placeName, choice.entrance, translate),
+      choice.markerLatLng);
+  }
+
+  var picker = createPicker(options.map, {
+    translate: translate,
+    fetchOutline: options.fetchOutline,
+    paneWidth: options.paneWidth,
+    onSelect: applySelection
+  });
+
+  function onGeocodeResult(e) {
+    var result = e && e.value;
+    lastEvent = e;
+    // Two independent filters. Which end of the route this waypoint is decides
+    // the direction a door must work in — an entrance=exit can only be left
+    // through, an entrance=entrance only entered. The travel mode then decides
+    // which of those the traveller may actually use, from the door's own OSM
+    // access tags.
+    var count = plan && plan._waypoints ? plan._waypoints.length : 0;
+    var role = entrancePicker.waypointRole(e.waypointIndex, count);
+    var entrances = result
+      ? entrancePicker.routableEntrances(result.entrances, role, mode())
+      : [];
+    if (!entrances.length) {
+      picker.hide();
+      return false;
+    }
+
+    return picker.show({
+      waypointIndex: e.waypointIndex,
+      placeName: result.name,
+      placeCenter: result.center,
+      placeBounds: result.bbox,
+      entrances: entrances,
+      place: result
+    });
+  }
+
+  // Re-applies the filters to the place already on screen. Switching from foot
+  // to car can forbid the very door the waypoint sits on, so the offer has to be
+  // recomputed rather than left stale.
+  function refresh() {
+    if (!lastEvent || !picker.isOpen()) return false;
+    return onGeocodeResult(lastEvent);
+  }
+
+  return {
+    onGeocodeResult: onGeocodeResult,
+    applySelection: applySelection,
+    refresh: refresh,
+    hide: function() {
+      lastEvent = null;
+      picker.hide();
+    },
+    isOpen: function() {
+      return picker.isOpen(); 
+    },
+    focusView: function() {
+      picker.focusView(); 
+    },
+    waypointName: function(placeName, entrance) {
+      return entranceWaypointName(placeName, entrance, translate);
+    }
+  };
+}
+
+module.exports = {
+  waypointMarkerLatLng: waypointMarkerLatLng,
+  entranceWaypointName: entranceWaypointName,
+  createEntranceWaypoints: createEntranceWaypoints
+};

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -179,9 +179,10 @@ function createEntranceWaypoints(options) {
     return null;
   };
   // The last geocoding result seen for each waypoint, kept so a change of travel
-  // mode can re-apply the access rules to everything on screen without a fresh
+  // mode or of the waypoint's role can re-apply the filters without a fresh
   // geocode. Keyed by waypoint index, because several waypoints can be showing
-  // their doors at once.
+  // their doors at once; each entry holds the event and the role it was last
+  // filtered under, so a role change can be told from a mere renumbering.
   var lastEvents = {};
 
   // Points one waypoint at a new location without going through
@@ -232,7 +233,6 @@ function createEntranceWaypoints(options) {
 
   function onGeocodeResult(e) {
     var result = e && e.value;
-    lastEvents[e.waypointIndex] = e;
     // Two independent filters. Which end of the route this waypoint is decides
     // the direction a door must work in — an entrance=exit can only be left
     // through, an entrance=entrance only entered. The travel mode then decides
@@ -240,6 +240,7 @@ function createEntranceWaypoints(options) {
     // access tags.
     var count = plan && plan._waypoints ? plan._waypoints.length : 0;
     var role = entrancePicker.waypointRole(e.waypointIndex, count);
+    lastEvents[e.waypointIndex] = {event: e, role: role};
     var entrances = result
       ? entrancePicker.routableEntrances(result.entrances, role, mode())
       : [];
@@ -272,36 +273,78 @@ function createEntranceWaypoints(options) {
     var any = false;
     Object.keys(lastEvents).forEach(function(key) {
       if (!picker.isOpenFor(Number(key))) return;
-      if (onGeocodeResult(lastEvents[key])) any = true;
+      if (onGeocodeResult(lastEvents[key].event)) any = true;
     });
     return any;
+  }
+
+  // Where a waypoint that was spliced out has reappeared among the ones spliced
+  // in, or -1 if it is genuinely gone. LRM's reverse button replaces the whole
+  // list — spliceWaypoints(0, length, ...the same waypoint objects, reordered)
+  // — so "removed" and "added" overlap, and only object identity tells a real
+  // removal from a waypoint that merely changed places. LRM passes a waypoint
+  // through untouched when it already has a `latLng`, so the objects survive.
+  function addedIndexOf(added, waypoint) {
+    if (!waypoint || !added) return -1;
+    for (var i = 0; i < added.length; i++) {
+      if (added[i] === waypoint) return i;
+    }
+    return -1;
   }
 
   // Keeps the remembered results lined up with the waypoints they belong to.
   // Without this a refresh after a splice would re-offer a place against the
   // wrong waypoint.
+  //
+  // A splice can also change what a waypoint *is*: reversing start and
+  // destination, or adding one after it so it becomes a via. Which doors are on
+  // offer follows directly from that role — an entrance=exit can be left through
+  // but not entered — so every waypoint whose role changed is re-filtered
+  // against the result already remembered for it. Without this, reversing a
+  // route left a door that is only valid at the new end unoffered until the
+  // address was typed again.
   function spliceWaypoints(e) {
     var index = e && typeof e.index === 'number' ? e.index : 0;
     var removed = e && typeof e.nRemoved === 'number' ? e.nRemoved : 0;
-    var added = e && e.added ? e.added.length : 0;
+    var addedList = e && e.added ? e.added : [];
+    var added = addedList.length;
     var delta = added - removed;
     var moved = {};
     Object.keys(lastEvents).forEach(function(key) {
       var at = Number(key);
+      var record = lastEvents[key];
+      var to;
       if (at < index) {
-        moved[at] = lastEvents[key];
+        // Untouched: it sits before the splice.
+        moved[at] = record;
         return;
       }
-      if (at < index + removed) return;
-      var to = at + delta;
-      var event = lastEvents[key];
+      if (at < index + removed) {
+        var reAdded = addedIndexOf(addedList, record.event && record.event.waypoint);
+        // Its waypoint is gone, and so is the place it belonged to.
+        if (reAdded === -1) return;
+        to = index + reAdded;
+      } else {
+        to = at + delta;
+      }
       // The event carries the index the picker is keyed by, so it has to move
       // with it.
-      if (event && typeof event === 'object') event.waypointIndex = to;
-      moved[to] = event;
+      if (record.event) record.event.waypointIndex = to;
+      moved[to] = record;
     });
     lastEvents = moved;
+    // Renumber the offers first. A waypoint that moved has had its offer dropped
+    // here — spliceOffers cannot tell it apart from a removal — and the
+    // re-filtering below puts it back at the index it now has.
     picker.spliceOffers(index, removed, added);
+
+    var count = plan && plan._waypoints ? plan._waypoints.length : 0;
+    Object.keys(lastEvents).forEach(function(key) {
+      var record = lastEvents[key];
+      if (!record || !record.event) return;
+      if (entrancePicker.waypointRole(Number(key), count) === record.role) return;
+      onGeocodeResult(record.event);
+    });
   }
 
   return {

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -277,8 +277,40 @@ function createEntranceWaypoints(options) {
     return any;
   }
 
+  // Keeps the remembered results lined up with the waypoints they belong to.
+  // Without this a refresh after a splice would re-offer a place against the
+  // wrong waypoint.
+  function spliceWaypoints(e) {
+    var index = e && typeof e.index === 'number' ? e.index : 0;
+    var removed = e && typeof e.nRemoved === 'number' ? e.nRemoved : 0;
+    var added = e && e.added ? e.added.length : 0;
+    var delta = added - removed;
+    var moved = {};
+    Object.keys(lastEvents).forEach(function(key) {
+      var at = Number(key);
+      if (at < index) {
+        moved[at] = lastEvents[key];
+        return;
+      }
+      if (at < index + removed) return;
+      var to = at + delta;
+      var event = lastEvents[key];
+      // The event carries the index the picker is keyed by, so it has to move
+      // with it.
+      if (event && typeof event === 'object') event.waypointIndex = to;
+      moved[to] = event;
+    });
+    lastEvents = moved;
+    picker.spliceOffers(index, removed, added);
+  }
+
   return {
     onGeocodeResult: onGeocodeResult,
+    spliceWaypoints: spliceWaypoints,
+    hideWaypoint: function(waypointIndex) {
+      delete lastEvents[waypointIndex];
+      picker.hideWaypoint(waypointIndex);
+    },
     applySelection: applySelection,
     refresh: refresh,
     hide: function() {

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -181,10 +181,10 @@ function createEntranceWaypoints(options) {
       picker.hide();
     },
     isOpen: function() {
-      return picker.isOpen(); 
+      return picker.isOpen();
     },
     focusView: function() {
-      picker.focusView(); 
+      picker.focusView();
     },
     waypointName: function(placeName, entrance) {
       return entranceWaypointName(placeName, entrance, translate);

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -156,6 +156,9 @@ function createEntranceWaypoints(options) {
 
     return picker.show({
       waypointIndex: e.waypointIndex,
+      // The picker marks doors differently per mode, so it needs the same value
+      // the filtering above used.
+      mode: mode(),
       placeName: result.name,
       placeCenter: result.center,
       placeBounds: result.bbox,

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -165,7 +165,7 @@ function createReverseNotifier(options) {
  *   so switching between car, bike and foot re-applies the access rules
  * @param {function} [options.createPicker] — injection seam for tests
  * @returns {{onGeocodeResult: function, hide: function, isOpen: function,
- *   focusView: function, waypointName: function}}
+ *   claimView: function, waypointName: function}}
  */
 function createEntranceWaypoints(options) {
   options = options || {};
@@ -184,6 +184,13 @@ function createEntranceWaypoints(options) {
   // their doors at once; each entry holds the event and the role it was last
   // filtered under, so a role change can be told from a mere renumbering.
   var lastEvents = {};
+  // Set when a fresh geocode opens or re-opens an offer and the picker frames
+  // it. The route that follows would otherwise be fitted over that framing;
+  // index.js asks for the claim once per route and stands down if it is set.
+  // Only a fresh geocode claims: a route recomputed for a new via point, a
+  // profile change or a reorder is not the picker's doing, and the view must
+  // not jump to the doors on every one of them.
+  var viewClaimed = false;
 
   // Points one waypoint at a new location without going through
   // spliceWaypoints, which recreates the geocoder inputs and would steal the
@@ -231,7 +238,10 @@ function createEntranceWaypoints(options) {
     onSelect: applySelection
   });
 
-  function onGeocodeResult(e) {
+  // `frame` is false for the internal re-filters below; the plan's event
+  // handler passes only the event, and a fresh geocode frames its doors.
+  function onGeocodeResult(e, frame) {
+    frame = frame !== false;
     var result = e && e.value;
     // Two independent filters. Which end of the route this waypoint is decides
     // the direction a door must work in — an entrance=exit can only be left
@@ -252,7 +262,7 @@ function createEntranceWaypoints(options) {
       return false;
     }
 
-    return picker.show({
+    var shown = picker.show({
       waypointIndex: e.waypointIndex,
       // The picker marks doors differently per mode, so it needs the same value
       // the filtering above used.
@@ -261,8 +271,11 @@ function createEntranceWaypoints(options) {
       placeCenter: result.center,
       placeBounds: result.bbox,
       entrances: entrances,
-      place: result
+      place: result,
+      frame: frame
     });
+    if (shown && frame) viewClaimed = true;
+    return shown;
   }
 
   // Re-applies the filters to every place on screen. Switching from foot to car
@@ -273,7 +286,7 @@ function createEntranceWaypoints(options) {
     var any = false;
     Object.keys(lastEvents).forEach(function(key) {
       if (!picker.isOpenFor(Number(key))) return;
-      if (onGeocodeResult(lastEvents[key].event)) any = true;
+      if (onGeocodeResult(lastEvents[key].event, false)) any = true;
     });
     return any;
   }
@@ -343,7 +356,7 @@ function createEntranceWaypoints(options) {
       var record = lastEvents[key];
       if (!record || !record.event) return;
       if (entrancePicker.waypointRole(Number(key), count) === record.role) return;
-      onGeocodeResult(record.event);
+      onGeocodeResult(record.event, false);
     });
   }
 
@@ -363,8 +376,12 @@ function createEntranceWaypoints(options) {
     isOpen: function() {
       return picker.isOpen();
     },
-    focusView: function() {
-      picker.focusView();
+    // Whether the next route belongs to a picker that has just framed its
+    // doors. Answering consumes the claim, so only one route stands down.
+    claimView: function() {
+      var claimed = viewClaimed;
+      viewClaimed = false;
+      return claimed;
     },
     waypointName: function(placeName, entrance) {
       return entranceWaypointName(placeName, entrance, translate);

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var L = require('leaflet');
+var simplify = require('./simplify');
 
 var geocoder = function(i, num) {
   var container = L.DomUtil.create('div',
@@ -77,11 +78,18 @@ function announceRateLimit(msg) {
 geocoder.coordPreserving = function(nominatimUrl) {
   var nominatim;
   var normalizedNominatimUrl = typeof nominatimUrl === 'string' ? nominatimUrl.trim() : '';
+  // Nominatim only reports a place's entrance nodes when asked (`entrances=1`,
+  // supported since Nominatim 5.2 on /search and /reverse). Older instances
+  // ignore the parameter, so it is safe to send unconditionally.
+  var entranceParams = {
+    geocodingQueryParams: {entrances: 1},
+    reverseQueryParams: {entrances: 1}
+  };
   if (normalizedNominatimUrl.length > 0) {
-    nominatim = L.Control.Geocoder.nominatim({serviceUrl: normalizedNominatimUrl});
+    nominatim = L.Control.Geocoder.nominatim(L.extend({serviceUrl: normalizedNominatimUrl}, entranceParams));
   } else {
     // Preserve Leaflet-Control-Geocoder's default behavior when no URL provided
-    nominatim = L.Control.Geocoder.nominatim();
+    nominatim = L.Control.Geocoder.nominatim(L.extend({}, entranceParams));
   }
 
   // LRU cache persisted to localStorage when available.
@@ -166,6 +174,21 @@ geocoder.coordPreserving = function(nominatimUrl) {
                 out.bbox = r.bbox;
               }
             }
+            if (r.osmType) out.osmType = r.osmType;
+            if (r.osmId !== undefined) out.osmId = r.osmId;
+            if (Array.isArray(r.entrances)) {
+              out.entrances = r.entrances.map(function(e) {
+                var entry = {
+                  osmId: e.osmId,
+                  type: e.type,
+                  center: e.center ? {lat: e.center.lat, lng: e.center.lng} : null
+                };
+                // Without the tags a cached place silently loses its access
+                // rules and would offer doors the mode forbids.
+                if (e.tags) entry.tags = e.tags;
+                return entry;
+              });
+            }
             return out;
           })
         }];
@@ -205,6 +228,14 @@ geocoder.coordPreserving = function(nominatimUrl) {
                         if (!(r.center && typeof r.center.toBounds === 'function')) {
                           r.center = L.latLng(r.center.lat, r.center.lng);
                         }
+                      }
+                      // rehydrate entrance centers -> L.latLng
+                      if (r && Array.isArray(r.entrances)) {
+                        r.entrances.forEach(function(e) {
+                          if (e && e.center && e.center.lat !== undefined && e.center.lng !== undefined) {
+                            e.center = L.latLng(e.center.lat, e.center.lng);
+                          }
+                        });
                       }
                       // rehydrate bbox -> L.latLngBounds when possible
                       if (r && r.bbox) {
@@ -300,10 +331,74 @@ geocoder.coordPreserving = function(nominatimUrl) {
     };
   }
 
-  if (!globalNominatimCache) globalNominatimCache = createLRUCache('osrm_nominatim_cache_v1', 128, 24 * 60 * 60 * 1000);
+  if (!globalNominatimCache) globalNominatimCache = createLRUCache('osrm_nominatim_cache_v2', 128, 24 * 60 * 60 * 1000);
   var cache = globalNominatimCache;
   var supportsFetch = typeof fetch === 'function';
   var serviceBase = (normalizedNominatimUrl && normalizedNominatimUrl.length > 0) ? normalizedNominatimUrl.replace(/\/+$/, '') + '/' : 'https://nominatim.openstreetmap.org/';
+
+  // Place outlines are fetched one at a time, only when something is actually
+  // about to draw one. They deliberately do not ride along on search: `suggest`
+  // runs on every keystroke, and a polygon per result would multiply a payload
+  // that is almost always discarded. Kept in memory only — the persisted result
+  // cache has a fixed shape that geometry has no place in.
+  var outlineCache = {};
+
+  var OSM_TYPE_PREFIX = {node: 'N', way: 'W', relation: 'R'};
+
+  // Backstop against a pathological relation. Ordinary places are governed by
+  // visual negligibility instead and never come near this.
+  var MAX_OUTLINE_POINTS_PER_RING = 2000;
+
+  function buildLookupUrl(osmType, osmId) {
+    var prefix = OSM_TYPE_PREFIX[String(osmType).toLowerCase()];
+    if (!prefix) return null;
+    // The full outline is requested and thinned here instead of via Nominatim's
+    // polygon_threshold, whose tolerance is an absolute number of degrees: a
+    // value large enough to thin a 5 km airport also flattens a 170 m building
+    // into a few stray corners. See simplifyOutline below.
+    return serviceBase + 'lookup?format=json&polygon_geojson=1' +
+      '&osm_ids=' + prefix + encodeURIComponent(osmId);
+  }
+
+  // Thins the outline without changing how it looks: Visvalingam–Whyatt drops
+  // vertices in order of the area they contribute and stops as soon as the
+  // smallest survivor would be visible at the scale the picker draws the place.
+  // A building keeps every corner that reads as a corner; only redundant
+  // vertices go.
+  function simplifyOutline(geometry) {
+    return simplify.simplifyGeometry(geometry, {maxPoints: MAX_OUTLINE_POINTS_PER_RING});
+  }
+
+  // Resolves to the place's GeoJSON outline, or null when it has none (a node),
+  // when the endpoint is an older Nominatim, or when the request fails. Callers
+  // treat a missing outline as "just don't draw one".
+  function fetchOutline(result) {
+    if (!result || result.osmType === undefined || result.osmId === undefined) {
+      return Promise.resolve(null);
+    }
+    var url = buildLookupUrl(result.osmType, result.osmId);
+    if (!url) return Promise.resolve(null);
+    if (Object.prototype.hasOwnProperty.call(outlineCache, url)) {
+      return Promise.resolve(outlineCache[url]);
+    }
+    if (!supportsFetch) return Promise.resolve(null);
+    return fetch(url, {headers: {'Accept': 'application/json'}}).then(function(resp) {
+      if (!resp.ok) return null;
+      return resp.json();
+    }).then(function(json) {
+      var geometry = Array.isArray(json) && json[0] ? json[0].geojson : null;
+      // Only areas are worth outlining; a node's outline is the point itself.
+      if (!geometry || (geometry.type !== 'Polygon' && geometry.type !== 'MultiPolygon')) {
+        geometry = null;
+      } else {
+        geometry = simplifyOutline(geometry);
+      }
+      outlineCache[url] = geometry;
+      return geometry;
+    }).catch(function() {
+      return null;
+    });
+  }
 
   function setInputBgFromContext(context, color) {
     try {
@@ -318,7 +413,7 @@ geocoder.coordPreserving = function(nominatimUrl) {
   }
 
   function buildSearchUrl(query) {
-    return serviceBase + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent(query);
+    return serviceBase + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent(query);
   }
 
   function buildReverseUrl(latlng, scale) {
@@ -339,7 +434,53 @@ geocoder.coordPreserving = function(nominatimUrl) {
       }
     } catch (e) {}
     zoom = Math.max(0, Math.min(18, zoom));
-    return serviceBase + 'reverse?format=json&addressdetails=1&lat=' + encodeURIComponent(lat) + '&lon=' + encodeURIComponent(lon) + '&zoom=' + encodeURIComponent(zoom);
+    return serviceBase + 'reverse?format=json&addressdetails=1&entrances=1&lat=' + encodeURIComponent(lat) + '&lon=' + encodeURIComponent(lon) + '&zoom=' + encodeURIComponent(zoom);
+  }
+
+  // Normalizes Nominatim's `entrances` array into the shape the rest of the app
+  // uses. Returns null rather than an empty array so callers can treat "no
+  // entrance data" and "place has no entrances" identically.
+  //
+  // `tags` is the entrance node's own tag set, which Nominatim returns as
+  // `extratags` without being asked for it. It carries the OSM access keys —
+  // `access`, `foot`, `bicycle`, `motor_vehicle` — that say which modes may use
+  // a door, so it has to survive as far as the picker.
+  function parseEntrances(raw) {
+    if (!Array.isArray(raw)) return null;
+    var entrances = [];
+    raw.forEach(function(e) {
+      if (!e) return;
+      var lat = parseFloat(e.lat);
+      var lon = parseFloat(e.lon);
+      if (isNaN(lat) || isNaN(lon)) return;
+      var parsed = {
+        osmId: e.osm_id,
+        type: typeof e.type === 'string' ? e.type : 'yes',
+        center: L.latLng(lat, lon)
+      };
+      if (e.extratags && typeof e.extratags === 'object') parsed.tags = e.extratags;
+      entrances.push(parsed);
+    });
+    return entrances.length ? entrances : null;
+  }
+
+  // Lifts entrances out of the raw Nominatim payload that
+  // leaflet-control-geocoder preserves on `properties`. Used for the
+  // nominatim.geocode()/reverse() path, which maps results to {name, bbox,
+  // center, properties} and would otherwise drop the entrance list.
+  function attachPlaceDetails(results) {
+    if (!Array.isArray(results)) return results;
+    return results.map(function(r) {
+      if (!r || !r.properties) return r;
+      var extra = {};
+      if (!r.entrances) {
+        var entrances = parseEntrances(r.properties.entrances);
+        if (entrances) extra.entrances = entrances;
+      }
+      if (r.osmType === undefined && r.properties.osm_type) extra.osmType = r.properties.osm_type;
+      if (r.osmId === undefined && r.properties.osm_id !== undefined) extra.osmId = r.properties.osm_id;
+      return Object.keys(extra).length ? L.extend({}, r, extra) : r;
+    });
   }
 
   function parseSearchResults(json) {
@@ -354,11 +495,16 @@ geocoder.coordPreserving = function(nominatimUrl) {
           );
         }
       } catch (e) {}
-      return {
+      var result = {
         name: r.display_name || r.name || '',
         bbox: bbox,
         center: L.latLng(parseFloat(r.lat), parseFloat(r.lon))
       };
+      var entrances = parseEntrances(r.entrances);
+      if (entrances) result.entrances = entrances;
+      if (r.osm_type) result.osmType = r.osm_type;
+      if (r.osm_id !== undefined) result.osmId = r.osm_id;
+      return result;
     });
   }
 
@@ -398,7 +544,8 @@ geocoder.coordPreserving = function(nominatimUrl) {
 
     // Prefer using nominatim.geocode when available (helps tests that mock it).
     if (nominatim && typeof nominatim.geocode === 'function') {
-      return nominatim.geocode(query).then(function(results) {
+      return nominatim.geocode(query).then(function(rawResults) {
+        var results = attachPlaceDetails(rawResults);
         try {
           cache.set(url, results);
         } catch (e) {}
@@ -439,7 +586,8 @@ geocoder.coordPreserving = function(nominatimUrl) {
       setInputBgFromContext(context, 'white');
       basePromise = Promise.resolve(cached);
     } else if (nominatim && typeof nominatim.reverse === 'function') {
-      basePromise = nominatim.reverse(latlngWrapped, scale).then(function(results) {
+      basePromise = nominatim.reverse(latlngWrapped, scale).then(function(rawResults) {
+        var results = attachPlaceDetails(rawResults);
         try {
           cache.set(url, results);
         } catch (e) {}
@@ -475,11 +623,16 @@ geocoder.coordPreserving = function(nominatimUrl) {
               );
             }
           } catch (e) {}
-          var res = [{
+          var reverseResult = {
             name: json.display_name || json.name || '',
             bbox: bbox,
             center: L.latLng(parseFloat(json.lat), parseFloat(json.lon))
-          }];
+          };
+          var reverseEntrances = parseEntrances(json.entrances);
+          if (reverseEntrances) reverseResult.entrances = reverseEntrances;
+          if (json.osm_type) reverseResult.osmType = json.osm_type;
+          if (json.osm_id !== undefined) reverseResult.osmId = json.osm_id;
+          var res = [reverseResult];
           cache.set(url, res);
           setInputBgFromContext(context, 'white');
           return res;
@@ -510,10 +663,15 @@ geocoder.coordPreserving = function(nominatimUrl) {
     // Use scale corresponding to zoom level 18 (was hard-coded as 256 * 2^18 = 67108864)
     return doReverse(latlng, L.CRS.EPSG3857.scale(18), context).then(function(results) {
       if (results && results.length > 0) {
-        return [L.extend({}, results[0], {
+        var coordMatch = L.extend({}, results[0], {
           center: latlng,
           bbox: latlng.toBounds(1000)
-        })];
+        });
+        // A typed coordinate means "exactly here"; offering the entrances of
+        // whatever place happens to surround it would move the waypoint away
+        // from the point the user asked for.
+        delete coordMatch.entrances;
+        return [coordMatch];
       }
       return [{ name: query, center: latlng, bbox: latlng.toBounds(1000) }];
     }).catch(function() {
@@ -555,6 +713,8 @@ geocoder.coordPreserving = function(nominatimUrl) {
         return results;
       });
     },
+
+    fetchOutline: fetchOutline,
 
     reverse: function(latlng, scale, cb, context) {
       return doReverse(latlng, scale, context).then(function(results) {

--- a/src/index.js
+++ b/src/index.js
@@ -775,8 +775,16 @@ if (modeSelector && modeSelector.select) {
 
 // Adding, removing or reordering waypoints invalidates the index the picker is
 // pinned to; dragging the pin means the user has already chosen a spot.
-plan.on('waypointsspliced', entranceWaypoints.hide);
-plan.on('waypointdragstart', entranceWaypoints.hide);
+// Adding or removing a waypoint renumbers the ones after it, and each waypoint
+// keeps its own offer — so the offers are renumbered too rather than thrown
+// away. Dropping them all meant placing a destination by clicking the map took
+// the start's doors off the screen with it.
+plan.on('waypointsspliced', entranceWaypoints.spliceWaypoints);
+// Only the dragged waypoint's doors go: it is being moved off the place they
+// belong to, and no other waypoint is affected.
+plan.on('waypointdragstart', function(e) {
+  entranceWaypoints.hideWaypoint(e && e.index);
+});
 
 // If dst/src address params were passed and no loc= waypoints exist, geocode them now.
 (function applyAddressParams() {

--- a/src/index.js
+++ b/src/index.js
@@ -294,8 +294,22 @@ function makeIcon(i, n) {
 
 var routingGeocoder = createGeocoder.coordPreserving(leafletOptions.nominatim && leafletOptions.nominatim.path);
 
-var plan = new ReversablePlan([], {
+// Declared before the geocoder wrapper below, which reads it back late: the
+// plan is built from that geocoder and so cannot exist yet when it is made.
+var plan;
+
+// A waypoint restored from a URL, dropped by a map click or dragged is named by
+// LRM through a reverse geocode that never fires `geocoded`, so its entrance
+// list would be thrown away with the result. This re-fires it at the plan.
+var planGeocoder = entranceWaypointsModule.createReverseNotifier({
   geocoder: routingGeocoder,
+  getPlan: function() {
+    return plan;
+  }
+});
+
+plan = new ReversablePlan([], {
+  geocoder: planGeocoder,
   waypointNameFallback: createGeocoder.wrappedWaypointNameFallback,
   language: mergedOptions.language,
   routeWhileDragging: true,

--- a/src/index.js
+++ b/src/index.js
@@ -763,6 +763,12 @@ var entranceWaypoints = createEntranceWaypoints({
 
 plan.on('waypointgeocoderesult', entranceWaypoints.onGeocodeResult);
 
+// The route the picker was waiting on never came; its claim on the view must
+// not carry over to whatever route comes next.
+lrmControl.on('routingerror', function() {
+  entranceWaypoints.claimView();
+});
+
 // The doors on offer depend on the travel mode, so an open picker is recomputed
 // rather than left showing ones the new profile forbids. Registered here rather
 // than alongside the other profile-change handlers so it runs after the wiring
@@ -908,12 +914,13 @@ lrmControl.on('routeselected', function(e) {
     paneWidth = container.offsetWidth;
   }
 
-  // An open picker is a question waiting on the user, so the view belongs to it:
-  // the area being chosen from stays framed clear of the directions pane, and
-  // the route fit stands down until the picker closes.
-  if (entranceWaypoints.isOpen()) {
+  // A picker that has just framed the doors it offers keeps the view: the route
+  // that follows the geocode must not fit itself over them. Only that route
+  // stands down. A picker that is merely still open — while a via point is
+  // added, the profile changed or the list reordered — has no claim, or the
+  // map would jump back to the doors on every route.
+  if (entranceWaypoints.claimView()) {
     routeFitTracker.clearFitPending();
-    entranceWaypoints.focusView();
     return;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ var geocoderPatches = require('./geocoder_patches');
 geocoderPatches();
 var LRM = require('leaflet-routing-machine');
 var resolveWaypointSlot = require('./waypoint_placement').resolveWaypointSlot;
+var entranceWaypointsModule = require('./entrance_waypoints');
+var createEntranceWaypoints = entranceWaypointsModule.createEntranceWaypoints;
 
 // Register app languages that LRM does not have built-in so LRM does not throw
 // "No localization for language" when they are selected. We reuse English
@@ -249,6 +251,21 @@ map.on('overlayremove', function(e) {
 
 /* OSRM setup */
 var ReversablePlan = L.Routing.Plan.extend({
+  // LRM's own `waypointgeocoded` event carries only the waypoint, dropping the
+  // geocoding result and with it the entrance list Nominatim returned. Re-fire
+  // it with the result attached.
+  _createGeocoder: function(i) {
+    var geocoderElem = L.Routing.Plan.prototype._createGeocoder.call(this, i);
+    geocoderElem.on('geocoded', function(e) {
+      this.fire('waypointgeocoderesult', {
+        waypointIndex: i,
+        waypoint: e.waypoint,
+        value: e.value
+      });
+    }, this);
+    return geocoderElem;
+  },
+
   createGeocoders: function() {
     var container = L.Routing.Plan.prototype.createGeocoders.call(this);
     // Inject mode selector after geocoders are created
@@ -275,8 +292,10 @@ function makeIcon(i, n) {
   return L.icon(waypointMarker.waypointIconOptions(i, n));
 }
 
+var routingGeocoder = createGeocoder.coordPreserving(leafletOptions.nominatim && leafletOptions.nominatim.path);
+
 var plan = new ReversablePlan([], {
-  geocoder: createGeocoder.coordPreserving(leafletOptions.nominatim && leafletOptions.nominatim.path),
+  geocoder: routingGeocoder,
   waypointNameFallback: createGeocoder.wrappedWaypointNameFallback,
   language: mergedOptions.language,
   routeWhileDragging: true,
@@ -285,7 +304,10 @@ var plan = new ReversablePlan([], {
       draggable: this.draggableWaypoints,
       icon: makeIcon(i, n)
     };
-    var marker = L.marker(wp.latLng, options);
+    // Choosing an entrance routes to the door but leaves the pin on the place
+    // that was searched for, so the pin is drawn where the place is, not where
+    // the route ends.
+    var marker = L.marker(entranceWaypointsModule.waypointMarkerLatLng(wp), options);
     marker.on('click', function() {
       plan.spliceWaypoints(i, 1);
     });
@@ -699,6 +721,49 @@ plan.on('waypointgeocoded', function(e) {
   }
 });
 
+/* Entrance picker — see src/entrance_waypoints.js for what it does and why. */
+
+function directionsPaneWidth() {
+  var pane = document.querySelector('.leaflet-routing-container');
+  if (!pane || pane.classList.contains('leaflet-routing-container-hide')) return 0;
+  return pane.offsetWidth;
+}
+
+var entranceWaypoints = createEntranceWaypoints({
+  map: map,
+  plan: plan,
+  routeFitTracker: routeFitTracker,
+  translate: function(key) {
+    return localization.t(mergedOptions.language, key);
+  },
+  fetchOutline: routingGeocoder.fetchOutline,
+  paneWidth: directionsPaneWidth,
+  // Read live: a door forbidden to cars may be fine on foot, so the offer has to
+  // follow whatever profile is selected right now.
+  mode: function() {
+    var index = typeof state.options.profile === 'number'
+      ? state.options.profile : activeProfileIndex;
+    return services[index] && services[index].profile;
+  }
+});
+
+plan.on('waypointgeocoderesult', entranceWaypoints.onGeocodeResult);
+
+// The doors on offer depend on the travel mode, so an open picker is recomputed
+// rather than left showing ones the new profile forbids. Registered here rather
+// than alongside the other profile-change handlers so it runs after the wiring
+// above exists.
+if (modeSelector && modeSelector.select) {
+  L.DomEvent.on(modeSelector.select, 'change', function() {
+    entranceWaypoints.refresh();
+  });
+}
+
+// Adding, removing or reordering waypoints invalidates the index the picker is
+// pinned to; dragging the pin means the user has already chosen a spot.
+plan.on('waypointsspliced', entranceWaypoints.hide);
+plan.on('waypointdragstart', entranceWaypoints.hide);
+
 // If dst/src address params were passed and no loc= waypoints exist, geocode them now.
 (function applyAddressParams() {
   var hasLocWaypoints = mergedOptions.waypoints && mergedOptions.waypoints.some(function(wp) {
@@ -821,6 +886,15 @@ lrmControl.on('routeselected', function(e) {
     paneWidth = container.offsetWidth;
   }
 
+  // An open picker is a question waiting on the user, so the view belongs to it:
+  // the area being chosen from stays framed clear of the directions pane, and
+  // the route fit stands down until the picker closes.
+  if (entranceWaypoints.isOpen()) {
+    routeFitTracker.clearFitPending();
+    entranceWaypoints.focusView();
+    return;
+  }
+
   if (!routeFitTracker.isFitPending()) {
     // A drag leaves the view alone, unless it pushed the route into the
     // directions pane — the route must never run underneath it.
@@ -863,6 +937,7 @@ lrmControl.on('routeselected', function(e) {
   } else {
     map.fitBounds(bounds, paddingOpts);
   }
+
 });
 
 plan.on('waypointschanged', function(e) {

--- a/src/simplify.js
+++ b/src/simplify.js
@@ -1,0 +1,322 @@
+'use strict';
+
+/**
+ * Visvalingam–Whyatt polygon simplification, driven by visual negligibility.
+ *
+ * Repeatedly discards the vertex whose triangle with its two neighbours has the
+ * smallest area, recomputing the neighbours each time. Ranking by area rather
+ * than by perpendicular distance is what keeps the outline recognisable: a
+ * vertex only goes when the sliver it contributes is too small to see.
+ *
+ * The stopping rule is the point of this module. Simplification halts as soon as
+ * the smallest surviving triangle would be visible on screen, so the shape the
+ * user sees is the shape of the thing on the map — a U-shaped museum stays
+ * U-shaped. The threshold is a fraction of the shape's own bounding box, which
+ * makes it scale-free: the picker frames a place to roughly the same number of
+ * pixels whether it is a 5 km airport or a 170 m building, so the same fraction
+ * means the same number of pixels in both cases. An absolute tolerance in
+ * degrees — Nominatim's polygon_threshold — cannot do this: a value large enough
+ * to thin the airport flattens the building into a few stray corners.
+ *
+ * A point budget exists only as a backstop against pathological geometry. It is
+ * far above what a building or a site actually has, and reaching it is the one
+ * case where the shape may visibly change.
+ *
+ * Coordinates are GeoJSON [lon, lat] pairs. Areas are compared in that raw
+ * degree space: every comparison is between triangles of the same shape, so the
+ * longitude foreshortening is a constant factor and does not affect the ranking.
+ *
+ * @module simplify
+ */
+
+// Roughly the width in pixels the picker gives a framed place. Only used to turn
+// "half a pixel" into a fraction of the shape's extent, so it does not need to
+// match any particular viewport closely.
+var ASSUMED_RENDER_SPAN_PX = 1000;
+
+// A triangle smaller than this on screen cannot be distinguished from the line
+// through its neighbours.
+var NEGLIGIBLE_PX = 0.5;
+
+// Backstop only. A building runs to a few dozen points and BER to under 400, so
+// this is not reached by anything the picker normally draws.
+var DEFAULT_MAX_POINTS = 2000;
+
+// Twice the area of the triangle (a, b, c) — the cross product of its two edges.
+// The factor of two is common to every vertex and to the threshold, so it never
+// affects a comparison and is left in.
+function doubleTriangleArea(a, b, c) {
+  return Math.abs((b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1]));
+}
+
+/**
+ * The doubled-triangle-area below which a vertex is invisible once the given
+ * extent is framed on screen. Returns 0 for a degenerate extent, which disables
+ * negligibility removal rather than removing everything.
+ *
+ * @param {{width: number, height: number}} extent — in degrees
+ */
+function negligibleDoubleArea(extent) {
+  if (!extent) return 0;
+  var span = Math.max(extent.width || 0, extent.height || 0);
+  if (!(span > 0)) return 0;
+  var degreesPerPixel = span / ASSUMED_RENDER_SPAN_PX;
+  return 2 * NEGLIGIBLE_PX * degreesPerPixel * degreesPerPixel;
+}
+
+// Binary min-heap of {area, index}. Entries are never removed on update; a stale
+// entry is recognised on pop by comparing its area against the vertex's current
+// one, which is the usual lazy-deletion trick and keeps the heap simple.
+function createMinHeap() {
+  var items = [];
+
+  function swap(i, j) {
+    var tmp = items[i];
+    items[i] = items[j];
+    items[j] = tmp;
+  }
+
+  return {
+    size: function() {
+      return items.length;
+    },
+    push: function(item) {
+      items.push(item);
+      var i = items.length - 1;
+      while (i > 0) {
+        var parent = (i - 1) >> 1;
+        if (items[parent].area <= items[i].area) break;
+        swap(parent, i);
+        i = parent;
+      }
+    },
+    pop: function() {
+      if (items.length === 0) return null;
+      var top = items[0];
+      var last = items.pop();
+      if (items.length > 0) {
+        items[0] = last;
+        var i = 0;
+        for (;;) {
+          var left = 2 * i + 1;
+          var right = left + 1;
+          var smallest = i;
+          if (left < items.length && items[left].area < items[smallest].area) smallest = left;
+          if (right < items.length && items[right].area < items[smallest].area) smallest = right;
+          if (smallest === i) break;
+          swap(i, smallest);
+          i = smallest;
+        }
+      }
+      return top;
+    }
+  };
+}
+
+/**
+ * Simplifies an open sequence of points, keeping the first and last exactly.
+ *
+ * @param {Array<Array<number>>} points — [[lon, lat], …]
+ * @param {object} [options]
+ * @param {number} [options.minDoubleArea] — remove vertices below this; 0 removes none
+ * @param {number} [options.maxPoints] — hard cap, enforced even if it costs shape
+ * @param {number} [options.floor] — never go below this many points
+ * @param {boolean} [options.closed] — treat the sequence as a cycle, so no vertex
+ *   is pinned. A ring has no start, and pinning one leaves a stray vertex sitting
+ *   on the closing edge that nothing can remove.
+ * @returns {Array<Array<number>>} the input itself when nothing was removed
+ */
+function simplifyLine(points, options) {
+  if (!Array.isArray(points) || points.length < 3) return points;
+  options = options || {};
+  var minDoubleArea = options.minDoubleArea > 0 ? options.minDoubleArea : 0;
+  var maxPoints = options.maxPoints > 0 ? options.maxPoints : DEFAULT_MAX_POINTS;
+  var closed = !!options.closed;
+  var floor = Math.max(closed ? 3 : 2, options.floor || 0);
+
+  if (minDoubleArea === 0 && points.length <= maxPoints) return points;
+
+  // Doubly linked list over the original indices, so neighbours stay findable as
+  // vertices are removed.
+  var n = points.length;
+  var prev = new Array(n);
+  var next = new Array(n);
+  var alive = new Array(n);
+  var area = new Array(n);
+  for (var i = 0; i < n; i++) {
+    prev[i] = i - 1;
+    next[i] = i + 1;
+    alive[i] = true;
+    area[i] = Infinity;
+  }
+  if (closed) {
+    prev[0] = n - 1;
+    next[n - 1] = 0;
+  } else {
+    next[n - 1] = -1;
+  }
+
+  var heap = createMinHeap();
+  var firstCandidate = closed ? 0 : 1;
+  var lastCandidate = closed ? n - 1 : n - 2;
+  for (var k = firstCandidate; k <= lastCandidate; k++) {
+    area[k] = doubleTriangleArea(points[prev[k]], points[k], points[next[k]]);
+    heap.push({area: area[k], index: k});
+  }
+
+  var remaining = points.length;
+  var removed = 0;
+  while (remaining > floor && heap.size() > 0) {
+    var top = heap.pop();
+    var idx = top.index;
+    // Stale entry: this vertex has since been removed, or its area was
+    // recomputed after a neighbour disappeared.
+    if (!alive[idx] || top.area !== area[idx]) continue;
+
+    // The heap is ordered, so once the smallest survivor is visible there is
+    // nothing left that can go without altering the shape. Keep going only if
+    // the hard cap still demands it.
+    var negligible = top.area < minDoubleArea;
+    if (!negligible && remaining <= maxPoints) break;
+
+    alive[idx] = false;
+    remaining--;
+    removed++;
+    var before = prev[idx];
+    var after = next[idx];
+    next[before] = after;
+    prev[after] = before;
+
+    // Both neighbours now span a different triangle.
+    [before, after].forEach(function(nb) {
+      if (prev[nb] < 0 || next[nb] < 0) return;
+      area[nb] = doubleTriangleArea(points[prev[nb]], points[nb], points[next[nb]]);
+      heap.push({area: area[nb], index: nb});
+    });
+  }
+
+  if (removed === 0) return points;
+
+  var out = [];
+  for (var j = 0; j < points.length; j++) {
+    if (alive[j]) out.push(points[j]);
+  }
+  return out;
+}
+
+/**
+ * Simplifies a closed GeoJSON ring. The repeated closing vertex is held out of
+ * the simplification and re-appended, so the ring stays closed, and the result
+ * never drops below the four points a valid ring needs.
+ */
+function simplifyRing(ring, options) {
+  if (!Array.isArray(ring) || ring.length < 5) return ring;
+
+  var first = ring[0];
+  var last = ring[ring.length - 1];
+  var closed = first[0] === last[0] && first[1] === last[1];
+  var open = closed ? ring.slice(0, -1) : ring;
+
+  var opts = {
+    minDoubleArea: options && options.minDoubleArea,
+    maxPoints: options && options.maxPoints ? Math.max(3, options.maxPoints - (closed ? 1 : 0)) : 0,
+    // Cyclic: the vertex the ring happens to start at is not special, and pinning
+    // it would strand a removable point on the closing edge.
+    closed: closed,
+    floor: 3
+  };
+  var simplified = simplifyLine(open, opts);
+  if (simplified === open) return ring;
+  return closed ? simplified.concat([simplified[0]]) : simplified;
+}
+
+function geometryRings(geometry) {
+  if (!geometry || !Array.isArray(geometry.coordinates)) return [];
+  if (geometry.type === 'Polygon') return geometry.coordinates;
+  if (geometry.type === 'MultiPolygon') {
+    return geometry.coordinates.reduce(function(all, polygon) {
+      return all.concat(polygon);
+    }, []);
+  }
+  return [];
+}
+
+/**
+ * Bounding extent of a polygon geometry, in degrees. Null when there is nothing
+ * to measure.
+ */
+function geometryExtent(geometry) {
+  var rings = geometryRings(geometry);
+  var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  var seen = false;
+  rings.forEach(function(ring) {
+    if (!Array.isArray(ring)) return;
+    ring.forEach(function(p) {
+      if (!Array.isArray(p) || p.length < 2) return;
+      seen = true;
+      if (p[0] < minX) minX = p[0];
+      if (p[0] > maxX) maxX = p[0];
+      if (p[1] < minY) minY = p[1];
+      if (p[1] > maxY) maxY = p[1];
+    });
+  });
+  if (!seen) return null;
+  return {width: maxX - minX, height: maxY - minY};
+}
+
+/**
+ * Simplifies a GeoJSON Polygon or MultiPolygon, returning a new geometry and
+ * leaving the input untouched. The negligibility threshold is derived from the
+ * whole shape's extent — not per ring — because that extent is what sets the
+ * scale the shape is drawn at, and a hole's detail has to be judged at the same
+ * scale as the outer ring's. Anything that is not a polygon comes back as-is.
+ *
+ * @param {object} geometry
+ * @param {object} [options]
+ * @param {number} [options.maxPoints] — per-ring backstop
+ */
+function simplifyGeometry(geometry, options) {
+  if (!geometry || !Array.isArray(geometry.coordinates)) return geometry;
+  if (geometry.type !== 'Polygon' && geometry.type !== 'MultiPolygon') return geometry;
+
+  options = options || {};
+  var ringOptions = {
+    minDoubleArea: negligibleDoubleArea(geometryExtent(geometry)),
+    maxPoints: options.maxPoints || DEFAULT_MAX_POINTS
+  };
+
+  if (geometry.type === 'Polygon') {
+    return {
+      type: 'Polygon',
+      coordinates: geometry.coordinates.map(function(ring) {
+        return simplifyRing(ring, ringOptions);
+      })
+    };
+  }
+  return {
+    type: 'MultiPolygon',
+    coordinates: geometry.coordinates.map(function(polygon) {
+      return polygon.map(function(ring) {
+        return simplifyRing(ring, ringOptions);
+      });
+    })
+  };
+}
+
+function countPoints(geometry) {
+  return geometryRings(geometry).reduce(function(sum, ring) {
+    return sum + (Array.isArray(ring) ? ring.length : 0);
+  }, 0);
+}
+
+module.exports = {
+  simplifyLine: simplifyLine,
+  simplifyRing: simplifyRing,
+  simplifyGeometry: simplifyGeometry,
+  geometryExtent: geometryExtent,
+  negligibleDoubleArea: negligibleDoubleArea,
+  countPoints: countPoints,
+  ASSUMED_RENDER_SPAN_PX: ASSUMED_RENDER_SPAN_PX,
+  NEGLIGIBLE_PX: NEGLIGIBLE_PX,
+  DEFAULT_MAX_POINTS: DEFAULT_MAX_POINTS
+};

--- a/test/__label_boxes.js
+++ b/test/__label_boxes.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Shared between a test and the mocked Leaflet marker, which cannot reach the
+// test's own scope because jest.mock is hoisted above it.
+var boxes = {};
+
+module.exports = {
+  set: function(map) { boxes = map || {}; },
+  get: function(text) { return boxes[text] || null; },
+  clear: function() { boxes = {}; }
+};

--- a/test/entrance_picker.test.js
+++ b/test/entrance_picker.test.js
@@ -421,43 +421,68 @@ describe('shouldZoomToExtent', () => {
   });
 });
 
-describe('isWheelchairAccessible', () => {
+describe('entranceMark', () => {
   const door = (tags) => ({ osmId: 1, type: 'yes', tags: tags });
+  const mark = (tags, mode) => entrancePicker.entranceMark(door(tags), mode);
 
-  test('a door tagged yes or designated is accessible', () => {
-    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'yes' }))).toBe(true);
-    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'designated' }))).toBe(true);
+  test('a step-free door is marked on foot', () => {
+    expect(mark({ wheelchair: 'yes' }, 'foot').label).toBe('Wheelchair accessible');
+    expect(mark({ wheelchair: 'designated' }, 'foot').label).toBe('Wheelchair accessible');
   });
 
   test('OSM values are matched regardless of case and stray whitespace', () => {
-    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: ' YES ' }))).toBe(true);
-    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'Designated' }))).toBe(true);
+    expect(mark({ wheelchair: ' YES ' }, 'foot')).not.toBeNull();
+    expect(mark({ wheelchair: 'Designated' }, 'foot')).not.toBeNull();
   });
 
   test('limited does not count: it promises step-free access it cannot deliver', () => {
-    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'limited' }))).toBe(false);
+    expect(mark({ wheelchair: 'limited' }, 'foot')).toBeNull();
   });
 
-  test('no is not accessible', () => {
-    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'no' }))).toBe(false);
+  test('no is not accessible, and an untagged door is unknown rather than either', () => {
+    // Roughly nineteen in twenty entrance nodes carry no wheelchair tag, so this
+    // is the common case and must never read as a promise in either direction.
+    expect(mark({ wheelchair: 'no' }, 'foot')).toBeNull();
+    expect(mark({ name: 'Nord' }, 'foot')).toBeNull();
+    expect(mark(undefined, 'foot')).toBeNull();
+    expect(entrancePicker.entranceMark(undefined, 'foot')).toBeNull();
+    expect(entrancePicker.entranceMark(null, 'foot')).toBeNull();
   });
 
-  test('an untagged door is unknown, not accessible', () => {
-    // Roughly seven in eight entrance nodes carry no wheelchair tag, so this is
-    // the common case and must never be read as a promise either way.
-    expect(entrancePicker.isWheelchairAccessible(door({ name: 'Nord' }))).toBe(false);
-    expect(entrancePicker.isWheelchairAccessible(door(undefined))).toBe(false);
-    expect(entrancePicker.isWheelchairAccessible(undefined)).toBe(false);
-    expect(entrancePicker.isWheelchairAccessible(null)).toBe(false);
+  test('a non-string wheelchair value is ignored rather than coerced', () => {
+    expect(mark({ wheelchair: true }, 'foot')).toBeNull();
   });
 
-  test('a non-string value is ignored rather than coerced', () => {
-    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: true }))).toBe(false);
+  test('a parking entrance is marked when driving', () => {
+    const m = mark({ amenity: 'parking_entrance', parking: 'multi-storey' }, 'car');
+    expect(m.label).toBe('Parking entrance');
+    expect(entrancePicker.entranceMark(
+      door({ amenity: 'parking_entrance' }), 'driving').label).toBe('Parking entrance');
   });
 
-  test('accessibility never removes a door from the offer', () => {
-    // The mark is advisory. Filtering on it would drop every unsurveyed door,
-    // which is most of them.
+  test('each mark belongs to one mode and appears in no other', () => {
+    // Step-free access says nothing to a driver, and which door swallows cars is
+    // noise to everyone else.
+    expect(mark({ wheelchair: 'yes' }, 'car')).toBeNull();
+    expect(mark({ wheelchair: 'yes' }, 'driving')).toBeNull();
+    expect(mark({ amenity: 'parking_entrance' }, 'foot')).toBeNull();
+  });
+
+  test('cycling has no mark of its own', () => {
+    // `bicycle` on an entrance node does not reach 0.05% of them globally, so a
+    // cycling mark would be an icon nobody ever sees.
+    expect(mark({ wheelchair: 'yes' }, 'bike')).toBeNull();
+    expect(mark({ amenity: 'parking_entrance' }, 'bike')).toBeNull();
+    expect(mark({ bicycle: 'designated' }, 'bicycle')).toBeNull();
+  });
+
+  test('an unknown or absent mode marks nothing', () => {
+    expect(mark({ wheelchair: 'yes' }, 'hovercraft')).toBeNull();
+    expect(mark({ wheelchair: 'yes' }, undefined)).toBeNull();
+  });
+
+  test('a mark never removes a door from the offer', () => {
+    // Filtering on it would drop every unsurveyed door, which is most of them.
     const doors = [
       { osmId: 1, type: 'main', center: {}, tags: { wheelchair: 'no' } },
       { osmId: 2, type: 'yes', center: {}, tags: { wheelchair: 'yes' } },

--- a/test/entrance_picker.test.js
+++ b/test/entrance_picker.test.js
@@ -1,0 +1,413 @@
+'use strict';
+
+// Mock leaflet so this test runs in the node environment without a DOM. The
+// functions exercised here are the pure ones; only createEntrancePicker touches
+// Leaflet, and it is covered end-to-end in the browser instead.
+jest.mock('leaflet', () => ({
+  layerGroup: () => ({}),
+  marker: () => ({}),
+  divIcon: () => ({}),
+  latLngBounds: () => ({}),
+  DomEvent: { stopPropagation: () => {} }
+}));
+
+const entrancePicker = require('../src/entrance_picker');
+
+function entrance(osmId, type, lat, lng) {
+  return { osmId: osmId, type: type, center: { lat: lat, lng: lng } };
+}
+
+// BER publishes five entrances, every one of them tagged entrance=main. It is
+// the case the picker exists for: there is no single "main" one to prefer.
+const BER = [
+  entrance(9942967218, 'main', 52.36361, 13.5100542),
+  entrance(9942967219, 'main', 52.3650916, 13.5091228),
+  entrance(9944430790, 'main', 52.3653507, 13.5086652),
+  entrance(9959231437, 'main', 52.3641971, 13.5096892),
+  entrance(9959231438, 'main', 52.3645019, 13.5094986)
+];
+
+// Pergamonmuseum has one main door and one secondary one.
+const PERGAMON = [
+  entrance(1, 'main', 52.5209566, 13.3965227),
+  entrance(2, 'yes', 52.520724, 13.3974377)
+];
+
+// Directions follow the OSM wiki's own definitions of the one-way values:
+//   entrance=exit      "it is a one-way out of a building or enclosed area"
+//   entrance=entrance  "it is an entrance only, a one-way in"
+describe('routableEntrances', () => {
+  const ALL = [
+    entrance(1, 'main', 1, 1),
+    entrance(2, 'yes', 2, 2),
+    entrance(3, 'secondary', 3, 3),
+    entrance(4, 'shop', 4, 4),
+    entrance(5, 'home', 5, 5),
+    entrance(6, 'entrance', 6, 6),
+    entrance(7, 'exit', 7, 7),
+    entrance(8, 'service', 8, 8),
+    entrance(9, 'emergency', 9, 9),
+    entrance(10, 'staircase', 10, 10),
+    entrance(11, 'garage', 11, 11),
+    entrance(12, 'no', 12, 12)
+  ];
+  const ids = (role) => entrancePicker.routableEntrances(ALL, role).map((e) => e.osmId);
+
+  test('a destination takes the two-way doors and the entrance-only one', () => {
+    expect(ids('destination')).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  test('an origin takes the two-way doors and the exit-only one', () => {
+    expect(ids('origin')).toEqual([1, 2, 3, 4, 5, 7]);
+  });
+
+  test('a via point is arrived at and left, so only two-way doors qualify', () => {
+    expect(ids('via')).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test('an exit is never offered as a destination, an entrance never as an origin', () => {
+    expect(ids('destination')).not.toContain(7);
+    expect(ids('origin')).not.toContain(6);
+  });
+
+  test('doors that are nobody’s route endpoint are always dropped', () => {
+    // service, emergency, staircase, garage, and no — the last of which the wiki
+    // defines as looking like a door but not being usable at all.
+    [8, 9, 10, 11, 12].forEach((id) => {
+      ['origin', 'destination', 'via'].forEach((role) => {
+        expect(ids(role)).not.toContain(id);
+      });
+    });
+  });
+
+  test('defaults to the strictest role when none is given', () => {
+    expect(entrancePicker.routableEntrances(ALL).map((e) => e.osmId)).toEqual(ids('via'));
+  });
+
+  test('drops entrances without coordinates and tolerates non-arrays', () => {
+    expect(entrancePicker.routableEntrances([{ osmId: 1, type: 'main' }], 'destination')).toEqual([]);
+    expect(entrancePicker.routableEntrances(null, 'destination')).toEqual([]);
+    expect(entrancePicker.routableEntrances(undefined, 'destination')).toEqual([]);
+  });
+});
+
+// Doors carry OSM access tags, and Nominatim returns them on every entrance
+// without being asked. A door the selected mode may not use is not offered.
+// Most doors have no name — which is why the picker is a map, not a list — but
+// Alexa's are signed and OSM records the signage.
+describe('entranceName', () => {
+  const door = (tags) => ({ osmId: 1, type: 'main', center: { lat: 1, lng: 1 }, tags });
+
+  test('takes the name OSM gives the door', () => {
+    expect(entrancePicker.entranceName(door({ name: 'Haupteingang Alexanderplatz' })))
+      .toBe('Haupteingang Alexanderplatz');
+  });
+
+  test('falls back to ref for a door that is numbered rather than named', () => {
+    expect(entrancePicker.entranceName(door({ ref: 'E0' }))).toBe('E0');
+    expect(entrancePicker.entranceName(door({ name: 'Nord', ref: 'E0' }))).toBe('Nord');
+  });
+
+  test('an unnamed door has nothing to offer', () => {
+    expect(entrancePicker.entranceName(door(undefined))).toBeNull();
+    expect(entrancePicker.entranceName(door({ wheelchair: 'yes' }))).toBeNull();
+    expect(entrancePicker.entranceName(undefined)).toBeNull();
+  });
+
+  test('whitespace-only and non-string names are ignored', () => {
+    expect(entrancePicker.entranceName(door({ name: '   ' }))).toBeNull();
+    expect(entrancePicker.entranceName(door({ name: 42 }))).toBeNull();
+  });
+
+  test('a padded name is trimmed', () => {
+    expect(entrancePicker.entranceName(door({ name: '  Eingang Ravelinplatz ' })))
+      .toBe('Eingang Ravelinplatz');
+  });
+});
+
+const box = (l, t, r, b) => ({ left: l, top: t, right: r, bottom: b });
+
+describe('boxesOverlap', () => {
+  test('separated boxes do not overlap', () => {
+    expect(entrancePicker.boxesOverlap(box(0, 0, 10, 10), box(20, 0, 30, 10))).toBe(false);
+    expect(entrancePicker.boxesOverlap(box(0, 0, 10, 10), box(0, 20, 10, 30))).toBe(false);
+  });
+
+  test('boxes flush against each other are not overlapping', () => {
+    // Labels may sit edge to edge; only real overlap makes them unreadable.
+    expect(entrancePicker.boxesOverlap(box(0, 0, 10, 10), box(10, 0, 20, 10))).toBe(false);
+  });
+
+  test('boxes sharing any area overlap', () => {
+    expect(entrancePicker.boxesOverlap(box(0, 0, 10, 10), box(9, 9, 20, 20))).toBe(true);
+    // One entirely inside another.
+    expect(entrancePicker.boxesOverlap(box(0, 0, 30, 30), box(5, 5, 10, 10))).toBe(true);
+  });
+});
+
+describe('clusterOverlappingLabels', () => {
+  test('labels that all fit stay one per group', () => {
+    const groups = entrancePicker.clusterOverlappingLabels([
+      box(0, 0, 10, 10), box(50, 0, 60, 10), box(100, 0, 110, 10)
+    ]);
+    expect(groups).toEqual([[0], [1], [2]]);
+  });
+
+  test('a colliding pair becomes one group', () => {
+    const groups = entrancePicker.clusterOverlappingLabels([
+      box(0, 0, 10, 10), box(5, 5, 15, 15), box(100, 0, 110, 10)
+    ]);
+    expect(groups).toEqual([[0, 1], [2]]);
+  });
+
+  test('overlap carries along a chain', () => {
+    // A overlaps B and B overlaps C, but A and C are clear. Showing A and C
+    // while hiding B would be arbitrary, so the run collapses together.
+    const groups = entrancePicker.clusterOverlappingLabels([
+      box(0, 0, 10, 10), box(8, 0, 18, 10), box(16, 0, 26, 10)
+    ]);
+    expect(groups).toEqual([[0, 1, 2]]);
+  });
+
+  test('keeps the original order, of groups and within them', () => {
+    const groups = entrancePicker.clusterOverlappingLabels([
+      box(100, 0, 110, 10), box(0, 0, 10, 10), box(5, 5, 15, 15)
+    ]);
+    expect(groups).toEqual([[0], [1, 2]]);
+  });
+
+  test('everything on top of everything is a single group', () => {
+    const groups = entrancePicker.clusterOverlappingLabels([
+      box(0, 0, 20, 20), box(1, 1, 21, 21), box(2, 2, 22, 22), box(3, 3, 23, 23)
+    ]);
+    expect(groups).toEqual([[0, 1, 2, 3]]);
+  });
+
+  test('tolerates nothing to place', () => {
+    expect(entrancePicker.clusterOverlappingLabels([])).toEqual([]);
+    expect(entrancePicker.clusterOverlappingLabels(null)).toEqual([]);
+    expect(entrancePicker.clusterOverlappingLabels([box(0, 0, 5, 5)])).toEqual([[0]]);
+  });
+});
+
+describe('allowsMode', () => {
+  const door = (tags) => ({ osmId: 1, type: 'main', center: { lat: 1, lng: 1 }, tags });
+
+  test('a door with nothing to say is usable by everyone', () => {
+    expect(entrancePicker.allowsMode(door(undefined), 'foot')).toBe(true);
+    expect(entrancePicker.allowsMode(door({}), 'driving')).toBe(true);
+  });
+
+  test('access=private or no shuts every mode out', () => {
+    ['foot', 'bike', 'driving'].forEach((mode) => {
+      expect(entrancePicker.allowsMode(door({ access: 'private' }), mode)).toBe(false);
+      expect(entrancePicker.allowsMode(door({ access: 'no' }), mode)).toBe(false);
+    });
+  });
+
+  test('permissive, customers and designated are all usable', () => {
+    ['permissive', 'customers', 'designated', 'destination', 'yes'].forEach((v) => {
+      expect(entrancePicker.allowsMode(door({ access: v }), 'foot')).toBe(true);
+    });
+  });
+
+  test('the mode-specific key beats the general one, in both directions', () => {
+    // A door closed in general but explicitly opened to pedestrians.
+    expect(entrancePicker.allowsMode(door({ access: 'no', foot: 'yes' }), 'foot')).toBe(true);
+    // ...and one open in general but closed to them.
+    expect(entrancePicker.allowsMode(door({ access: 'yes', foot: 'no' }), 'foot')).toBe(false);
+  });
+
+  test('vehicle sits between the specific key and access for wheeled modes', () => {
+    expect(entrancePicker.allowsMode(door({ access: 'yes', vehicle: 'no' }), 'bike')).toBe(false);
+    expect(entrancePicker.allowsMode(door({ access: 'yes', vehicle: 'no' }), 'driving')).toBe(false);
+    // ...but says nothing about walking.
+    expect(entrancePicker.allowsMode(door({ access: 'yes', vehicle: 'no' }), 'foot')).toBe(true);
+    // The more specific key still wins over it.
+    expect(entrancePicker.allowsMode(door({ vehicle: 'no', bicycle: 'yes' }), 'bike')).toBe(true);
+  });
+
+  test('a service entrance for deliveries is closed to cars but open on foot', () => {
+    const d = door({ motor_vehicle: 'no', foot: 'yes' });
+    expect(entrancePicker.allowsMode(d, 'driving')).toBe(false);
+    expect(entrancePicker.allowsMode(d, 'foot')).toBe(true);
+  });
+
+  test('an unrecognised value is not read as a prohibition', () => {
+    expect(entrancePicker.allowsMode(door({ access: 'unknown_value' }), 'foot')).toBe(true);
+  });
+
+  test('values are matched case-insensitively', () => {
+    expect(entrancePicker.allowsMode(door({ access: 'No' }), 'foot')).toBe(false);
+    expect(entrancePicker.allowsMode(door({ access: 'PRIVATE' }), 'foot')).toBe(false);
+  });
+
+  test('no mode, or one we have no rules for, filters nothing', () => {
+    expect(entrancePicker.allowsMode(door({ access: 'no' }), undefined)).toBe(true);
+    expect(entrancePicker.allowsMode(door({ access: 'no' }), 'hovercraft')).toBe(true);
+  });
+
+  test('both spellings of each wheeled mode are understood', () => {
+    const d = door({ motor_vehicle: 'no' });
+    expect(entrancePicker.allowsMode(d, 'driving')).toBe(false);
+    expect(entrancePicker.allowsMode(d, 'car')).toBe(false);
+    const b = door({ bicycle: 'no' });
+    expect(entrancePicker.allowsMode(b, 'bike')).toBe(false);
+    expect(entrancePicker.allowsMode(b, 'bicycle')).toBe(false);
+  });
+});
+
+describe('routableEntrances with a mode', () => {
+  const open = { osmId: 1, type: 'main', center: { lat: 1, lng: 1 } };
+  const noCars = { osmId: 2, type: 'yes', center: { lat: 2, lng: 2 }, tags: { motor_vehicle: 'no' } };
+  const priv = { osmId: 3, type: 'yes', center: { lat: 3, lng: 3 }, tags: { access: 'private' } };
+  const all = [open, noCars, priv];
+  const ids = (mode) => entrancePicker.routableEntrances(all, 'destination', mode).map((e) => e.osmId);
+
+  test('drops the doors the mode forbids', () => {
+    expect(ids('driving')).toEqual([1]);
+    expect(ids('foot')).toEqual([1, 2]);
+  });
+
+  test('applies the direction and the access rules together', () => {
+    const exitNoCars = {
+      osmId: 4, type: 'exit', center: { lat: 4, lng: 4 }, tags: { motor_vehicle: 'no' }
+    };
+    const set = [open, exitNoCars];
+    // Forbidden to cars, and an exit is no use as a destination anyway.
+    expect(entrancePicker.routableEntrances(set, 'destination', 'driving').map((e) => e.osmId))
+      .toEqual([1]);
+    // Right direction for an origin, but still forbidden to cars.
+    expect(entrancePicker.routableEntrances(set, 'origin', 'driving').map((e) => e.osmId))
+      .toEqual([1]);
+    // Right direction and allowed on foot.
+    expect(entrancePicker.routableEntrances(set, 'origin', 'foot').map((e) => e.osmId))
+      .toEqual([1, 4]);
+  });
+
+  test('omitting the mode applies no access filtering at all', () => {
+    expect(entrancePicker.routableEntrances(all, 'destination').map((e) => e.osmId))
+      .toEqual([1, 2, 3]);
+  });
+});
+
+describe('waypointRole', () => {
+  test('names each end of the route', () => {
+    expect(entrancePicker.waypointRole(0, 2)).toBe('origin');
+    expect(entrancePicker.waypointRole(1, 2)).toBe('destination');
+  });
+
+  test('anything in between is a via point', () => {
+    expect(entrancePicker.waypointRole(1, 3)).toBe('via');
+    expect(entrancePicker.waypointRole(2, 4)).toBe('via');
+  });
+});
+
+describe('no automatic selection', () => {
+  test('the module exposes no way to pick an entrance for the user', () => {
+    expect(entrancePicker.selectPrimaryEntrance).toBeUndefined();
+  });
+
+  test('a lone main entrance is still only offered, never applied', () => {
+    const choices = entrancePicker.buildChoices(
+      { lat: 52.5209336, lng: 13.3956302 }, PERGAMON);
+    // Both doors, and nothing marked as already chosen.
+    expect(choices.map((c) => c.kind)).toEqual(['main', 'other']);
+    expect(choices.every((c) => c.selected === undefined)).toBe(true);
+  });
+});
+
+describe('buildChoices', () => {
+  const centre = { lat: 52.3657974, lng: 13.4888906 };
+
+  test('offers the doors and nothing else', () => {
+    // The place centre is not a dot: the waypoint's pin never leaves it.
+    const choices = entrancePicker.buildChoices(centre, PERGAMON);
+    expect(choices.map((c) => c.id)).toEqual(['osm:1', 'osm:2']);
+    expect(choices.map((c) => c.kind)).toEqual(['main', 'other']);
+  });
+
+  test('every choice keeps its entrance, so a click knows which door it was', () => {
+    const choices = entrancePicker.buildChoices(centre, PERGAMON);
+    expect(choices[0].entrance).toBe(PERGAMON[0]);
+    expect(choices[1].entrance).toBe(PERGAMON[1]);
+  });
+
+  test('a place with a single door still yields one choice', () => {
+    expect(entrancePicker.buildChoices(centre, [PERGAMON[0]])).toHaveLength(1);
+  });
+
+  test('drops anything without coordinates', () => {
+    expect(entrancePicker.buildChoices(centre, [{ osmId: 9, type: 'main' }])).toEqual([]);
+  });
+});
+
+describe('choicePoints', () => {
+  const centre = { lat: 52.3657974, lng: 13.4888906 };
+
+  test('includes the place centre, where the pin stays', () => {
+    const points = entrancePicker.choicePoints(
+      entrancePicker.buildChoices(centre, PERGAMON), centre);
+    expect(points).toHaveLength(3);
+    expect(points).toContain(centre);
+  });
+
+  test('omits it when there is none to include', () => {
+    expect(entrancePicker.choicePoints(
+      entrancePicker.buildChoices(centre, PERGAMON), null)).toHaveLength(2);
+  });
+});
+
+describe('isExtentClear', () => {
+  const mapSize = { x: 1400, y: 800 };
+
+  test('an extent inside the uncovered part of the map is clear', () => {
+    expect(entrancePicker.isExtentClear({ x: 100, y: 700 }, { x: 900, y: 100 }, mapSize, 380)).toBe(true);
+  });
+
+  test('an extent reaching under the directions pane is not clear', () => {
+    expect(entrancePicker.isExtentClear({ x: 100, y: 700 }, { x: 1100, y: 100 }, mapSize, 380)).toBe(false);
+  });
+
+  test('the same extent is clear once the pane is hidden', () => {
+    expect(entrancePicker.isExtentClear({ x: 100, y: 700 }, { x: 1100, y: 100 }, mapSize, 0)).toBe(true);
+  });
+
+  test('an extent running off the top or left is not clear', () => {
+    expect(entrancePicker.isExtentClear({ x: -40, y: 700 }, { x: 900, y: 100 }, mapSize, 380)).toBe(false);
+    expect(entrancePicker.isExtentClear({ x: 100, y: 700 }, { x: 900, y: -20 }, mapSize, 380)).toBe(false);
+  });
+});
+
+describe('shouldZoomToExtent', () => {
+  const viewport = { width: 1000, height: 780 };
+  const fills = (frac) => ({ width: viewport.width * frac, height: 10 });
+
+  test('zooms when part of the area is off screen or under the pane', () => {
+    expect(entrancePicker.shouldZoomToExtent(fills(0.9), viewport, false)).toBe(true);
+  });
+
+  test('zooms when the area is a small blob rather than framed', () => {
+    // BER's 5 km bbox is ~120px wide at zoom 11 in a ~1000px free viewport.
+    expect(entrancePicker.shouldZoomToExtent({ width: 122, height: 122 }, viewport, true)).toBe(true);
+  });
+
+  test('leaves the view alone once the area fills the free viewport', () => {
+    expect(entrancePicker.shouldZoomToExtent(fills(0.8), viewport, true)).toBe(false);
+  });
+
+  test('either dimension filling the viewport is enough', () => {
+    expect(entrancePicker.shouldZoomToExtent(
+      { width: 10, height: viewport.height * 0.8 }, viewport, true)).toBe(false);
+  });
+
+  test('is measured against the free viewport, so a wide pane forces a zoom', () => {
+    const extent = { width: 200, height: 200 };
+    expect(entrancePicker.shouldZoomToExtent(extent, { width: 500, height: 500 }, true)).toBe(false);
+    expect(entrancePicker.shouldZoomToExtent(extent, { width: 1200, height: 900 }, true)).toBe(true);
+  });
+
+  test('zooms rather than dividing by zero when the pane leaves no room', () => {
+    expect(entrancePicker.shouldZoomToExtent(fills(0.8), { width: 0, height: 0 }, true)).toBe(true);
+  });
+});

--- a/test/entrance_picker.test.js
+++ b/test/entrance_picker.test.js
@@ -411,3 +411,49 @@ describe('shouldZoomToExtent', () => {
     expect(entrancePicker.shouldZoomToExtent(fills(0.8), { width: 0, height: 0 }, true)).toBe(true);
   });
 });
+
+describe('isWheelchairAccessible', () => {
+  const door = (tags) => ({ osmId: 1, type: 'yes', tags: tags });
+
+  test('a door tagged yes or designated is accessible', () => {
+    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'yes' }))).toBe(true);
+    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'designated' }))).toBe(true);
+  });
+
+  test('OSM values are matched regardless of case and stray whitespace', () => {
+    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: ' YES ' }))).toBe(true);
+    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'Designated' }))).toBe(true);
+  });
+
+  test('limited does not count: it promises step-free access it cannot deliver', () => {
+    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'limited' }))).toBe(false);
+  });
+
+  test('no is not accessible', () => {
+    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: 'no' }))).toBe(false);
+  });
+
+  test('an untagged door is unknown, not accessible', () => {
+    // Roughly seven in eight entrance nodes carry no wheelchair tag, so this is
+    // the common case and must never be read as a promise either way.
+    expect(entrancePicker.isWheelchairAccessible(door({ name: 'Nord' }))).toBe(false);
+    expect(entrancePicker.isWheelchairAccessible(door(undefined))).toBe(false);
+    expect(entrancePicker.isWheelchairAccessible(undefined)).toBe(false);
+    expect(entrancePicker.isWheelchairAccessible(null)).toBe(false);
+  });
+
+  test('a non-string value is ignored rather than coerced', () => {
+    expect(entrancePicker.isWheelchairAccessible(door({ wheelchair: true }))).toBe(false);
+  });
+
+  test('accessibility never removes a door from the offer', () => {
+    // The mark is advisory. Filtering on it would drop every unsurveyed door,
+    // which is most of them.
+    const doors = [
+      { osmId: 1, type: 'main', center: {}, tags: { wheelchair: 'no' } },
+      { osmId: 2, type: 'yes', center: {}, tags: { wheelchair: 'yes' } },
+      { osmId: 3, type: 'yes', center: {} }
+    ];
+    expect(entrancePicker.routableEntrances(doors, 'destination', 'foot')).toHaveLength(3);
+  });
+});

--- a/test/entrance_picker.test.js
+++ b/test/entrance_picker.test.js
@@ -54,15 +54,24 @@ describe('routableEntrances', () => {
   const ids = (role) => entrancePicker.routableEntrances(ALL, role).map((e) => e.osmId);
 
   test('a destination takes the two-way doors and the entrance-only one', () => {
-    expect(ids('destination')).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(ids('destination')).toEqual([1, 2, 3, 4, 5, 6, 10]);
   });
 
   test('an origin takes the two-way doors and the exit-only one', () => {
-    expect(ids('origin')).toEqual([1, 2, 3, 4, 5, 7]);
+    expect(ids('origin')).toEqual([1, 2, 3, 4, 5, 7, 10]);
   });
 
   test('a via point is arrived at and left, so only two-way doors qualify', () => {
-    expect(ids('via')).toEqual([1, 2, 3, 4, 5]);
+    expect(ids('via')).toEqual([1, 2, 3, 4, 5, 10]);
+  });
+
+  test('a staircase door is a way in, like a home door', () => {
+    // The wiki calls it "Door to staircase": the door of a stairwell, which is
+    // how residents and visitors of an apartment building get in. It differs
+    // from entrance=home only in what lies immediately behind it.
+    ['origin', 'destination', 'via'].forEach((role) => {
+      expect(ids(role)).toContain(10);
+    });
   });
 
   test('an exit is never offered as a destination, an entrance never as an origin', () => {
@@ -71,9 +80,9 @@ describe('routableEntrances', () => {
   });
 
   test('doors that are nobody’s route endpoint are always dropped', () => {
-    // service, emergency, staircase, garage, and no — the last of which the wiki
-    // defines as looking like a door but not being usable at all.
-    [8, 9, 10, 11, 12].forEach((id) => {
+    // service, emergency, garage, and no — the last of which the wiki defines as
+    // looking like a door but not being usable at all.
+    [8, 9, 11, 12].forEach((id) => {
       ['origin', 'destination', 'via'].forEach((role) => {
         expect(ids(role)).not.toContain(id);
       });

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -664,74 +664,116 @@ describe('label placement', () => {
   });
 });
 
-describe('wheelchair mark', () => {
+describe('mode-dependent marks', () => {
   const labelBoxes = require('./__label_boxes');
   const box = (l, t, r, b) => ({ left: l, top: t, right: r, bottom: b });
-  // The mark is part of the label's rendered text, so the test harness — which
-  // keys measured boxes by that text — sees it in the key too.
-  const MARK = '\u267F';
+  // A mark is part of the label's rendered text, so the harness — which keys
+  // measured boxes by that text — sees it in the key too.
+  const WC = '\u267F';
+  const PK = '\uD83C\uDD7F';
 
-  const ACCESSIBLE = { osmId: 1, type: 'main', center: { lat: 52.5209, lng: 13.3965 },
+  const STEP_FREE = { osmId: 1, type: 'main', center: { lat: 52.5209, lng: 13.3965 },
     tags: { name: 'Nord', wheelchair: 'yes' } };
   const STEPPED = { osmId: 2, type: 'yes', center: { lat: 52.5208, lng: 13.3970 },
     tags: { name: 'Ost', wheelchair: 'no' } };
   const UNKNOWN = { osmId: 3, type: 'yes', center: { lat: 52.5207, lng: 13.3975 },
     tags: { name: 'Sued' } };
+  const GARAGE = { osmId: 4, type: 'yes', center: { lat: 52.5206, lng: 13.3980 },
+    tags: { name: 'Tiefgarage', amenity: 'parking_entrance', parking: 'underground' } };
 
   afterEach(() => labelBoxes.clear());
 
-  function open(entrances, boxes) {
+  function open(entrances, boxes, mode) {
     labelBoxes.set(boxes);
     const map = makeMap();
-    entrancePicker.createEntrancePicker(map, {}).show({
-      waypointIndex: 1, placeCenter: CENTRE, entrances: entrances
-    });
-    return map;
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: entrances, mode: mode });
+    return { map, picker };
   }
 
-  const APART = {
-    ['Nord' + MARK]: box(0, 0, 44, 16),
-    Ost: box(100, 0, 140, 16),
-    Sued: box(200, 0, 240, 16)
-  };
+  const html = (map) => labels(map).map((m) => m.options.icon.options.html);
 
-  test('only the accessible door is marked', () => {
-    const html = labels(open([ACCESSIBLE, STEPPED, UNKNOWN], APART))
-      .map((m) => m.options.icon.options.html);
-    expect(html[0]).toContain('osrm-entrance-wheelchair');
-    expect(html[1]).not.toContain('osrm-entrance-wheelchair');
-    expect(html[2]).not.toContain('osrm-entrance-wheelchair');
+  test('on foot, only the step-free door is marked', () => {
+    const { map } = open([STEP_FREE, STEPPED, UNKNOWN], {
+      ['Nord' + WC]: box(0, 0, 44, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16)
+    }, 'foot');
+    expect(html(map)[0]).toContain('osrm-entrance-mark-wheelchair');
+    expect(html(map)[1]).not.toContain('osrm-entrance-mark');
+    expect(html(map)[2]).not.toContain('osrm-entrance-mark');
+  });
+
+  test('when driving, the parking entrance is marked and the step-free door is not', () => {
+    const { map } = open([STEP_FREE, GARAGE], {
+      Nord: box(0, 0, 40, 16), ['Tiefgarage' + PK]: box(100, 0, 180, 16)
+    }, 'car');
+    expect(html(map)[0]).not.toContain('osrm-entrance-mark');
+    expect(html(map)[1]).toContain('osrm-entrance-mark-parking');
+  });
+
+  test('cycling marks nothing', () => {
+    const { map } = open([STEP_FREE, GARAGE], {
+      Nord: box(0, 0, 40, 16), Tiefgarage: box(100, 0, 180, 16)
+    }, 'bike');
+    expect(html(map).join('')).not.toContain('osrm-entrance-mark');
+  });
+
+  test('changing mode re-marks the labels already on screen', () => {
+    // refresh() re-shows an open picker when the profile changes, so the marks
+    // have to follow rather than keep describing the mode the user has left.
+    labelBoxes.set({
+      ['Nord' + WC]: box(0, 0, 44, 16), Nord: box(0, 0, 40, 16),
+      ['Tiefgarage' + PK]: box(100, 0, 180, 16), Tiefgarage: box(100, 0, 180, 16)
+    });
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    const show = (mode) => picker.show({
+      waypointIndex: 1, placeCenter: CENTRE, entrances: [STEP_FREE, GARAGE], mode: mode
+    });
+
+    show('foot');
+    expect(html(map)[0]).toContain('osrm-entrance-mark-wheelchair');
+    expect(html(map)[1]).not.toContain('osrm-entrance-mark');
+
+    show('car');
+    expect(html(map)[0]).not.toContain('osrm-entrance-mark');
+    expect(html(map)[1]).toContain('osrm-entrance-mark-parking');
+
+    show('bike');
+    expect(html(map).join('')).not.toContain('osrm-entrance-mark');
   });
 
   test('the mark is hidden from assistive tech, which reads the dot instead', () => {
-    const map = open([ACCESSIBLE], { ['Nord' + MARK]: box(0, 0, 44, 16) });
-    expect(labels(map)[0].options.icon.options.html).toContain('aria-hidden="true"');
+    const { map } = open([STEP_FREE], { ['Nord' + WC]: box(0, 0, 44, 16) }, 'foot');
+    expect(html(map)[0]).toContain('aria-hidden="true"');
     expect(dots(map)[0].options.alt).toBe('Nord (Wheelchair accessible)');
   });
 
+  test('the driving alt text names the parking entrance', () => {
+    const { map } = open([GARAGE], { ['Tiefgarage' + PK]: box(0, 0, 80, 16) }, 'car');
+    expect(dots(map)[0].options.alt).toBe('Tiefgarage (Parking entrance)');
+  });
+
   test('an unmarked door says only its name', () => {
-    const map = open([UNKNOWN], { Sued: box(0, 0, 40, 16) });
+    const { map } = open([UNKNOWN], { Sued: box(0, 0, 40, 16) }, 'foot');
     expect(dots(map)[0].options.alt).toBe('Sued');
   });
 
   test('a merged label marks only the doors that earned it', () => {
     // Nord and Ost collide and merge; the mark must stay on Nord's line alone.
-    const map = open([ACCESSIBLE, STEPPED, UNKNOWN], {
-      ['Nord' + MARK]: box(0, 0, 44, 16),
-      Ost: box(20, 0, 60, 16),
-      Sued: box(200, 0, 240, 16)
-    });
-    const merged = labels(map)[0].options.icon.options.html;
-    expect(merged.match(/osrm-entrance-wheelchair/g)).toHaveLength(1);
+    const { map } = open([STEP_FREE, STEPPED, UNKNOWN], {
+      ['Nord' + WC]: box(0, 0, 44, 16), Ost: box(20, 0, 60, 16), Sued: box(200, 0, 240, 16)
+    }, 'foot');
+    const merged = html(map)[0];
+    expect(merged.match(/osrm-entrance-mark/g)).toHaveLength(2);   // base class + modifier
     expect(labelTexts(map)[0]).toContain('Nord');
     expect(labelTexts(map)[0]).toContain('Ost');
   });
 
   test('the mark survives selecting the door it belongs to', () => {
-    const map = open([ACCESSIBLE, STEPPED],
-      { ['Nord' + MARK]: box(0, 0, 44, 16), Ost: box(100, 0, 140, 16) });
+    const { map } = open([STEP_FREE, STEPPED],
+      { ['Nord' + WC]: box(0, 0, 44, 16), Ost: box(100, 0, 140, 16) }, 'foot');
     dots(map)[0].fire('click', {});
-    expect(labels(map)[0].options.icon.options.html).toContain('osrm-entrance-wheelchair');
+    expect(html(map)[0]).toContain('osrm-entrance-mark-wheelchair');
   });
 });
 

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -920,3 +920,70 @@ describe('offers for several waypoints at once', () => {
     expect(picker.getWaypointIndex()).toBe(1);
   });
 });
+
+describe('following a splice of the waypoint list', () => {
+  const labelBoxes = require('./__label_boxes');
+  const box = (l, t, r, b) => ({ left: l, top: t, right: r, bottom: b });
+  const START = [{ osmId: 1, type: 'main', center: { lat: 52.5209, lng: 13.3965 },
+    tags: { name: 'Nord' } }];
+  const OTHER = [{ osmId: 2, type: 'main', center: { lat: 52.5300, lng: 13.4000 },
+    tags: { name: 'Werk' } }];
+
+  afterEach(() => labelBoxes.clear());
+
+  function open(index, entrances) {
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Werk: box(200, 0, 240, 16) });
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({ waypointIndex: index, placeCenter: CENTRE, entrances: entrances });
+    return { map, picker };
+  }
+
+  test("placing a destination keeps the start's doors on the map", () => {
+    // The reported bug: searching a start, then clicking the map to drop a
+    // destination, took the start's entrance dots away. A map click splices the
+    // waypoint list, and every offer was being dropped with it.
+    const { map, picker } = open(0, START);
+    expect(dots(map)).toHaveLength(1);
+
+    picker.spliceOffers(1, 0, 1);   // a destination appended after the start
+    expect(picker.isOpenFor(0)).toBe(true);
+    expect(dots(map)).toHaveLength(1);
+  });
+
+  test('an offer after the splice is renumbered, not dropped', () => {
+    const { picker } = open(1, START);
+    picker.spliceOffers(0, 0, 1);   // a waypoint inserted before it
+    expect(picker.isOpenFor(2)).toBe(true);
+    expect(picker.isOpenFor(1)).toBe(false);
+    expect(picker.getWaypointIndex()).toBe(2);
+  });
+
+  test('removing the waypoint an offer belongs to withdraws that offer', () => {
+    const { map, picker } = open(1, START);
+    picker.spliceOffers(1, 1, 0);
+    expect(picker.isOpen()).toBe(false);
+    expect(dots(map)).toHaveLength(0);
+  });
+
+  test('a removal keeps the offers that survive it, renumbered', () => {
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Werk: box(200, 0, 240, 16) });
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({ waypointIndex: 0, placeCenter: CENTRE, entrances: START });
+    picker.show({ waypointIndex: 2, placeCenter: CENTRE, entrances: OTHER });
+
+    picker.spliceOffers(1, 1, 0);   // the middle waypoint goes
+    expect(picker.isOpenFor(0)).toBe(true);
+    expect(picker.isOpenFor(1)).toBe(true);   // was 2, shifted down
+    expect(picker.isOpenFor(2)).toBe(false);
+    expect(dots(map)).toHaveLength(2);
+  });
+
+  test('a splice that changes nothing leaves the offers alone', () => {
+    const { map, picker } = open(0, START);
+    const before = dots(map)[0];
+    picker.spliceOffers(3, 0, 0);
+    expect(dots(map)[0]).toBe(before);
+  });
+});

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -810,3 +810,96 @@ describe('re-showing while already open', () => {
     expect(dots(map)).toHaveLength(0);
   });
 });
+
+describe('offers for several waypoints at once', () => {
+  const labelBoxes = require('./__label_boxes');
+  const box = (l, t, r, b) => ({ left: l, top: t, right: r, bottom: b });
+
+  const DEST = [
+    { osmId: 1, type: 'main', center: { lat: 52.5209, lng: 13.3965 }, tags: { name: 'Nord' } },
+    { osmId: 2, type: 'yes', center: { lat: 52.5208, lng: 13.3970 }, tags: { name: 'Ost' } }
+  ];
+  const START = [
+    { osmId: 3, type: 'main', center: { lat: 52.5300, lng: 13.4000 }, tags: { name: 'Werk' } }
+  ];
+
+  afterEach(() => labelBoxes.clear());
+
+  function open() {
+    labelBoxes.set({
+      Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Werk: box(300, 0, 340, 16)
+    });
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: DEST });
+    return { map, picker };
+  }
+
+  test("naming a start leaves the destination's doors on the map", () => {
+    // The reported bug: a second waypoint's offer replaced the first one's.
+    const { map, picker } = open();
+    expect(dots(map)).toHaveLength(2);
+
+    picker.show({ waypointIndex: 0, placeCenter: CENTRE, entrances: START });
+    expect(dots(map)).toHaveLength(3);
+    expect(labelTexts(map).sort()).toEqual(['Nord', 'Ost', 'Werk']);
+  });
+
+  test('a start with no doors withdraws only its own offer', () => {
+    const { map, picker } = open();
+    expect(picker.show({ waypointIndex: 0, placeCenter: CENTRE, entrances: [] })).toBe(false);
+    expect(dots(map)).toHaveLength(2);
+    expect(picker.isOpen()).toBe(true);
+    expect(picker.isOpenFor(1)).toBe(true);
+    expect(picker.isOpenFor(0)).toBe(false);
+  });
+
+  test('withdrawing the last offer tears the picker down', () => {
+    const { map, picker } = open();
+    picker.hideWaypoint(1);
+    expect(picker.isOpen()).toBe(false);
+    expect(dots(map)).toHaveLength(0);
+    expect(map._handlers.zoomend).toHaveLength(0);
+  });
+
+  test('each waypoint keeps its own selection', () => {
+    const { map, picker } = open();
+    picker.show({ waypointIndex: 0, placeCenter: CENTRE, entrances: START });
+
+    dots(map)[0].fire('click', {});   // a destination door
+    expect(picker.getSelectedId(1)).toBe('osm:1');
+    expect(picker.getSelectedId(0)).toBeNull();
+
+    dots(map)[2].fire('click', {});   // the start's door
+    expect(picker.getSelectedId(1)).toBe('osm:1');
+    expect(picker.getSelectedId(0)).toBe('osm:3');
+  });
+
+  test('re-showing one waypoint replaces its offer without touching the other', () => {
+    const { map, picker } = open();
+    picker.show({ waypointIndex: 0, placeCenter: CENTRE, entrances: START });
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [DEST[0]] });
+    expect(dots(map)).toHaveLength(2);
+    expect(labelTexts(map).sort()).toEqual(['Nord', 'Werk']);
+  });
+
+  test('a click on a dot whose offer has been withdrawn does nothing', () => {
+    const selected = [];
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16) });
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, { onSelect: (c) => selected.push(c) });
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: DEST });
+    const stale = dots(map)[0];
+    picker.hideWaypoint(1);
+    stale.fire('click', {});
+    expect(selected).toHaveLength(0);
+  });
+
+  test('the view frames the newest offer, and falls back when it is withdrawn', () => {
+    const { map, picker } = open();
+    picker.show({ waypointIndex: 0, placeCenter: CENTRE, entrances: START });
+    expect(picker.getWaypointIndex()).toBe(0);
+    picker.hideWaypoint(0);
+    expect(picker.getWaypointIndex()).toBe(1);
+  });
+});

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -1,0 +1,665 @@
+/**
+ * @jest-environment jsdom
+ */
+'use strict';
+
+/**
+ * Behaviour of the live picker — the half that talks to Leaflet: which dots get
+ * drawn, what a click does, when the view is re-framed, and how the site outline
+ * is loaded. The pure helpers are covered in entrance_picker.test.js.
+ *
+ * Leaflet is faked rather than loaded: the real thing needs a DOM, and what
+ * matters here is the sequence of calls the picker makes, not Leaflet's own
+ * rendering.
+ */
+
+// --- Leaflet fake -----------------------------------------------------------
+
+function mockMakeLayerGroup(children) {
+  return {
+    _kind: 'layerGroup',
+    _layers: (children || []).slice(),
+    _added: [],
+    addLayer(l) { this._layers.push(l); this._added.push(l); return this; },
+    clearLayers() { this._layers = []; return this; },
+    addTo(map) { map._layers.push(this); return this; }
+  };
+}
+
+function mockMakeBounds(points) {
+  const lats = points.map((p) => p.lat);
+  const lngs = points.map((p) => p.lng);
+  return {
+    _kind: 'bounds',
+    _points: points,
+    isValid: () => points.length > 0,
+    getSouthWest: () => ({ lat: Math.min(...lats), lng: Math.min(...lngs) }),
+    getNorthEast: () => ({ lat: Math.max(...lats), lng: Math.max(...lngs) })
+  };
+}
+
+// Where each label's box lands, keyed by its text. Set by a test before the
+// layout pass runs; an absent entry means "not measurable yet".
+const mockLabelBoxes = {};
+
+jest.mock('leaflet', () => ({
+  layerGroup: (children) => mockMakeLayerGroup(children),
+  latLngBounds: (points) => mockMakeBounds(points),
+  point: (x, y) => ({ x, y }),
+  divIcon: (opts) => ({ _kind: 'divIcon', options: opts }),
+  geoJSON: (geometry, opts) => ({ _kind: 'geoJSON', geometry, options: opts }),
+  polyline: (points, style) => ({ _kind: 'polyline', points, style }),
+  DomEvent: { stopPropagation: jest.fn() },
+  marker: (latLng, opts) => ({
+    _kind: 'marker',
+    latLng,
+    options: opts,
+    handlers: {},
+    getLatLng() { return this.latLng; },
+    // Mimics enough of the label element for the layout pass to measure it.
+    getElement() {
+      const html = (this.options.icon && this.options.icon.options.html) || '';
+      const text = html.replace(/<[^>]*>/g, '');
+      const boxes = require('./__label_boxes');
+      const box = boxes.get(text);
+      return {
+        querySelector: (sel) => (sel === '.osrm-entrance-label-inner' && box
+          ? { getBoundingClientRect: () => box }
+          : null)
+      };
+    },
+    on(evt, fn) { this.handlers[evt] = fn; return this; },
+    fire(evt, e) { this.handlers[evt] && this.handlers[evt](e || {}); }
+  })
+}));
+
+const entrancePicker = require('../src/entrance_picker');
+
+const makeBounds = mockMakeBounds;
+
+// --- Map fake ---------------------------------------------------------------
+
+// Projects around a centre so container points land inside the viewport, as
+// they would on a real map. At pixelsPerDegree = 10000, 0.001° is 10 px.
+function makeMap(overrides) {
+  const o = Object.assign({
+    size: { x: 1200, y: 800 },
+    pixelsPerDegree: 10000,
+    center: { lat: 52.5209336, lng: 13.3956302 }
+  }, overrides);
+  return {
+    _layers: [],
+    _handlers: {},
+    fitBounds: jest.fn(),
+    getSize: () => o.size,
+    hasLayer(l) { return this._layers.indexOf(l) !== -1; },
+    removeLayer(l) { this._layers = this._layers.filter((x) => x !== l); },
+    latLngToContainerPoint: (ll) => ({
+      x: (ll.lng - o.center.lng) * o.pixelsPerDegree + o.size.x / 2,
+      y: (o.center.lat - ll.lat) * o.pixelsPerDegree + o.size.y / 2
+    }),
+    project: (ll, zoom) => ({
+      x: ll.lng * o.pixelsPerDegree * (zoom || 1),
+      y: -ll.lat * o.pixelsPerDegree * (zoom || 1)
+    }),
+    getBoundsZoom: jest.fn(() => o.boundsZoom !== undefined ? o.boundsZoom : 1),
+    _panes: {},
+    getPane(name) { return this._panes[name]; },
+    createPane(name) { this._panes[name] = { style: {} }; return this._panes[name]; },
+    on(evt, fn) { (this._handlers[evt] = this._handlers[evt] || []).push(fn); },
+    off(evt, fn) {
+      this._handlers[evt] = (this._handlers[evt] || []).filter((f) => f !== fn);
+    },
+    fire(evt) { (this._handlers[evt] || []).slice().forEach((f) => f()); }
+  };
+}
+
+const CENTRE = { lat: 52.5209336, lng: 13.3956302 };
+const MAIN = { osmId: 1, type: 'main', center: { lat: 52.5209566, lng: 13.3965227 } };
+const SIDE = { osmId: 2, type: 'yes', center: { lat: 52.5207240, lng: 13.3974377 } };
+
+function openPicker(extra, showOpts) {
+  const map = makeMap(extra && extra.map);
+  const onSelect = jest.fn();
+  const picker = entrancePicker.createEntrancePicker(
+    map, Object.assign({ onSelect }, extra && extra.options));
+  const opened = picker.show(Object.assign({
+    waypointIndex: 1,
+    placeName: 'Pergamonmuseum',
+    placeCenter: CENTRE,
+    entrances: [MAIN, SIDE]
+  }, showOpts));
+  return { map, picker, onSelect, opened };
+}
+
+// The picker's own layer group holds [outlineLayer, markerLayer], in that order.
+function pickerGroup(map) {
+  return map._layers[0];
+}
+
+function outlineLayer(map) {
+  const g = pickerGroup(map);
+  return g ? g._layers[0] : null;
+}
+
+// The picker's group holds [outlineLayer, linkLayer, labelLayer, markerLayer].
+function linkLayerOf(map) {
+  const g = pickerGroup(map);
+  return g ? g._layers[1] : null;
+}
+
+// The label markers currently drawn.
+function labels(map) {
+  const g = pickerGroup(map);
+  return g ? g._layers[2]._layers : [];
+}
+
+// The text of each drawn label, in order.
+function labelTexts(map) {
+  return labels(map).map((m) => m.options.icon.options.html.replace(/<[^>]*>/g, ''));
+}
+
+// The dots currently drawn, latest render only.
+function dots(map) {
+  const g = pickerGroup(map);
+  return g ? g._layers[3]._layers : [];
+}
+
+function classesOf(map) {
+  return dots(map).map((m) => m.options.icon.options.className);
+}
+
+// The dashed links from a chosen door back to the pin.
+function links(map) {
+  const l = linkLayerOf(map);
+  return l ? l._layers.filter((x) => x._kind === 'polyline') : [];
+}
+
+function kindsOf(map) {
+  return kindsOfClasses(classesOf(map));
+}
+
+function kindsOfClasses(classes) {
+  return classes.map((c) => c.replace('osrm-entrance-marker osrm-entrance-marker-', ''));
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe('show', () => {
+  test('adds its layer to the map and reports that it opened', () => {
+    const { map, picker, opened } = openPicker();
+    expect(opened).toBe(true);
+    expect(picker.isOpen()).toBe(true);
+    expect(map._layers).toHaveLength(1);
+  });
+
+  test('draws every door, none chosen yet', () => {
+    const { map } = openPicker();
+    expect(kindsOf(map)).toEqual(['main', 'other']);
+  });
+
+  test('opens for a place with a single door', () => {
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    expect(picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN] })).toBe(true);
+    expect(dots(map)).toHaveLength(1);
+  });
+
+  test('refuses to open when the place has no doors at all', () => {
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    expect(picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [] })).toBe(false);
+    expect(picker.isOpen()).toBe(false);
+    expect(map._layers).toHaveLength(0);
+  });
+
+  test('remembers which waypoint it belongs to, with nothing chosen', () => {
+    const { picker } = openPicker(null, { waypointIndex: 3 });
+    expect(picker.getWaypointIndex()).toBe(3);
+    expect(picker.getSelectedId()).toBeNull();
+  });
+
+  test('draws no link back to the pin until a door is chosen', () => {
+    const { map } = openPicker();
+    expect(links(map)).toHaveLength(0);
+  });
+
+  test('labels each dot through the supplied translator', () => {
+    const translate = jest.fn((k) => 'T:' + k);
+    const { map } = openPicker({ options: { translate } });
+    expect(labelTexts(map)).toEqual(['T:Main entrance', 'T:Entrance']);
+    expect(translate).toHaveBeenCalledWith('Main entrance');
+  });
+
+  test('falls back to the raw key when no translator is given', () => {
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN, SIDE] });
+    expect(labelTexts(map)).toEqual(['Main entrance', 'Entrance']);
+  });
+
+  test('an exit-only door is labelled an exit, not an entrance', () => {
+    const exit = { osmId: 8, type: 'exit', center: { lat: 52.5206, lng: 13.398 } };
+    const { map } = openPicker(null, { entrances: [MAIN, exit] });
+    expect(labelTexts(map)).toEqual(['Main entrance', 'Exit']);
+  });
+
+  test('a door that names itself is labelled with that name', () => {
+    const named = {
+      osmId: 7, type: 'yes', center: { lat: 52.521, lng: 13.413 },
+      tags: { name: 'Eingang Ravelinplatz' }
+    };
+    const translate = jest.fn((k) => 'T:' + k);
+    const { map } = openPicker({ options: { translate } }, { entrances: [MAIN, named] });
+    expect(labelTexts(map)).toEqual(['T:Main entrance', 'Eingang Ravelinplatz']);
+    // A name from OSM is not run through the translator.
+    expect(translate).not.toHaveBeenCalledWith('Eingang Ravelinplatz');
+  });
+});
+
+describe('selecting a dot', () => {
+  test('routes to the door while reporting where the pin belongs', () => {
+    const { map, onSelect } = openPicker();
+    dots(map)[0].fire('click');
+    expect(onSelect).toHaveBeenCalledWith({
+      waypointIndex: 1,
+      placeName: 'Pergamonmuseum',
+      latLng: MAIN.center,
+      markerLatLng: CENTRE,
+      entrance: MAIN
+    });
+  });
+
+  test('stops the click reaching the map, which would drop a new waypoint', () => {
+    const L = require('leaflet');
+    L.DomEvent.stopPropagation.mockClear();
+    const { map } = openPicker();
+    dots(map)[0].fire('click', { fake: 'event' });
+    expect(L.DomEvent.stopPropagation).toHaveBeenCalledWith({ fake: 'event' });
+  });
+
+  test('keeps every door on the map and marks the chosen one', () => {
+    const { map, picker } = openPicker();
+    dots(map)[0].fire('click');
+    expect(picker.getSelectedId()).toBe('osm:1');
+    expect(dots(map)).toHaveLength(2);
+    expect(classesOf(map)[0]).toContain('osrm-entrance-marker-selected');
+    expect(classesOf(map)[1]).not.toContain('osrm-entrance-marker-selected');
+  });
+
+  test('draws a dashed link from the chosen door to the pin', () => {
+    const { map } = openPicker();
+    dots(map)[0].fire('click');
+    const drawn = links(map);
+    expect(drawn).toHaveLength(1);
+    expect(drawn[0].points).toEqual([MAIN.center, CENTRE]);
+    expect(drawn[0].style.dashArray).toBeTruthy();
+  });
+
+  test('the link moves with the choice', () => {
+    const { map } = openPicker();
+    dots(map)[0].fire('click');
+    dots(map)[1].fire('click');
+    expect(links(map)[0].points).toEqual([SIDE.center, CENTRE]);
+  });
+
+  test('clicking the chosen door again releases it, routing back to the place', () => {
+    const { map, picker, onSelect } = openPicker();
+    dots(map)[0].fire('click');
+    onSelect.mockClear();
+    dots(map)[0].fire('click');
+    expect(picker.getSelectedId()).toBeNull();
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({
+      latLng: CENTRE, markerLatLng: CENTRE, entrance: null
+    }));
+    expect(links(map)).toHaveLength(0);
+  });
+
+  test('a click after hide does nothing', () => {
+    const { map, picker, onSelect } = openPicker();
+    const dot = dots(map)[0];
+    picker.hide();
+    dot.fire('click');
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('hide', () => {
+  test('drops the layer from the map and closes', () => {
+    const { map, picker } = openPicker();
+    picker.hide();
+    expect(picker.isOpen()).toBe(false);
+    expect(picker.getSelectedId()).toBeNull();
+    expect(picker.getWaypointIndex()).toBeNull();
+    expect(map._layers).toHaveLength(0);
+  });
+
+  test('is safe to call when already closed', () => {
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    expect(() => picker.hide()).not.toThrow();
+  });
+
+  test('Escape closes the picker', () => {
+    const { picker } = openPicker();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(picker.isOpen()).toBe(false);
+  });
+
+  test('other keys leave it open', () => {
+    const { picker } = openPicker();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    expect(picker.isOpen()).toBe(true);
+  });
+
+  test('the Escape handler is removed, so a later key cannot reach a closed picker', () => {
+    const { picker } = openPicker();
+    picker.hide();
+    expect(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })))
+      .not.toThrow();
+    expect(picker.isOpen()).toBe(false);
+  });
+});
+
+describe('site outline', () => {
+  const GEOMETRY = { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] };
+
+  // Whether an outline path has actually been drawn.
+  function hasOutline(map) {
+    const l = outlineLayer(map);
+    return !!(l && l._layers.some((x) => x._kind === 'geoJSON'));
+  }
+
+  test('is fetched for the place and drawn beneath the dots', async () => {
+    const fetchOutline = jest.fn(() => Promise.resolve(GEOMETRY));
+    const place = { osmType: 'way', osmId: 313659704 };
+    const { map } = openPicker({ options: { fetchOutline } }, { place });
+    expect(fetchOutline).toHaveBeenCalledWith(place);
+    await Promise.resolve();
+    expect(hasOutline(map)).toBe(true);
+  });
+
+  test('a place with no outline simply gets none', async () => {
+    const fetchOutline = jest.fn(() => Promise.resolve(null));
+    const { map } = openPicker({ options: { fetchOutline } }, { place: {} });
+    await Promise.resolve();
+    expect(hasOutline(map)).toBe(false);
+  });
+
+  test('is not requested when the result carries no place', () => {
+    const fetchOutline = jest.fn();
+    openPicker({ options: { fetchOutline } });
+    expect(fetchOutline).not.toHaveBeenCalled();
+  });
+
+  test('an outline that arrives after the picker closed is discarded', async () => {
+    let resolve;
+    const fetchOutline = jest.fn(() => new Promise((r) => { resolve = r; }));
+    const { map, picker } = openPicker({ options: { fetchOutline } }, { place: {} });
+    picker.hide();
+    resolve(GEOMETRY);
+    await Promise.resolve();
+    expect(map._layers).toHaveLength(0);
+  });
+
+  test('an outline for a place the user has moved on from is discarded', async () => {
+    const pending = [];
+    const fetchOutline = jest.fn(() => new Promise((r) => pending.push(r)));
+    const { map, picker } = openPicker({ options: { fetchOutline } }, { place: { osmId: 1 } });
+    // A second place is picked before the first outline lands.
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN, SIDE], place: { osmId: 2 } });
+    pending[0](GEOMETRY);
+    await Promise.resolve();
+    expect(hasOutline(map)).toBe(false);
+    pending[1](GEOMETRY);
+    await Promise.resolve();
+    expect(hasOutline(map)).toBe(true);
+  });
+});
+
+describe('framing the view', () => {
+  // The picker waits for the map to settle before re-framing, so every
+  // assertion here runs the timers first.
+  function settle(map) {
+    jest.advanceTimersByTime(500);
+    return map.fitBounds.mock.calls[map.fitBounds.mock.calls.length - 1];
+  }
+
+  test('re-frames once the map settles, not immediately', () => {
+    const { map } = openPicker(null, { placeBounds: makeBounds([CENTRE, MAIN.center]) });
+    expect(map.fitBounds).not.toHaveBeenCalled();
+    settle(map);
+    expect(map.fitBounds).toHaveBeenCalledTimes(1);
+  });
+
+  test('a moveend re-frames without waiting for the backstop timer', () => {
+    const { map } = openPicker(null, { placeBounds: makeBounds([CENTRE, MAIN.center]) });
+    map.fire('moveend');
+    expect(map.fitBounds).toHaveBeenCalledTimes(1);
+    // The timer must not fire a second time afterwards.
+    jest.advanceTimersByTime(500);
+    expect(map.fitBounds).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps the framed extent clear of the directions pane', () => {
+    const paneWidth = () => 400;
+    const { map } = openPicker(
+      { options: { paneWidth } },
+      { placeBounds: makeBounds([CENTRE, MAIN.center]) });
+    const call = settle(map);
+    expect(call[1].paddingBottomRight).toEqual({ x: 424, y: 24 });
+    expect(call[1].paddingTopLeft).toEqual({ x: 24, y: 24 });
+  });
+
+  // Small enough that the framing is still worth doing — an area already filling
+  // the viewport is left alone regardless of which bounds were chosen.
+  const AREA = () => makeBounds([{ lat: 52.518, lng: 13.392 }, { lat: 52.524, lng: 13.400 }]);
+
+  test('frames the place bbox when it leaves the doors far enough apart', () => {
+    const area = AREA();
+    // At this zoom the two doors project ~450 px apart, well clear of the
+    // minimum separation, so the site wins.
+    const { map } = openPicker({ map: { boundsZoom: 50 } }, { placeBounds: area });
+    expect(settle(map)[0]).toBe(area);
+  });
+
+  test('frames the doors instead when the bbox would bunch them up', () => {
+    const area = AREA();
+    // A tiny zoom projects the two doors within a pixel of each other.
+    const { map } = openPicker({ map: { boundsZoom: 0.01 } }, { placeBounds: area });
+    const call = settle(map);
+    expect(call[0]).not.toBe(area);
+    expect(call[0]._points).toEqual([MAIN.center, SIDE.center]);
+  });
+
+  test('the separation is judged at the zoom the bbox would actually produce', () => {
+    const area = AREA();
+    const { map } = openPicker({ map: { boundsZoom: 50 } }, { placeBounds: area });
+    settle(map);
+    // The pane width is part of that calculation, so it is passed through.
+    expect(map.getBoundsZoom).toHaveBeenCalledWith(area, false, { x: 48, y: 48 });
+  });
+
+  test('falls back to the dots when the place has no bbox at all', () => {
+    const { map } = openPicker();
+    const call = settle(map);
+    expect(call[0]._points).toEqual([MAIN.center, SIDE.center]);
+  });
+
+  test('a single door falls back to door-and-centre so both stay in view', () => {
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN] });
+    jest.advanceTimersByTime(500);
+    expect(map.fitBounds.mock.calls[0][0]._points).toEqual([MAIN.center, CENTRE]);
+  });
+
+  test('leaves the view alone when the extent already fills the free viewport', () => {
+    // 0.06° apart is 600 px, over half the 1152 px of free viewport, and both
+    // sit inside the map rather than off its edges.
+    const wide = [
+      { osmId: 1, type: 'main', center: { lat: 52.5209336, lng: 13.3656302 } },
+      { osmId: 2, type: 'yes', center: { lat: 52.5209336, lng: 13.4256302 } }
+    ];
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: wide });
+    jest.advanceTimersByTime(500);
+    expect(map.fitBounds).not.toHaveBeenCalled();
+  });
+
+  test('does nothing once the picker has closed', () => {
+    const { map, picker } = openPicker();
+    picker.hide();
+    jest.advanceTimersByTime(500);
+    expect(map.fitBounds).not.toHaveBeenCalled();
+  });
+
+  test('focusView is a no-op on a closed picker rather than throwing', () => {
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    expect(() => picker.focusView()).not.toThrow();
+    jest.advanceTimersByTime(500);
+    expect(map.fitBounds).not.toHaveBeenCalled();
+  });
+});
+
+describe('label placement', () => {
+  const labelBoxes = require('./__label_boxes');
+  const box = (l, t, r, b) => ({ left: l, top: t, right: r, bottom: b });
+
+  const NAMED = [
+    { osmId: 1, type: 'main', center: { lat: 52.5209, lng: 13.3965 }, tags: { name: 'Nord' } },
+    { osmId: 2, type: 'yes', center: { lat: 52.5208, lng: 13.3970 }, tags: { name: 'Ost' } },
+    { osmId: 3, type: 'yes', center: { lat: 52.5207, lng: 13.3975 }, tags: { name: 'Sued' } }
+  ];
+
+  afterEach(() => labelBoxes.clear());
+
+  // Opens the picker with the given per-label boxes already in place, so the
+  // layout pass measures them as it runs.
+  function openWith(boxesByText, entrances) {
+    labelBoxes.set(boxesByText);
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({
+      waypointIndex: 1, placeCenter: CENTRE, entrances: entrances || NAMED
+    });
+    return { map, picker };
+  }
+
+  test('every door names itself when the labels all fit', () => {
+    const { map } = openWith({
+      Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16)
+    });
+    expect(labelTexts(map)).toEqual(['Nord', 'Ost', 'Sued']);
+  });
+
+  test('a colliding run collapses into one label listing every door in it', () => {
+    const { map } = openWith({
+      Nord: box(0, 0, 40, 16), Ost: box(20, 0, 60, 16), Sued: box(200, 0, 240, 16)
+    });
+    // Two labels now: the merged run, and the one that still fits.
+    expect(labelTexts(map)).toEqual(['NordOst', 'Sued']);
+  });
+
+  test('the merged label is marked as such, and anchored on the first door', () => {
+    const { map } = openWith({
+      Nord: box(0, 0, 40, 16), Ost: box(20, 0, 60, 16), Sued: box(200, 0, 240, 16)
+    });
+    const merged = labels(map)[0];
+    expect(merged.options.icon.options.className).toContain('osrm-entrance-label-merged');
+    expect(merged.latLng).toBe(NAMED[0].center);
+    expect(labels(map)[1].options.icon.options.className)
+      .not.toContain('osrm-entrance-label-merged');
+  });
+
+  test('everything colliding at once becomes a single label', () => {
+    const { map } = openWith({
+      Nord: box(0, 0, 40, 16), Ost: box(5, 0, 45, 16), Sued: box(10, 0, 50, 16)
+    });
+    expect(labelTexts(map)).toEqual(['NordOstSued']);
+  });
+
+  test('labels are drawn beneath the dots, in a pane of their own', () => {
+    // A zIndexOffset cannot guarantee this: Leaflet derives a marker's z-index
+    // from its latitude, so a label on a northerly door would outrank a dot on
+    // a southerly one. The pane settles it for every marker at once.
+    const { map } = openWith({
+      Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16)
+    });
+    const pane = labels(map)[0].options.pane;
+    expect(pane).toBe('osrmEntranceLabels');
+    expect(Number(map._panes[pane].style.zIndex)).toBeLessThan(600);
+    // The dots stay in Leaflet's default marker pane.
+    expect(dots(map).every((m) => m.options.pane === undefined)).toBe(true);
+  });
+
+  test('labels never take a click meant for a door', () => {
+    const { map } = openWith({
+      Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16)
+    });
+    expect(labels(map).every((m) => m.options.interactive === false)).toBe(true);
+  });
+
+  test('the pane is made once and reused', () => {
+    const { map, picker } = openWith({ Nord: box(0, 0, 40, 16) });
+    const created = map.createPane.mock ? map.createPane.mock.calls.length : null;
+    picker.layoutLabels();
+    expect(map._panes.osrmEntranceLabels).toBeTruthy();
+    expect(created === null || created <= 1).toBe(true);
+  });
+
+  test('names go in as text, so OSM cannot inject markup', () => {
+    const nasty = '<img src=x onerror=alert(1)>';
+    const { map } = openWith(
+      { [nasty]: box(0, 0, 40, 16), Ost: box(20, 0, 60, 16) },
+      [Object.assign({}, NAMED[0], { tags: { name: nasty } }), NAMED[1]]
+    );
+    const html = labels(map)[0].options.icon.options.html;
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  test('gives up rather than guessing when a label cannot be measured', () => {
+    const { map, picker } = openWith({});
+    expect(picker.layoutLabels()).toBeNull();
+    // The per-door labels drawn for measuring are left in place.
+    expect(labelTexts(map)).toEqual(['Nord', 'Ost', 'Sued']);
+  });
+
+  test('re-runs the layout when the map zooms', () => {
+    const { map } = openWith({
+      Nord: box(0, 0, 40, 16), Ost: box(20, 0, 60, 16), Sued: box(200, 0, 240, 16)
+    });
+    expect(labelTexts(map)).toEqual(['NordOst', 'Sued']);
+
+    // Zoomed in far enough that they separate.
+    labelBoxes.set({
+      Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16)
+    });
+    map.fire('zoomend');
+    expect(labelTexts(map)).toEqual(['Nord', 'Ost', 'Sued']);
+  });
+
+  test('leaves no labels behind when it closes', () => {
+    const { map, picker } = openWith({
+      Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16)
+    });
+    picker.hide();
+    expect(labels(map)).toHaveLength(0);
+  });
+
+  test('stops re-laying out once closed', () => {
+    const { map, picker } = openWith({ Nord: box(0, 0, 40, 16) });
+    picker.hide();
+    expect(() => map.fire('zoomend')).not.toThrow();
+  });
+});

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -669,8 +669,8 @@ describe('mode-dependent marks', () => {
   const box = (l, t, r, b) => ({ left: l, top: t, right: r, bottom: b });
   // A mark is part of the label's rendered text, so the harness — which keys
   // measured boxes by that text — sees it in the key too.
-  const WC = '\u267F';
-  const PK = '\uD83C\uDD7F';
+  const WC = '\u267F\uFE0F';
+  const PK = '\uD83C\uDD7F\uFE0F';
 
   const STEP_FREE = { osmId: 1, type: 'main', center: { lat: 52.5209, lng: 13.3965 },
     tags: { name: 'Nord', wheelchair: 'yes' } };

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -663,3 +663,74 @@ describe('label placement', () => {
     expect(() => map.fire('zoomend')).not.toThrow();
   });
 });
+
+describe('wheelchair mark', () => {
+  const labelBoxes = require('./__label_boxes');
+  const box = (l, t, r, b) => ({ left: l, top: t, right: r, bottom: b });
+  // The mark is part of the label's rendered text, so the test harness — which
+  // keys measured boxes by that text — sees it in the key too.
+  const MARK = '\u267F';
+
+  const ACCESSIBLE = { osmId: 1, type: 'main', center: { lat: 52.5209, lng: 13.3965 },
+    tags: { name: 'Nord', wheelchair: 'yes' } };
+  const STEPPED = { osmId: 2, type: 'yes', center: { lat: 52.5208, lng: 13.3970 },
+    tags: { name: 'Ost', wheelchair: 'no' } };
+  const UNKNOWN = { osmId: 3, type: 'yes', center: { lat: 52.5207, lng: 13.3975 },
+    tags: { name: 'Sued' } };
+
+  afterEach(() => labelBoxes.clear());
+
+  function open(entrances, boxes) {
+    labelBoxes.set(boxes);
+    const map = makeMap();
+    entrancePicker.createEntrancePicker(map, {}).show({
+      waypointIndex: 1, placeCenter: CENTRE, entrances: entrances
+    });
+    return map;
+  }
+
+  const APART = {
+    ['Nord' + MARK]: box(0, 0, 44, 16),
+    Ost: box(100, 0, 140, 16),
+    Sued: box(200, 0, 240, 16)
+  };
+
+  test('only the accessible door is marked', () => {
+    const html = labels(open([ACCESSIBLE, STEPPED, UNKNOWN], APART))
+      .map((m) => m.options.icon.options.html);
+    expect(html[0]).toContain('osrm-entrance-wheelchair');
+    expect(html[1]).not.toContain('osrm-entrance-wheelchair');
+    expect(html[2]).not.toContain('osrm-entrance-wheelchair');
+  });
+
+  test('the mark is hidden from assistive tech, which reads the dot instead', () => {
+    const map = open([ACCESSIBLE], { ['Nord' + MARK]: box(0, 0, 44, 16) });
+    expect(labels(map)[0].options.icon.options.html).toContain('aria-hidden="true"');
+    expect(dots(map)[0].options.alt).toBe('Nord (Wheelchair accessible)');
+  });
+
+  test('an unmarked door says only its name', () => {
+    const map = open([UNKNOWN], { Sued: box(0, 0, 40, 16) });
+    expect(dots(map)[0].options.alt).toBe('Sued');
+  });
+
+  test('a merged label marks only the doors that earned it', () => {
+    // Nord and Ost collide and merge; the mark must stay on Nord's line alone.
+    const map = open([ACCESSIBLE, STEPPED, UNKNOWN], {
+      ['Nord' + MARK]: box(0, 0, 44, 16),
+      Ost: box(20, 0, 60, 16),
+      Sued: box(200, 0, 240, 16)
+    });
+    const merged = labels(map)[0].options.icon.options.html;
+    expect(merged.match(/osrm-entrance-wheelchair/g)).toHaveLength(1);
+    expect(labelTexts(map)[0]).toContain('Nord');
+    expect(labelTexts(map)[0]).toContain('Ost');
+  });
+
+  test('the mark survives selecting the door it belongs to', () => {
+    const map = open([ACCESSIBLE, STEPPED],
+      { ['Nord' + MARK]: box(0, 0, 44, 16), Ost: box(100, 0, 140, 16) });
+    dots(map)[0].fire('click', {});
+    expect(labels(map)[0].options.icon.options.html).toContain('osrm-entrance-wheelchair');
+  });
+});

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -734,3 +734,37 @@ describe('wheelchair mark', () => {
     expect(labels(map)[0].options.icon.options.html).toContain('osrm-entrance-wheelchair');
   });
 });
+
+describe('re-showing while already open', () => {
+  // refresh() re-shows the picker when the travel mode changes, so show() runs
+  // again on an open picker. Real Leaflet happens to ignore a repeat
+  // registration of the same handler, but the picker detaches first rather than
+  // depending on that — so this holds for any map object, including the fake
+  // here, which does not de-duplicate.
+  test('does not stack zoomend listeners', () => {
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    const show = () => picker.show({
+      waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN, SIDE]
+    });
+
+    show();
+    const after1 = map._handlers.zoomend.length;
+    show();
+    show();
+
+    expect(after1).toBe(1);
+    expect(map._handlers.zoomend).toHaveLength(after1);
+  });
+
+  test('one hide still tears the picker down completely', () => {
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN, SIDE] });
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN, SIDE] });
+    picker.hide();
+    expect(picker.isOpen()).toBe(false);
+    expect(map._handlers.zoomend).toHaveLength(0);
+    expect(dots(map)).toHaveLength(0);
+  });
+});

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -132,7 +132,7 @@ function openPicker(extra, showOpts) {
   return { map, picker, onSelect, opened };
 }
 
-// The picker's own layer group holds [outlineLayer, markerLayer], in that order.
+// The picker's own layer group; its members are indexed by the helpers below.
 function pickerGroup(map) {
   return map._layers[0];
 }
@@ -421,6 +421,23 @@ describe('site outline', () => {
     pending[1](GEOMETRY);
     await Promise.resolve();
     expect(hasOutline(map)).toBe(true);
+  });
+
+  test('showing another waypoint does not cancel an outline already in flight', () => {
+    // Offers are per waypoint, so a second waypoint being named while the
+    // first one's outline is still loading must leave that request alone. A
+    // shared cancellation counter got this wrong: the newer show() invalidated
+    // an outline the older, still-visible offer was waiting for.
+    const pending = [];
+    const fetchOutline = jest.fn(() => new Promise((r) => pending.push(r)));
+    const { map, picker } = openPicker({ options: { fetchOutline } }, { place: { osmId: 1 } });
+
+    picker.show({ waypointIndex: 0, placeCenter: CENTRE, entrances: [MAIN], place: { osmId: 2 } });
+    pending[0](GEOMETRY);
+
+    return Promise.resolve().then(() => {
+      expect(hasOutline(map)).toBe(true);
+    });
   });
 });
 

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -980,6 +980,20 @@ describe('following a splice of the waypoint list', () => {
     expect(dots(map)).toHaveLength(2);
   });
 
+  test('removing the framed offer hands the view to a surviving one', () => {
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Werk: box(200, 0, 240, 16) });
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    picker.show({ waypointIndex: 0, placeCenter: CENTRE, entrances: START });
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: OTHER });
+    expect(picker.getWaypointIndex()).toBe(1);
+
+    picker.spliceOffers(1, 1, 0);   // the framed offer's waypoint is deleted
+    expect(picker.getWaypointIndex()).toBe(0);
+    expect(picker.isOpenFor(0)).toBe(true);
+    expect(dots(map)).toHaveLength(1);
+  });
+
   test('a splice that changes nothing leaves the offers alone', () => {
     const { map, picker } = open(0, START);
     const before = dots(map)[0];

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -456,6 +456,17 @@ describe('framing the view', () => {
     expect(map.fitBounds).toHaveBeenCalledTimes(1);
   });
 
+  test('frame: false redraws the offer without moving the view', () => {
+    // A change of travel mode or of a waypoint's role re-shows the offer; the
+    // user did not ask to be taken to the doors.
+    const { map } = openPicker(null, {
+      placeBounds: makeBounds([CENTRE, MAIN.center]), frame: false
+    });
+    map.fire('moveend');
+    jest.advanceTimersByTime(500);
+    expect(map.fitBounds).not.toHaveBeenCalled();
+  });
+
   test('a moveend re-frames without waiting for the backstop timer', () => {
     const { map } = openPicker(null, { placeBounds: makeBounds([CENTRE, MAIN.center]) });
     map.fire('moveend');
@@ -619,11 +630,71 @@ describe('label placement', () => {
     expect(dots(map).every((m) => m.options.pane === undefined)).toBe(true);
   });
 
-  test('labels never take a click meant for a door', () => {
-    const { map } = openWith({
-      Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16)
-    });
-    expect(labels(map).every((m) => m.options.interactive === false)).toBe(true);
+  test('a label is clickable and stands in for its door', () => {
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16) });
+    const { map, onSelect } = openPicker(null, { entrances: NAMED });
+    expect(labels(map).every((m) => m.options.interactive === true)).toBe(true);
+    labels(map)[1].fire('click', { originalEvent: { target: {} } });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].entrance).toBe(NAMED[1]);
+  });
+
+  test('a click on a label does not fall through to the map', () => {
+    const L = require('leaflet');
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16) });
+    const { map } = openPicker(null, { entrances: NAMED });
+    L.DomEvent.stopPropagation.mockClear();
+    const event = { originalEvent: { target: {} } };
+    labels(map)[0].fire('click', event);
+    expect(L.DomEvent.stopPropagation).toHaveBeenCalledWith(event);
+  });
+
+  // A merged label's lines are the inner span's children; a click carries the
+  // element it landed on, which knows its parent's children.
+  function lineTarget(lineIndex, lineCount) {
+    const lines = [];
+    for (let i = 0; i < lineCount; i++) lines.push({ parentNode: null });
+    const parent = { children: lines };
+    lines.forEach((line) => { line.parentNode = parent; });
+    const line = lines[lineIndex];
+    return { closest: (sel) => (sel === '.osrm-entrance-label-inner > div' ? line : null) };
+  }
+
+  test('a line of a merged label picks that door, which is the only way to reach it', () => {
+    // Nord and Ost collide, so they share one label; the doors themselves are
+    // too close together to aim at.
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Ost: box(20, 0, 60, 16), Sued: box(200, 0, 240, 16) });
+    const { map, onSelect } = openPicker(null, { entrances: NAMED });
+    expect(labelTexts(map)).toEqual(['NordOst', 'Sued']);
+    labels(map)[0].fire('click', { originalEvent: { target: lineTarget(1, 2) } });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].entrance).toBe(NAMED[1]);
+  });
+
+  test('a click on a merged label that misses every line picks nothing', () => {
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Ost: box(20, 0, 60, 16), Sued: box(200, 0, 240, 16) });
+    const { map, onSelect } = openPicker(null, { entrances: NAMED });
+    labels(map)[0].fire('click', { originalEvent: { target: { closest: () => null } } });
+    labels(map)[0].fire('click', {});
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test('a merged label marks the line of the chosen door', () => {
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Ost: box(20, 0, 60, 16), Sued: box(200, 0, 240, 16) });
+    const { map } = openPicker(null, { entrances: NAMED });
+    dots(map)[1].fire('click');
+    const html = labels(map)[0].options.icon.options.html;
+    expect(html).toContain('<div>Nord</div>');
+    expect(html).toContain('<div class="osrm-entrance-label-selected">Ost</div>');
+    // Choosing it again releases it, and the mark goes with it.
+    dots(map)[1].fire('click');
+    expect(labels(map)[0].options.icon.options.html).not.toContain('osrm-entrance-label-selected');
+  });
+
+  test('labels do not take keyboard focus, which stays with the dots', () => {
+    labelBoxes.set({ Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16), Sued: box(200, 0, 240, 16) });
+    const { map } = openPicker(null, { entrances: NAMED });
+    expect(labels(map).every((m) => m.options.keyboard === false)).toBe(true);
   });
 
   test('the pane is made once and reused', () => {

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -24,6 +24,8 @@ const { createEntranceWaypoints, entranceWaypointName, waypointMarkerLatLng,
 const MAIN = { osmId: 1, type: 'main', center: { lat: 52.5209566, lng: 13.3965227 } };
 const SIDE = { osmId: 2, type: 'yes', center: { lat: 52.5207240, lng: 13.3974377 } };
 const EXIT = { osmId: 3, type: 'exit', center: { lat: 52.5206, lng: 13.3980 } };
+// entrance=entrance is one-way in: usable at a destination, never at an origin.
+const WAY_IN = { osmId: 4, type: 'entrance', center: { lat: 52.5205, lng: 13.3985 } };
 const CENTRE = { lat: 52.5209336, lng: 13.3956302 };
 
 // A plan with the two internals the module reaches into, recorded so the tests
@@ -674,6 +676,70 @@ describe('splicing the waypoint list', () => {
     wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1 }));
 
     wiring.spliceWaypoints({ index: 1, nRemoved: 1, added: [] });
+    expect(wiring.refresh()).toBe(false);
+    expect(picker.shown).toHaveLength(1);
+  });
+
+  test('reversing the route re-offers the doors the new roles allow', () => {
+    // The reported bug. An entrance=exit can be left through but not entered,
+    // so it is right to offer nothing while the place is the destination — and
+    // wrong to keep offering nothing once it becomes the start. LRM's reverse
+    // button replaces the whole list, so this arrives as a splice of everything.
+    const plan = makePlan(2);
+    const [first, second] = plan._waypoints;
+    const { wiring, picker } = build({ plan });
+
+    wiring.onGeocodeResult(geocodeEvent([EXIT], { waypointIndex: 1, waypoint: second }));
+    expect(picker.isOpenFor(1)).toBe(false);
+
+    plan._waypoints.reverse();
+    wiring.spliceWaypoints({ index: 0, nRemoved: 2, added: [second, first] });
+
+    expect(picker.isOpenFor(0)).toBe(true);
+    const offer = picker.shown[picker.shown.length - 1];
+    expect(offer.waypointIndex).toBe(0);
+    expect(offer.entrances).toEqual([EXIT]);
+  });
+
+  test('a door that only works at the end is withdrawn when it becomes a via', () => {
+    // The mirror of the same gap: entrance=entrance is one-way in, so it is no
+    // use at a stop that must also be left again.
+    const plan = makePlan(2);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([WAY_IN], { waypointIndex: 1, waypoint: plan._waypoints[1] }));
+    expect(picker.isOpenFor(1)).toBe(true);
+
+    // A third waypoint appended after it: index 1 is now a via.
+    plan._waypoints.push({ latLng: null, name: '' });
+    wiring.spliceWaypoints({ index: 2, nRemoved: 0, added: [plan._waypoints[2]] });
+
+    expect(picker.isOpenFor(1)).toBe(false);
+    expect(picker.hiddenWaypoints).toContain(1);
+  });
+
+  test('a splice that leaves the roles alone does not re-offer anything', () => {
+    const plan = makePlan(3);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 0, waypoint: plan._waypoints[0] }));
+    const before = picker.shown.length;
+
+    // A waypoint appended at the end: index 0 is the origin either way.
+    plan._waypoints.push({ latLng: null, name: '' });
+    wiring.spliceWaypoints({ index: 3, nRemoved: 0, added: [plan._waypoints[3]] });
+
+    expect(picker.shown).toHaveLength(before);
+    expect(picker.isOpenFor(0)).toBe(true);
+  });
+
+  test('a waypoint replaced by a different one does not inherit its doors', () => {
+    // Identity, not position, is what says a waypoint survived a splice.
+    const plan = makePlan(2);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1, waypoint: plan._waypoints[1] }));
+
+    plan._waypoints[1] = { latLng: null, name: '' };
+    wiring.spliceWaypoints({ index: 1, nRemoved: 1, added: [plan._waypoints[1]] });
+
     expect(wiring.refresh()).toBe(false);
     expect(picker.shown).toHaveLength(1);
   });

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -75,6 +75,18 @@ function makeFakePicker() {
       picker.openFor.delete(waypointIndex);
       picker.open = picker.openFor.size > 0;
     }),
+    // Mirrors the real picker: offers are renumbered by a splice, not dropped.
+    spliceOffers: jest.fn(function(index, nRemoved, nAdded) {
+      const delta = (nAdded || 0) - (nRemoved || 0);
+      const next = new Set();
+      picker.openFor.forEach((at) => {
+        if (at < index) { next.add(at); return; }
+        if (at < index + (nRemoved || 0)) return;
+        next.add(at + delta);
+      });
+      picker.openFor = next;
+      picker.open = picker.openFor.size > 0;
+    }),
     isOpen: jest.fn(() => picker.open),
     isOpenFor: jest.fn((waypointIndex) => picker.openFor.has(waypointIndex)),
     focusView: jest.fn()
@@ -625,5 +637,56 @@ describe('createReverseNotifier', () => {
     })();
     expect(() => wrapped.reverse(at(52.5, 13.4), 100, () => {})).not.toThrow();
     expect(fired).toHaveLength(0);
+  });
+});
+
+describe('splicing the waypoint list', () => {
+  test("a destination placed by clicking the map keeps the start's offer", () => {
+    // The reported bug, at the wiring level: the splice handler used to hide
+    // every offer.
+    const plan = makePlan(2);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 0 }));
+    expect(picker.isOpenFor(0)).toBe(true);
+
+    wiring.spliceWaypoints({ index: 1, nRemoved: 0, added: [{}] });
+    expect(picker.hide).not.toHaveBeenCalled();
+    expect(picker.isOpenFor(0)).toBe(true);
+  });
+
+  test('a remembered result moves with its waypoint, so refresh stays correct', () => {
+    let mode = 'foot';
+    const plan = makePlan(3);
+    const { wiring, picker } = build({ plan, options: { mode: () => mode } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1 }));
+
+    wiring.spliceWaypoints({ index: 0, nRemoved: 0, added: [{}] });
+    mode = 'driving';
+    wiring.refresh();
+
+    // Re-offered against the index the waypoint now has, not the old one.
+    expect(picker.shown[picker.shown.length - 1].waypointIndex).toBe(2);
+  });
+
+  test('a removed waypoint takes its remembered result with it', () => {
+    const plan = makePlan(2);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1 }));
+
+    wiring.spliceWaypoints({ index: 1, nRemoved: 1, added: [] });
+    expect(wiring.refresh()).toBe(false);
+    expect(picker.shown).toHaveLength(1);
+  });
+
+  test('dragging a waypoint withdraws only its own offer', () => {
+    const plan = makePlan(2);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 0 }));
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1 }));
+
+    wiring.hideWaypoint(1);
+    expect(picker.hiddenWaypoints).toEqual([1]);
+    expect(picker.hide).not.toHaveBeenCalled();
+    expect(picker.isOpenFor(0)).toBe(true);
   });
 });

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -228,6 +228,20 @@ describe('the travel mode', () => {
     expect(picker.shown[1].entrances).toEqual([MAIN]);
   });
 
+  test('is handed to the picker, which marks doors differently per mode', () => {
+    // The picker cannot derive it: the filtering happens here, and the marks it
+    // draws have to agree with the mode that filtering used.
+    let mode = 'foot';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+
+    wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    expect(picker.shown[0].mode).toBe('foot');
+
+    mode = 'driving';
+    wiring.refresh();
+    expect(picker.shown[1].mode).toBe('driving');
+  });
+
   test('refresh re-applies the rules to the place already on screen', () => {
     let mode = 'foot';
     const { wiring, picker } = build({ options: { mode: () => mode } });

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -1,0 +1,400 @@
+'use strict';
+
+/**
+ * The wiring between a geocoding result and the routing plan: deciding whether
+ * to offer the picker at all, what to offer, and what a chosen dot does to the
+ * waypoint. This used to live inline in index.js, where none of it could be
+ * reached without booting the whole app.
+ */
+
+jest.mock('leaflet', () => ({
+  layerGroup: () => ({ addLayer() {}, clearLayers() {}, addTo() {} }),
+  marker: () => ({ bindTooltip() { return this; }, on() { return this; } }),
+  divIcon: () => ({}),
+  latLngBounds: () => ({ isValid: () => false }),
+  point: (x, y) => ({ x, y }),
+  geoJSON: () => ({}),
+  DomEvent: { stopPropagation() {} }
+}));
+
+const { createEntranceWaypoints, entranceWaypointName, waypointMarkerLatLng } =
+  require('../src/entrance_waypoints');
+
+const MAIN = { osmId: 1, type: 'main', center: { lat: 52.5209566, lng: 13.3965227 } };
+const SIDE = { osmId: 2, type: 'yes', center: { lat: 52.5207240, lng: 13.3974377 } };
+const EXIT = { osmId: 3, type: 'exit', center: { lat: 52.5206, lng: 13.3980 } };
+const CENTRE = { lat: 52.5209336, lng: 13.3956302 };
+
+// A plan with the two internals the module reaches into, recorded so the tests
+// can assert what LRM would have been told.
+function makePlan(waypointCount) {
+  const waypoints = [];
+  const geocoderElems = [];
+  for (let i = 0; i < (waypointCount || 2); i++) {
+    waypoints.push({ latLng: null, name: '' });
+    geocoderElems.push({ value: null, setValue(v) { this.value = v; } });
+  }
+  return {
+    _waypoints: waypoints,
+    _geocoderElems: geocoderElems,
+    _updateMarkers: jest.fn(),
+    _fireChanged: jest.fn()
+  };
+}
+
+function makeTracker() {
+  return { waypointDragStarted: jest.fn() };
+}
+
+// Stands in for the picker so the wiring can be observed directly.
+function makeFakePicker() {
+  const picker = {
+    shown: [],
+    hidden: 0,
+    open: false,
+    onSelect: null,
+    options: null,
+    show: jest.fn(function(opts) { picker.shown.push(opts); picker.open = true; return true; }),
+    hide: jest.fn(function() { picker.hidden++; picker.open = false; }),
+    isOpen: jest.fn(() => picker.open),
+    focusView: jest.fn()
+  };
+  return picker;
+}
+
+function build(extra) {
+  const plan = (extra && extra.plan) || makePlan();
+  const routeFitTracker = makeTracker();
+  const picker = makeFakePicker();
+  const wiring = createEntranceWaypoints(Object.assign({
+    map: { fake: 'map' },
+    plan,
+    routeFitTracker,
+    createPicker: (map, opts) => {
+      picker.map = map;
+      picker.options = opts;
+      picker.onSelect = opts.onSelect;
+      return picker;
+    }
+  }, extra && extra.options));
+  return { wiring, plan, routeFitTracker, picker };
+}
+
+function geocodeEvent(entrances, overrides) {
+  return Object.assign({
+    waypointIndex: 1,
+    value: {
+      name: 'Pergamonmuseum, 5, Am Kupfergraben, Berlin',
+      center: CENTRE,
+      bbox: { isValid: () => true },
+      entrances
+    }
+  }, overrides);
+}
+
+describe('entranceWaypointName', () => {
+  test('names each kind of door for what it is', () => {
+    expect(entranceWaypointName('Museum', MAIN)).toBe('Museum (main entrance)');
+    expect(entranceWaypointName('Museum', SIDE)).toBe('Museum (entrance)');
+    // An exit is only ever offered at an origin; calling it an entrance there
+    // would contradict why it is on offer.
+    expect(entranceWaypointName('Museum', EXIT)).toBe('Museum (exit)');
+  });
+
+  test('uses the door\u2019s own name, so input and tooltip agree', () => {
+    const named = { osmId: 7, type: 'yes', tags: { name: 'Eingang Ravelinplatz' } };
+    expect(entranceWaypointName('Alexa', named)).toBe('Alexa (Eingang Ravelinplatz)');
+  });
+
+  test('a named door is not passed through the translator', () => {
+    const named = { osmId: 7, type: 'main', tags: { name: 'Haupteingang Alexanderplatz' } };
+    const de = jest.fn((k) => 'DE:' + k);
+    expect(entranceWaypointName('Alexa', named, de)).toBe('Alexa (Haupteingang Alexanderplatz)');
+    expect(de).not.toHaveBeenCalled();
+  });
+
+  test('leaves the name alone for the place centre', () => {
+    expect(entranceWaypointName('Museum', null)).toBe('Museum');
+  });
+
+  test('runs the suffix through the translator', () => {
+    const de = (k) => ({ 'main entrance': 'Haupteingang', entrance: 'Eingang' }[k] || k);
+    expect(entranceWaypointName('Museum', MAIN, de)).toBe('Museum (Haupteingang)');
+    expect(entranceWaypointName('Museum', SIDE, de)).toBe('Museum (Eingang)');
+  });
+});
+
+describe('picker construction', () => {
+  test('hands the picker its map and collaborators', () => {
+    const fetchOutline = jest.fn();
+    const paneWidth = jest.fn();
+    const translate = jest.fn((k) => k);
+    const { picker } = build({ options: { fetchOutline, paneWidth, translate } });
+    expect(picker.map).toEqual({ fake: 'map' });
+    expect(picker.options.fetchOutline).toBe(fetchOutline);
+    expect(picker.options.paneWidth).toBe(paneWidth);
+    expect(picker.options.translate).toBe(translate);
+    expect(typeof picker.options.onSelect).toBe('function');
+  });
+});
+
+describe('a geocoding result', () => {
+  test('opens the picker with every usable door and the place centre', () => {
+    const { wiring, picker } = build();
+    expect(wiring.onGeocodeResult(geocodeEvent([MAIN, SIDE]))).toBe(true);
+    expect(picker.shown).toHaveLength(1);
+    expect(picker.shown[0]).toEqual(expect.objectContaining({
+      waypointIndex: 1,
+      placeName: 'Pergamonmuseum, 5, Am Kupfergraben, Berlin',
+      placeCenter: CENTRE,
+      entrances: [MAIN, SIDE]
+    }));
+  });
+
+  test('leaves the waypoint alone — nothing is chosen for the user', () => {
+    const { wiring, plan, picker } = build();
+    wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    expect(picker.shown[0].selectedId).toBeUndefined();
+    expect(plan._waypoints[1].latLng).toBeNull();
+    expect(plan._fireChanged).not.toHaveBeenCalled();
+  });
+
+  test('passes the place through so its outline can be fetched', () => {
+    const { wiring, picker } = build();
+    const e = geocodeEvent([MAIN]);
+    wiring.onGeocodeResult(e);
+    expect(picker.shown[0].place).toBe(e.value);
+    expect(picker.shown[0].placeBounds).toBe(e.value.bbox);
+  });
+
+  test('closes the picker for a place with no entrances', () => {
+    const { wiring, picker } = build();
+    expect(wiring.onGeocodeResult(geocodeEvent(undefined))).toBe(false);
+    expect(picker.hide).toHaveBeenCalled();
+    expect(picker.show).not.toHaveBeenCalled();
+  });
+
+  test('closes the picker when the result itself is missing', () => {
+    const { wiring, picker } = build();
+    expect(wiring.onGeocodeResult({ waypointIndex: 0, value: null })).toBe(false);
+    expect(picker.hide).toHaveBeenCalled();
+  });
+
+  test('closes the picker when every entrance is unusable', () => {
+    const service = { osmId: 9, type: 'service', center: { lat: 1, lng: 1 } };
+    const { wiring, picker } = build();
+    expect(wiring.onGeocodeResult(geocodeEvent([service]))).toBe(false);
+    expect(picker.hide).toHaveBeenCalled();
+  });
+
+  // The direction a door has to work in comes from which end of the route the
+  // waypoint is — see the OSM wiki's one-way entrance values.
+  test('a destination is offered the entrance-only door but not the exit-only one', () => {
+    const { wiring, picker } = build({ plan: makePlan(2) });
+    const inOnly = { osmId: 4, type: 'entrance', center: { lat: 1, lng: 1 } };
+    wiring.onGeocodeResult(geocodeEvent([MAIN, inOnly, EXIT], { waypointIndex: 1 }));
+    expect(picker.shown[0].entrances).toEqual([MAIN, inOnly]);
+  });
+
+  test('an origin is offered the exit-only door but not the entrance-only one', () => {
+    const { wiring, picker } = build({ plan: makePlan(2) });
+    const inOnly = { osmId: 4, type: 'entrance', center: { lat: 1, lng: 1 } };
+    wiring.onGeocodeResult(geocodeEvent([MAIN, inOnly, EXIT], { waypointIndex: 0 }));
+    expect(picker.shown[0].entrances).toEqual([MAIN, EXIT]);
+  });
+
+  test('a via point is offered only the doors that work both ways', () => {
+    const { wiring, picker } = build({ plan: makePlan(3) });
+    const inOnly = { osmId: 4, type: 'entrance', center: { lat: 1, lng: 1 } };
+    wiring.onGeocodeResult(geocodeEvent([MAIN, inOnly, EXIT], { waypointIndex: 1 }));
+    expect(picker.shown[0].entrances).toEqual([MAIN]);
+  });
+});
+
+describe('the travel mode', () => {
+  const NO_CARS = {
+    osmId: 5, type: 'main', center: { lat: 1, lng: 1 }, tags: { motor_vehicle: 'no' }
+  };
+
+  test('is read live, so switching profile changes what is offered', () => {
+    let mode = 'foot';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+
+    wiring.onGeocodeResult(geocodeEvent([MAIN, NO_CARS]));
+    expect(picker.shown[0].entrances).toEqual([MAIN, NO_CARS]);
+
+    mode = 'driving';
+    wiring.onGeocodeResult(geocodeEvent([MAIN, NO_CARS]));
+    expect(picker.shown[1].entrances).toEqual([MAIN]);
+  });
+
+  test('refresh re-applies the rules to the place already on screen', () => {
+    let mode = 'foot';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN, NO_CARS]));
+
+    mode = 'driving';
+    expect(wiring.refresh()).toBe(true);
+    expect(picker.shown[1].entrances).toEqual([MAIN]);
+  });
+
+  test('a refresh that leaves no usable door closes the picker', () => {
+    let mode = 'foot';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+    wiring.onGeocodeResult(geocodeEvent([NO_CARS]));
+    expect(picker.isOpen()).toBe(true);
+
+    mode = 'driving';
+    expect(wiring.refresh()).toBe(false);
+    expect(picker.hide).toHaveBeenCalled();
+    expect(picker.isOpen()).toBe(false);
+  });
+
+  test('refresh does nothing when no picker is open', () => {
+    const { wiring, picker } = build({ options: { mode: () => 'foot' } });
+    expect(wiring.refresh()).toBe(false);
+    expect(picker.show).not.toHaveBeenCalled();
+  });
+
+  test('refresh forgets the place once the picker has been hidden', () => {
+    const { wiring, picker } = build({ options: { mode: () => 'foot' } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    wiring.hide();
+    expect(wiring.refresh()).toBe(false);
+    expect(picker.show).toHaveBeenCalledTimes(1);
+  });
+
+  test('no mode supplied means no access filtering', () => {
+    const { wiring, picker } = build();
+    wiring.onGeocodeResult(geocodeEvent([MAIN, NO_CARS]));
+    expect(picker.shown[0].entrances).toEqual([MAIN, NO_CARS]);
+  });
+});
+
+describe('choosing a dot', () => {
+  function chooseOn(setup, choice) {
+    const built = build(setup);
+    built.picker.onSelect(choice);
+    return built;
+  }
+
+  const CHOICE = {
+    waypointIndex: 1,
+    placeName: 'Pergamonmuseum',
+    latLng: MAIN.center,
+    markerLatLng: CENTRE,
+    entrance: MAIN
+  };
+
+  test('routes to the door and names the waypoint after it', () => {
+    const { plan } = chooseOn(null, CHOICE);
+    expect(plan._waypoints[1].latLng).toBe(MAIN.center);
+    expect(plan._waypoints[1].name).toBe('Pergamonmuseum (main entrance)');
+  });
+
+  test('leaves the pin on the place, not on the door', () => {
+    const { plan } = chooseOn(null, CHOICE);
+    const wp = plan._waypoints[1];
+    // The route runs to the door...
+    expect(wp.latLng).toBe(MAIN.center);
+    // ...while the pin is drawn at the place that was searched for.
+    expect(waypointMarkerLatLng(wp)).toBe(CENTRE);
+  });
+
+  test('a waypoint with no door drawn on it pins where it routes', () => {
+    const { plan } = build();
+    expect(waypointMarkerLatLng(plan._waypoints[0])).toBe(plan._waypoints[0].latLng);
+    expect(waypointMarkerLatLng(undefined)).toBeUndefined();
+  });
+
+  test('releasing the door puts the pin and the route back together', () => {
+    const { plan, wiring } = build();
+    wiring.applySelection(CHOICE);
+    wiring.applySelection(Object.assign({}, CHOICE, {
+      latLng: CENTRE, entrance: null
+    }));
+    const wp = plan._waypoints[1];
+    expect(wp.latLng).toBe(CENTRE);
+    expect(waypointMarkerLatLng(wp)).toBe(CENTRE);
+  });
+
+  test('writes the new name into the geocoder input', () => {
+    const { plan } = chooseOn(null, CHOICE);
+    expect(plan._geocoderElems[1].value).toBe('Pergamonmuseum (main entrance)');
+  });
+
+  test('redraws the markers and triggers a reroute', () => {
+    const { plan } = chooseOn(null, CHOICE);
+    expect(plan._updateMarkers).toHaveBeenCalled();
+    expect(plan._fireChanged).toHaveBeenCalled();
+  });
+
+  test('suppresses the route refit so the view stays where the user aimed', () => {
+    const { routeFitTracker } = chooseOn(null, CHOICE);
+    expect(routeFitTracker.waypointDragStarted).toHaveBeenCalled();
+  });
+
+  test('releasing the door drops the suffix again', () => {
+    const { plan } = chooseOn(null, Object.assign({}, CHOICE, {
+      latLng: CENTRE, entrance: null
+    }));
+    expect(plan._waypoints[1].name).toBe('Pergamonmuseum');
+    expect(plan._waypoints[1].latLng).toBe(CENTRE);
+  });
+
+  test('localises the suffix', () => {
+    const de = (k) => ({ 'main entrance': 'Haupteingang' }[k] || k);
+    const { plan } = chooseOn({ options: { translate: de } }, CHOICE);
+    expect(plan._waypoints[1].name).toBe('Pergamonmuseum (Haupteingang)');
+  });
+
+  test('a waypoint that has since gone away is left alone', () => {
+    const { wiring, plan } = build();
+    const moved = wiring.applySelection(Object.assign({}, CHOICE, { waypointIndex: 7 }));
+    expect(moved).toBe(false);
+    expect(plan._fireChanged).not.toHaveBeenCalled();
+  });
+
+  test('works even when the plan has no geocoder inputs yet', () => {
+    const plan = makePlan();
+    delete plan._geocoderElems;
+    const { wiring } = build({ plan });
+    expect(wiring.applySelection(CHOICE)).toBe(true);
+    expect(plan._waypoints[1].name).toBe('Pergamonmuseum (main entrance)');
+  });
+});
+
+describe('the view while the picker is open', () => {
+  test('reports whether it is open, so the route fit can stand down', () => {
+    const { wiring, picker } = build();
+    expect(wiring.isOpen()).toBe(false);
+    wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    expect(wiring.isOpen()).toBe(true);
+    picker.isOpen.mockClear();
+    wiring.isOpen();
+    expect(picker.isOpen).toHaveBeenCalled();
+  });
+
+  test('re-framing is delegated to the picker', () => {
+    const { wiring, picker } = build();
+    wiring.focusView();
+    expect(picker.focusView).toHaveBeenCalled();
+  });
+
+  test('hide closes the picker, which is what a splice or a drag does', () => {
+    const { wiring, picker } = build();
+    wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    wiring.hide();
+    expect(picker.hide).toHaveBeenCalled();
+    expect(wiring.isOpen()).toBe(false);
+  });
+});
+
+describe('waypointName', () => {
+  test('names a door through the wiring\u2019s own translator', () => {
+    const de = (k) => ({ 'main entrance': 'Haupteingang' }[k] || k);
+    const { wiring } = build({ options: { translate: de } });
+    expect(wiring.waypointName('Alexa', MAIN)).toBe('Alexa (Haupteingang)');
+    expect(wiring.waypointName('Alexa', null)).toBe('Alexa');
+  });
+});

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -17,7 +17,8 @@ jest.mock('leaflet', () => ({
   DomEvent: { stopPropagation() {} }
 }));
 
-const { createEntranceWaypoints, entranceWaypointName, waypointMarkerLatLng } =
+const { createEntranceWaypoints, entranceWaypointName, waypointMarkerLatLng,
+  createReverseNotifier } =
   require('../src/entrance_waypoints');
 
 const MAIN = { osmId: 1, type: 'main', center: { lat: 52.5209566, lng: 13.3965227 } };
@@ -51,12 +52,31 @@ function makeFakePicker() {
   const picker = {
     shown: [],
     hidden: 0,
+    // Waypoint indices withdrawn one at a time, in order.
+    hiddenWaypoints: [],
+    // Which waypoints currently have an offer, as the real picker tracks.
+    openFor: new Set(),
     open: false,
     onSelect: null,
     options: null,
-    show: jest.fn(function(opts) { picker.shown.push(opts); picker.open = true; return true; }),
-    hide: jest.fn(function() { picker.hidden++; picker.open = false; }),
+    show: jest.fn(function(opts) {
+      picker.shown.push(opts);
+      picker.openFor.add(opts.waypointIndex);
+      picker.open = true;
+      return true;
+    }),
+    hide: jest.fn(function() {
+      picker.hidden++;
+      picker.openFor.clear();
+      picker.open = false;
+    }),
+    hideWaypoint: jest.fn(function(waypointIndex) {
+      picker.hiddenWaypoints.push(waypointIndex);
+      picker.openFor.delete(waypointIndex);
+      picker.open = picker.openFor.size > 0;
+    }),
     isOpen: jest.fn(() => picker.open),
+    isOpenFor: jest.fn((waypointIndex) => picker.openFor.has(waypointIndex)),
     focusView: jest.fn()
   };
   return picker;
@@ -167,24 +187,49 @@ describe('a geocoding result', () => {
     expect(picker.shown[0].placeBounds).toBe(e.value.bbox);
   });
 
-  test('closes the picker for a place with no entrances', () => {
+  test('withdraws only that waypoint for a place with no entrances', () => {
     const { wiring, picker } = build();
     expect(wiring.onGeocodeResult(geocodeEvent(undefined))).toBe(false);
-    expect(picker.hide).toHaveBeenCalled();
+    expect(picker.hiddenWaypoints).toEqual([1]);
+    expect(picker.hide).not.toHaveBeenCalled();
     expect(picker.show).not.toHaveBeenCalled();
+  });
+
+  test("a doorless start leaves the destination's doors alone", () => {
+    // The reported bug: naming a start wiped the dots the destination was
+    // already showing, because one shared offer served every waypoint.
+    const plan = makePlan(2);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1 }));
+    expect(picker.isOpenFor(1)).toBe(true);
+
+    wiring.onGeocodeResult(geocodeEvent(undefined, { waypointIndex: 0 }));
+    expect(picker.hiddenWaypoints).toEqual([0]);
+    expect(picker.hide).not.toHaveBeenCalled();
+    expect(picker.isOpenFor(1)).toBe(true);
+  });
+
+  test('two waypoints can offer their doors at the same time', () => {
+    const plan = makePlan(2);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1 }));
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 0 }));
+    expect(picker.isOpenFor(0)).toBe(true);
+    expect(picker.isOpenFor(1)).toBe(true);
+    expect(picker.hide).not.toHaveBeenCalled();
   });
 
   test('closes the picker when the result itself is missing', () => {
     const { wiring, picker } = build();
     expect(wiring.onGeocodeResult({ waypointIndex: 0, value: null })).toBe(false);
-    expect(picker.hide).toHaveBeenCalled();
+    expect(picker.hiddenWaypoints).toEqual([0]);
   });
 
   test('closes the picker when every entrance is unusable', () => {
     const service = { osmId: 9, type: 'service', center: { lat: 1, lng: 1 } };
     const { wiring, picker } = build();
     expect(wiring.onGeocodeResult(geocodeEvent([service]))).toBe(false);
-    expect(picker.hide).toHaveBeenCalled();
+    expect(picker.hiddenWaypoints).toEqual([1]);
   });
 
   // The direction a door has to work in comes from which end of the route the
@@ -260,7 +305,7 @@ describe('the travel mode', () => {
 
     mode = 'driving';
     expect(wiring.refresh()).toBe(false);
-    expect(picker.hide).toHaveBeenCalled();
+    expect(picker.hiddenWaypoints).toEqual([1]);
     expect(picker.isOpen()).toBe(false);
   });
 
@@ -410,5 +455,175 @@ describe('waypointName', () => {
     const { wiring } = build({ options: { translate: de } });
     expect(wiring.waypointName('Alexa', MAIN)).toBe('Alexa (Haupteingang)');
     expect(wiring.waypointName('Alexa', null)).toBe('Alexa');
+  });
+});
+
+describe('createReverseNotifier', () => {
+  // A reverse result: same shape a search returns, entrances included.
+  const at = (lat, lng, extra) => Object.assign({
+    lat: lat, lng: lng,
+    distanceTo(other) {
+      // Metres, near enough for a test: ~111km per degree.
+      return Math.hypot(this.lat - other.lat, this.lng - other.lng) * 111000;
+    }
+  }, extra);
+
+  function build(overrides) {
+    const fired = [];
+    const waypoints = (overrides && overrides.waypoints) || [
+      { latLng: at(52.5, 13.4), name: '' }
+    ];
+    const plan = { _waypoints: waypoints, fire: (name, e) => fired.push({ name, e }) };
+    const calls = [];
+    const geocoder = {
+      geocode: function() { return 'geocode'; },
+      suggest: function() { return 'suggest'; },
+      fetchOutline: function() { return 'outline'; },
+      reverse: function(latLng, scale, cb, context) {
+        calls.push({ latLng, scale });
+        const results = (overrides && overrides.results !== undefined)
+          ? overrides.results
+          : [{ name: 'Somewhere', center: at(52.5, 13.4), entrances: [{ osmId: 1 }] }];
+        cb.call(context, results);
+        return 'promise';
+      }
+    };
+    const wrapped = createReverseNotifier({
+      geocoder: geocoder,
+      getPlan: () => plan,
+      tolerance: overrides && overrides.tolerance
+    });
+    return { wrapped, fired, calls, plan, geocoder };
+  }
+
+  test('re-fires the reverse result at the waypoint it belongs to', () => {
+    // This is the whole point: LRM names a restored waypoint by reverse
+    // geocoding and never fires `geocoded`, so the entrance list is lost.
+    const { wrapped, fired } = build();
+    wrapped.reverse(at(52.5, 13.4), 100, () => {});
+    expect(fired).toHaveLength(1);
+    expect(fired[0].name).toBe('waypointgeocoderesult');
+    expect(fired[0].e.waypointIndex).toBe(0);
+    expect(fired[0].e.value.entrances).toEqual([{ osmId: 1 }]);
+  });
+
+  test('finds the right waypoint among several', () => {
+    const { wrapped, fired } = build({
+      waypoints: [
+        { latLng: at(1, 1), name: '' },
+        { latLng: at(52.5, 13.4), name: '' },
+        { latLng: at(2, 2), name: '' }
+      ]
+    });
+    wrapped.reverse(at(52.5, 13.4), 100, () => {});
+    expect(fired[0].e.waypointIndex).toBe(1);
+    expect(fired[0].e.waypoint).toBe(fired[0].e.waypoint);
+  });
+
+  test("calls LRM's own callback first, so the waypoint is named before the offer", () => {
+    const { wrapped, fired } = build();
+    const order = [];
+    wrapped.reverse(at(52.5, 13.4), 100, function() { order.push('lrm'); });
+    order.push('fired:' + fired.length);
+    expect(order).toEqual(['lrm', 'fired:1']);
+  });
+
+  test('honours the callback context and returns what the geocoder returned', () => {
+    const { wrapped } = build();
+    const ctx = { seen: null };
+    const out = wrapped.reverse(at(52.5, 13.4), 100, function(r) { this.seen = r; }, ctx);
+    expect(ctx.seen[0].name).toBe('Somewhere');
+    expect(out).toBe('promise');
+  });
+
+  test('stays silent when the nearest place is beyond LRM tolerance', () => {
+    // LRM labels the waypoint with bare coordinates there, so offering that
+    // place's doors would offer doors of somewhere the user did not pick.
+    const { wrapped, fired } = build({
+      results: [{ name: 'Far away', center: at(52.6, 13.4), entrances: [{ osmId: 1 }] }]
+    });
+    wrapped.reverse(at(52.5, 13.4), 100, () => {});
+    expect(fired).toHaveLength(0);
+  });
+
+  test('respects a tolerance supplied by the caller', () => {
+    const far = [{ name: 'Down the road', center: at(52.5009, 13.4), entrances: [] }];
+    expect(build({ results: far, tolerance: 50 }).wrapped
+      .reverse(at(52.5, 13.4), 100, () => {}) && build({ results: far, tolerance: 50 }).fired)
+      .toHaveLength(0);
+
+    const near = build({ results: far, tolerance: 1000 });
+    near.wrapped.reverse(at(52.5, 13.4), 100, () => {});
+    expect(near.fired).toHaveLength(1);
+  });
+
+  test('matches the waypoint by identity, not only by coordinates', () => {
+    // LRM passes wp.latLng straight through, so the common case is the very
+    // same object; equality by value is the fallback for a rebuilt one.
+    const same = at(52.5, 13.4);
+    const { wrapped, fired } = build({ waypoints: [{ latLng: same, name: '' }] });
+    wrapped.reverse(same, 100, () => {});
+    expect(fired[0].e.waypointIndex).toBe(0);
+  });
+
+  test('skips a waypoint that has no position yet', () => {
+    const { wrapped, fired } = build({
+      waypoints: [{ latLng: null, name: '' }, { latLng: at(52.5, 13.4), name: '' }]
+    });
+    wrapped.reverse(at(52.5, 13.4), 100, () => {});
+    expect(fired[0].e.waypointIndex).toBe(1);
+  });
+
+  test('stays silent for coordinates that are not a waypoint', () => {
+    // A close-enough result, so the tolerance check passes and the lookup
+    // itself is what rejects it.
+    const { wrapped, fired } = build({
+      results: [{ name: 'Elsewhere', center: at(10, 10), entrances: [{ osmId: 9 }] }],
+      waypoints: [{ latLng: at(52.5, 13.4), name: '' }]
+    });
+    wrapped.reverse(at(10, 10), 100, () => {});
+    expect(fired).toHaveLength(0);
+  });
+
+  test('stays silent when reverse finds nothing', () => {
+    const { wrapped, fired } = build({ results: [] });
+    wrapped.reverse(at(52.5, 13.4), 100, () => {});
+    expect(fired).toHaveLength(0);
+  });
+
+  test('a result without a centre cannot be matched, and is skipped', () => {
+    const { wrapped, fired } = build({ results: [{ name: 'No centre' }] });
+    wrapped.reverse(at(52.5, 13.4), 100, () => {});
+    expect(fired).toHaveLength(0);
+  });
+
+  test('the rest of the geocoder is passed through untouched', () => {
+    const { wrapped } = build();
+    expect(wrapped.geocode()).toBe('geocode');
+    expect(wrapped.suggest()).toBe('suggest');
+    expect(wrapped.fetchOutline()).toBe('outline');
+  });
+
+  test('a geocoder that cannot reverse is returned as it is', () => {
+    const bare = { geocode: () => 'x' };
+    expect(createReverseNotifier({ geocoder: bare })).toBe(bare);
+    expect(createReverseNotifier({})).toBeUndefined();
+  });
+
+  test('a plan that is not ready yet is not an error', () => {
+    const { wrapped, fired } = (() => {
+      const geocoder = {
+        reverse: (latLng, scale, cb, context) => {
+          cb.call(context, [{ name: 'X', center: at(52.5, 13.4) }]);
+        }
+      };
+      const fired = [];
+      const wrapped = createReverseNotifier({
+        geocoder, getPlan: () => undefined
+      });
+      return { wrapped, fired };
+    })();
+    expect(() => wrapped.reverse(at(52.5, 13.4), 100, () => {})).not.toThrow();
+    expect(fired).toHaveLength(0);
   });
 });

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -311,6 +311,19 @@ describe('the travel mode', () => {
     expect(picker.shown[1].entrances).toEqual([MAIN]);
   });
 
+  test('a fresh geocode frames its doors; a refresh redraws them where they are', () => {
+    // Switching profile recomputes the route; the map must not jump back to
+    // the doors for that.
+    let mode = 'foot';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN, NO_CARS]));
+    expect(picker.shown[0].frame).toBe(true);
+
+    mode = 'driving';
+    wiring.refresh();
+    expect(picker.shown[1].frame).toBe(false);
+  });
+
   test('a refresh that leaves no usable door closes the picker', () => {
     let mode = 'foot';
     const { wiring, picker } = build({ options: { mode: () => mode } });
@@ -446,12 +459,6 @@ describe('the view while the picker is open', () => {
     picker.isOpen.mockClear();
     wiring.isOpen();
     expect(picker.isOpen).toHaveBeenCalled();
-  });
-
-  test('re-framing is delegated to the picker', () => {
-    const { wiring, picker } = build();
-    wiring.focusView();
-    expect(picker.focusView).toHaveBeenCalled();
   });
 
   test('hide closes the picker, which is what a splice or a drag does', () => {
@@ -717,6 +724,18 @@ describe('splicing the waypoint list', () => {
     expect(picker.hiddenWaypoints).toContain(1);
   });
 
+  test('a role change redraws the doors without moving the view', () => {
+    const plan = makePlan(2);
+    const [first, second] = plan._waypoints;
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1, waypoint: second }));
+
+    plan._waypoints.reverse();
+    wiring.spliceWaypoints({ index: 0, nRemoved: 2, added: [second, first] });
+
+    expect(picker.shown[picker.shown.length - 1].frame).toBe(false);
+  });
+
   test('a splice that leaves the roles alone does not re-offer anything', () => {
     const plan = makePlan(3);
     const { wiring, picker } = build({ plan });
@@ -754,5 +773,49 @@ describe('splicing the waypoint list', () => {
     expect(picker.hiddenWaypoints).toEqual([1]);
     expect(picker.hide).not.toHaveBeenCalled();
     expect(picker.isOpenFor(0)).toBe(true);
+  });
+});
+
+describe('claimView', () => {
+  // The route that follows the geocode which opened a picker must not fit
+  // itself over the doors the picker just framed. Any other route — for a
+  // new via point, a profile change, a reorder — is not the picker's doing.
+  test('the geocode that frames the doors claims the next route, once', () => {
+    const { wiring } = build();
+    expect(wiring.claimView()).toBe(false);
+    wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    expect(wiring.claimView()).toBe(true);
+    expect(wiring.claimView()).toBe(false);
+  });
+
+  test('a geocode with no usable door claims nothing', () => {
+    const { wiring } = build();
+    wiring.onGeocodeResult(geocodeEvent([]));
+    expect(wiring.claimView()).toBe(false);
+  });
+
+  test('a refresh does not claim the route it triggers', () => {
+    let mode = 'foot';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    wiring.claimView();
+
+    mode = 'driving';
+    expect(wiring.refresh()).toBe(true);
+    expect(picker.shown).toHaveLength(2);
+    expect(wiring.claimView()).toBe(false);
+  });
+
+  test('a splice that changes a role does not claim the route it triggers', () => {
+    const plan = makePlan(2);
+    const [first, second] = plan._waypoints;
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1, waypoint: second }));
+    wiring.claimView();
+
+    plan._waypoints.reverse();
+    wiring.spliceWaypoints({ index: 0, nRemoved: 2, added: [second, first] });
+    expect(picker.shown.length).toBeGreaterThan(1);
+    expect(wiring.claimView()).toBe(false);
   });
 });

--- a/test/geocoder.test.js
+++ b/test/geocoder.test.js
@@ -30,7 +30,11 @@ describe('geocoder.coordPreserving', () => {
     const L = require('leaflet');
 
     const g = geocoder.coordPreserving('https://nominatim.example/');
-    expect(L.Control.Geocoder.nominatim).toHaveBeenCalledWith({ serviceUrl: 'https://nominatim.example/' });
+    expect(L.Control.Geocoder.nominatim).toHaveBeenCalledWith({
+      serviceUrl: 'https://nominatim.example/',
+      geocodingQueryParams: { entrances: 1 },
+      reverseQueryParams: { entrances: 1 }
+    });
 
     const results = await g.geocode('34.129382,-118.141254');
     expect(results).toHaveLength(1);
@@ -61,7 +65,12 @@ describe('geocoder.coordPreserving', () => {
     // Call without argument to ensure default nominatim factory is used
     geocoder.coordPreserving();
     expect(L.Control.Geocoder.nominatim).toHaveBeenCalled();
-    expect(L.Control.Geocoder.nominatim.mock.calls[0].length).toBe(0);
+    // No serviceUrl, so leaflet-control-geocoder keeps its own default endpoint;
+    // the entrance parameters are still requested.
+    expect(L.Control.Geocoder.nominatim).toHaveBeenCalledWith({
+      geocodingQueryParams: { entrances: 1 },
+      reverseQueryParams: { entrances: 1 }
+    });
   });
 
   // Tests for reverse-geocode coordinate wrapping (issues #206, #307).
@@ -248,5 +257,216 @@ describe('geocoder.wrappedWaypointNameFallback', () => {
     const latLng = { lat: -33.9, lng: -70.6, wrap: () => ({ lat: -33.9, lng: -70.6 }) };
     const result = geocoder.wrappedWaypointNameFallback(latLng);
     expect(result).toBe('S33.9, W70.6');
+  });
+});
+
+// Nominatim 5.2+ returns a place's entrance nodes when asked for them. These
+// must survive every path a result can take to the UI, or the entrance picker
+// has nothing to offer.
+describe('geocoder entrance handling', () => {
+  const BER_ENTRANCES = [
+    { osm_id: 9942967218, type: 'main', lat: '52.3636100', lon: '13.5100542' },
+    { osm_id: 9959231437, type: 'main', lat: '52.3641971', lon: '13.5096892' }
+  ];
+
+  function mockLeaflet() {
+    jest.doMock('leaflet', () => ({
+      Control: { Geocoder: { nominatim: jest.fn(() => ({})) } },
+      CRS: { EPSG3857: { scale: () => 1 } },
+      latLng: (lat, lng) => {
+        const obj = { lat: +lat, lng: +lng, toBounds: () => ({}) };
+        obj.wrap = () => obj;
+        return obj;
+      },
+      latLngBounds: (sw, ne) => ({ sw, ne }),
+      extend: Object.assign
+    }));
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.localStorage = {
+      getItem: () => null,
+      setItem: () => {}
+    };
+  });
+
+  afterEach(() => {
+    delete global.localStorage;
+    delete global.fetch;
+  });
+
+  test('requests entrances and parses them off the search response', async () => {
+    mockLeaflet();
+    let requestedUrl = null;
+    global.fetch = jest.fn((url) => {
+      requestedUrl = url;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([{
+          display_name: 'Flughafen Berlin Brandenburg',
+          lat: '52.3657974',
+          lon: '13.4888906',
+          entrances: BER_ENTRANCES
+        }])
+      });
+    });
+
+    const geocoder = require('../src/geocoder');
+    const results = await geocoder.coordPreserving('https://nominatim.example/').geocode('BER');
+
+    expect(requestedUrl).toContain('entrances=1');
+    expect(results[0].entrances).toEqual([
+      { osmId: 9942967218, type: 'main', center: expect.objectContaining({ lat: 52.36361, lng: 13.5100542 }) },
+      { osmId: 9959231437, type: 'main', center: expect.objectContaining({ lat: 52.3641971, lng: 13.5096892 }) }
+    ]);
+  });
+
+  test('lifts entrances off the raw payload leaflet-control-geocoder preserves', async () => {
+    jest.doMock('leaflet', () => ({
+      Control: {
+        Geocoder: {
+          nominatim: jest.fn(() => ({
+            geocode: () => Promise.resolve([{
+              name: 'Flughafen Berlin Brandenburg',
+              center: { lat: 52.3657974, lng: 13.4888906 },
+              properties: { entrances: BER_ENTRANCES }
+            }])
+          }))
+        }
+      },
+      CRS: { EPSG3857: { scale: () => 1 } },
+      latLng: (lat, lng) => ({ lat: +lat, lng: +lng }),
+      latLngBounds: (sw, ne) => ({ sw, ne }),
+      extend: Object.assign
+    }));
+
+    const geocoder = require('../src/geocoder');
+    const results = await geocoder.coordPreserving('https://nominatim.example/').geocode('BER');
+
+    expect(results[0].entrances).toHaveLength(2);
+    expect(results[0].entrances[0].type).toBe('main');
+  });
+
+  test('a typed coordinate keeps its exact position and is offered no entrances', async () => {
+    jest.doMock('leaflet', () => ({
+      Control: {
+        Geocoder: {
+          nominatim: jest.fn(() => ({
+            reverse: () => Promise.resolve([{
+              name: 'Flughafen Berlin Brandenburg',
+              center: { lat: 52.3657974, lng: 13.4888906 },
+              properties: { entrances: BER_ENTRANCES }
+            }])
+          }))
+        }
+      },
+      CRS: { EPSG3857: { scale: () => 1 } },
+      latLng: (lat, lng) => {
+        const obj = { lat: +lat, lng: +lng, toBounds: () => ({}) };
+        obj.wrap = () => obj;
+        return obj;
+      },
+      latLngBounds: (sw, ne) => ({ sw, ne }),
+      extend: Object.assign
+    }));
+
+    const geocoder = require('../src/geocoder');
+    const results = await geocoder.coordPreserving('https://nominatim.example/')
+      .geocode('52.3657974,13.4888906');
+
+    expect(results[0].center.lat).toBeCloseTo(52.3657974);
+    expect(results[0].entrances).toBeUndefined();
+  });
+});
+
+// Entrance nodes carry no geometry of their own, so the site they belong to is
+// outlined instead. Its polygon is fetched separately, never as part of search.
+describe('geocoder.fetchOutline', () => {
+  function mockLeaflet() {
+    jest.doMock('leaflet', () => ({
+      Control: { Geocoder: { nominatim: jest.fn(() => ({})) } },
+      CRS: { EPSG3857: { scale: () => 1 } },
+      latLng: (lat, lng) => ({ lat: +lat, lng: +lng }),
+      latLngBounds: (sw, ne) => ({ sw, ne }),
+      extend: Object.assign
+    }));
+  }
+
+  const POLYGON = { type: 'Polygon', coordinates: [[[13.45, 52.34], [13.53, 52.34], [13.53, 52.39], [13.45, 52.34]]] };
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+  });
+
+  afterEach(() => {
+    delete global.localStorage;
+    delete global.fetch;
+  });
+
+  function respondWith(body) {
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve(body)
+    }));
+  }
+
+  test('looks the place up by OSM id and returns its polygon', async () => {
+    mockLeaflet();
+    respondWith([{ geojson: POLYGON }]);
+    const geocoder = require('../src/geocoder');
+
+    const outline = await geocoder.coordPreserving('https://nominatim.example/')
+      .fetchOutline({ osmType: 'way', osmId: 859790021 });
+
+    expect(outline).toEqual(POLYGON);
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toContain('lookup?');
+    expect(url).toContain('osm_ids=W859790021');
+    expect(url).toContain('polygon_geojson=1');
+    // No polygon_threshold: its tolerance is absolute degrees, so a value that
+    // usefully thins an airport flattens a building into a few stray corners.
+    expect(url).not.toContain('polygon_threshold');
+  });
+
+  test('caches by place so reopening the picker costs no request', async () => {
+    mockLeaflet();
+    respondWith([{ geojson: POLYGON }]);
+    const geocoder = require('../src/geocoder');
+    const g = geocoder.coordPreserving('https://nominatim.example/');
+
+    await g.fetchOutline({ osmType: 'way', osmId: 1 });
+    await g.fetchOutline({ osmType: 'way', osmId: 1 });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns null for a place with no area', async () => {
+    mockLeaflet();
+    respondWith([{ geojson: { type: 'Point', coordinates: [13.5, 52.3] } }]);
+    const geocoder = require('../src/geocoder');
+
+    expect(await geocoder.coordPreserving('https://nominatim.example/')
+      .fetchOutline({ osmType: 'node', osmId: 42 })).toBeNull();
+  });
+
+  test('returns null without requesting anything when the result has no OSM id', async () => {
+    mockLeaflet();
+    respondWith([{ geojson: POLYGON }]);
+    const geocoder = require('../src/geocoder');
+
+    expect(await geocoder.coordPreserving('https://nominatim.example/')
+      .fetchOutline({ name: 'somewhere' })).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('a failed lookup is not fatal — the picker just shows no outline', async () => {
+    mockLeaflet();
+    global.fetch = jest.fn(() => Promise.reject(new Error('offline')));
+    const geocoder = require('../src/geocoder');
+
+    expect(await geocoder.coordPreserving('https://nominatim.example/')
+      .fetchOutline({ osmType: 'relation', osmId: 7 })).toBeNull();
   });
 });

--- a/test/geocoder_cache.test.js
+++ b/test/geocoder_cache.test.js
@@ -75,10 +75,10 @@ describe('geocoder cache', function() {
     expect(ctx.input.style.backgroundColor).toBe('white');
 
     // persisted cache should contain the search URL key
-    var raw = localStorage.getItem('osrm_nominatim_cache_v1');
+    var raw = localStorage.getItem('osrm_nominatim_cache_v2');
     expect(raw).toBeTruthy();
     var entries = JSON.parse(raw);
-    var expectedUrl = 'https://nominatim.example/search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('Somewhere');
+    var expectedUrl = 'https://nominatim.example/search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent('Somewhere');
     var found = entries.find(function(e) { return e[0] === expectedUrl; });
     expect(found).toBeDefined();
   });
@@ -107,10 +107,10 @@ describe('geocoder cache', function() {
   test('expires old entries on load (TTL)', async function() {
     // create an expired entry in localStorage before the cache is created
     var q = 'OldPlace';
-    var url = 'https://nominatim.example/search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent(q);
+    var url = 'https://nominatim.example/search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent(q);
     var oldTs = Date.now() - (24 * 60 * 60 * 1000) - 1000; // older than 24h
     var stored = [[url, { value: [{ name: 'Old', center: { lat: 11, lng: 22 } }], ts: oldTs }]];
-    localStorage.setItem('osrm_nominatim_cache_v1', JSON.stringify(stored));
+    localStorage.setItem('osrm_nominatim_cache_v2', JSON.stringify(stored));
 
     jest.resetModules();
     jest.doMock('leaflet', function() {
@@ -138,10 +138,10 @@ describe('geocoder cache', function() {
     // Seed a cache entry that is 23h old (within 24h TTL)
     var q = 'SlidingPlace';
     var service = 'https://nominatim.example/';
-    var url = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent(q);
+    var url = service + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent(q);
     var almostExpiredTs = Date.now() - (23 * 60 * 60 * 1000); // 23h ago
     var stored = [[url, { value: [{ name: 'Sliding', center: { lat: 1, lng: 2 } }], ts: almostExpiredTs }]];
-    localStorage.setItem('osrm_nominatim_cache_v1', JSON.stringify(stored));
+    localStorage.setItem('osrm_nominatim_cache_v2', JSON.stringify(stored));
 
     jest.resetModules();
     // Use fake timers to make timestamp assertions deterministic
@@ -169,7 +169,7 @@ describe('geocoder cache', function() {
     jest.advanceTimersByTime(1000);
 
     // The timestamp in localStorage should now be refreshed to the fake 'now'
-    var raw = JSON.parse(localStorage.getItem('osrm_nominatim_cache_v1'));
+    var raw = JSON.parse(localStorage.getItem('osrm_nominatim_cache_v2'));
     var entry = raw.find(function(e) { return e[0] === url; });
     expect(entry).toBeDefined();
     var refreshedTs = entry[1].ts;
@@ -185,10 +185,10 @@ describe('geocoder cache', function() {
     var now = Date.now();
     var entries = [];
     for (var i = 0; i < 128; i++) {
-      var u = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('q' + i);
+      var u = service + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent('q' + i);
       entries.push([u, { value: [{ name: 'P' + i, center: { lat: i, lng: i } }], ts: now }]);
     }
-    localStorage.setItem('osrm_nominatim_cache_v1', JSON.stringify(entries));
+    localStorage.setItem('osrm_nominatim_cache_v2', JSON.stringify(entries));
 
     jest.resetModules();
     jest.doMock('leaflet', function() { return makeLeafletMock(); });
@@ -204,14 +204,14 @@ describe('geocoder cache', function() {
 
     var res = await g.geocode('NewPlace', undefined, ctx);
 
-    var raw = localStorage.getItem('osrm_nominatim_cache_v1');
+    var raw = localStorage.getItem('osrm_nominatim_cache_v2');
     expect(raw).toBeTruthy();
     var arr = JSON.parse(raw);
     // ensure size capped at 128 and oldest (q0) removed while NewPlace present
     expect(arr.length).toBeLessThanOrEqual(128);
-    var firstExpected = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('q0');
+    var firstExpected = service + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent('q0');
     expect(arr.find(function(e) { return e[0] === firstExpected; })).toBeUndefined();
-    var newUrl = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('NewPlace');
+    var newUrl = service + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent('NewPlace');
     expect(arr.find(function(e) { return e[0] === newUrl; })).toBeDefined();
   });
 
@@ -269,10 +269,10 @@ describe('geocoder cache', function() {
     var now = Date.now();
     var entries = [];
     for (var i = 0; i < 3; i++) {
-      var u = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('q' + i);
+      var u = service + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent('q' + i);
       entries.push([u, { value: [{ name: 'P' + i, center: { lat: i, lng: i } }], ts: now }]);
     }
-    localStorage.setItem('osrm_nominatim_cache_v1', JSON.stringify(entries));
+    localStorage.setItem('osrm_nominatim_cache_v2', JSON.stringify(entries));
 
     jest.resetModules();
     jest.doMock('leaflet', function() {
@@ -290,12 +290,12 @@ describe('geocoder cache', function() {
     await g.geocode('q0', undefined, ctx);
 
     // Check that localStorage now has q0 last (MRU)
-    var raw = JSON.parse(localStorage.getItem('osrm_nominatim_cache_v1'));
+    var raw = JSON.parse(localStorage.getItem('osrm_nominatim_cache_v2'));
     var keys = raw.map(function(e) { return e[0]; });
-    var q0Url = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('q0');
+    var q0Url = service + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent('q0');
     expect(keys[keys.length - 1]).toBe(q0Url);
     // q1 should now be the first (LRU) entry
-    var q1Url = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('q1');
+    var q1Url = service + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent('q1');
     expect(keys[0]).toBe(q1Url);
   });
 
@@ -305,10 +305,10 @@ describe('geocoder cache', function() {
     var now = Date.now();
     var entries = [];
     for (var i = 0; i < 140; i++) {
-      var u = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('over' + i);
+      var u = service + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent('over' + i);
       entries.push([u, { value: [{ name: 'P' + i, center: { lat: i, lng: i } }], ts: now }]);
     }
-    localStorage.setItem('osrm_nominatim_cache_v1', JSON.stringify(entries));
+    localStorage.setItem('osrm_nominatim_cache_v2', JSON.stringify(entries));
 
     jest.resetModules();
     jest.doMock('leaflet', function() {
@@ -327,10 +327,10 @@ describe('geocoder cache', function() {
     var ctx = { input: { style: {} } };
     await g.geocode('over139', undefined, ctx);
 
-    var raw = JSON.parse(localStorage.getItem('osrm_nominatim_cache_v1'));
+    var raw = JSON.parse(localStorage.getItem('osrm_nominatim_cache_v2'));
     expect(raw.length).toBeLessThanOrEqual(128);
     // The oldest entries (over0..over11) should have been evicted
-    var firstUrl = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('over0');
+    var firstUrl = service + 'search?format=json&addressdetails=1&entrances=1&limit=5&q=' + encodeURIComponent('over0');
     expect(raw.find(function(e) { return e[0] === firstUrl; })).toBeUndefined();
   });
 
@@ -364,7 +364,7 @@ describe('geocoder cache', function() {
 
     await g.geocode('BboxPlace', undefined, ctx);
 
-    var raw = JSON.parse(localStorage.getItem('osrm_nominatim_cache_v1'));
+    var raw = JSON.parse(localStorage.getItem('osrm_nominatim_cache_v2'));
     expect(raw.length).toBe(1);
     var cached = raw[0][1].value[0];
     // bbox should be stored as canonical [south, north, west, east] array

--- a/test/geocoder_entrances.test.js
+++ b/test/geocoder_entrances.test.js
@@ -1,0 +1,310 @@
+'use strict';
+
+/**
+ * The entrance data's journey through the geocoder: off the wire, through both
+ * request paths, into the persisted cache and back out again with usable
+ * Leaflet coordinates. A break anywhere along here leaves the picker with
+ * nothing to offer, and does so silently.
+ */
+
+// A real store, so a value written by one module instance can be read back by
+// the next — which is what the persistence tests turn on.
+function installLocalStorage() {
+  var store = Object.create(null);
+  global.localStorage = {
+    getItem: (k) => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+    clear: () => { store = Object.create(null); }
+  };
+  return () => store;
+}
+
+function leafletMock(nominatimImpl) {
+  return {
+    Control: { Geocoder: { nominatim: jest.fn(() => nominatimImpl || {}) } },
+    CRS: { EPSG3857: { scale: () => 1 } },
+    latLng: (lat, lng) => {
+      const o = { lat: +lat, lng: +lng, _leaflet: true, toBounds: () => ({}) };
+      o.wrap = () => o;
+      return o;
+    },
+    latLngBounds: (sw, ne) => ({ sw, ne, _leaflet: true }),
+    extend: Object.assign
+  };
+}
+
+const BER_ENTRANCES = [
+  { osm_id: 9942967218, type: 'main', lat: '52.3636100', lon: '13.5100542' },
+  { osm_id: 9959231437, type: 'exit', lat: '52.3641971', lon: '13.5096892' }
+];
+
+let readStore;
+
+beforeEach(() => {
+  jest.resetModules();
+  readStore = installLocalStorage();
+});
+
+afterEach(() => {
+  delete global.localStorage;
+  delete global.fetch;
+});
+
+describe('search results', () => {
+  test('entrances and OSM identity survive the fetch path', async () => {
+    jest.doMock('leaflet', () => leafletMock({}));
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([{
+        display_name: 'Flughafen BER',
+        osm_type: 'way',
+        osm_id: 859790021,
+        lat: '52.3657974',
+        lon: '13.4888906',
+        entrances: BER_ENTRANCES
+      }])
+    }));
+
+    const results = await require('../src/geocoder')
+      .coordPreserving('https://nominatim.example/').geocode('BER');
+
+    expect(results[0].osmType).toBe('way');
+    expect(results[0].osmId).toBe(859790021);
+    expect(results[0].entrances).toHaveLength(2);
+    expect(results[0].entrances[1]).toEqual({
+      osmId: 9959231437,
+      type: 'exit',
+      center: expect.objectContaining({ lat: 52.3641971, lng: 13.5096892 })
+    });
+  });
+
+  test('an entrance missing coordinates is dropped, not carried as NaN', async () => {
+    jest.doMock('leaflet', () => leafletMock({}));
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true, status: 200,
+      json: () => Promise.resolve([{
+        display_name: 'X', lat: '1', lon: '2',
+        entrances: [
+          { osm_id: 1, type: 'main', lat: 'nonsense', lon: '13.5' },
+          { osm_id: 2, type: 'main', lat: '52.4', lon: '13.5' }
+        ]
+      }])
+    }));
+
+    const results = await require('../src/geocoder')
+      .coordPreserving('https://nominatim.example/').geocode('X');
+    expect(results[0].entrances.map((e) => e.osmId)).toEqual([2]);
+  });
+
+  test('a place with an empty entrance list carries none at all', async () => {
+    jest.doMock('leaflet', () => leafletMock({}));
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true, status: 200,
+      json: () => Promise.resolve([{ display_name: 'X', lat: '1', lon: '2', entrances: [] }])
+    }));
+
+    const results = await require('../src/geocoder')
+      .coordPreserving('https://nominatim.example/').geocode('X');
+    // null rather than [], so the picker's "has entrances" check stays simple.
+    expect(results[0].entrances).toBeUndefined();
+  });
+
+  test('a type Nominatim did not label defaults to the generic value', async () => {
+    jest.doMock('leaflet', () => leafletMock({}));
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true, status: 200,
+      json: () => Promise.resolve([{
+        display_name: 'X', lat: '1', lon: '2',
+        entrances: [{ osm_id: 1, lat: '52.4', lon: '13.5' }]
+      }])
+    }));
+
+    const results = await require('../src/geocoder')
+      .coordPreserving('https://nominatim.example/').geocode('X');
+    expect(results[0].entrances[0].type).toBe('yes');
+  });
+});
+
+describe('reverse geocoding', () => {
+  test('carries entrances when the fetch path is used', async () => {
+    jest.doMock('leaflet', () => leafletMock({}));
+    let url = null;
+    global.fetch = jest.fn((u) => {
+      url = u;
+      return Promise.resolve({
+        ok: true, status: 200,
+        json: () => Promise.resolve({
+          display_name: 'Flughafen BER',
+          osm_type: 'way', osm_id: 859790021,
+          lat: '52.3657974', lon: '13.4888906',
+          entrances: BER_ENTRANCES
+        })
+      });
+    });
+
+    const g = require('../src/geocoder').coordPreserving('https://nominatim.example/');
+    const results = await g.reverse({ lat: 52.3657974, lng: 13.4888906 }, 1);
+
+    expect(url).toContain('reverse?');
+    expect(url).toContain('entrances=1');
+    expect(results[0].entrances).toHaveLength(2);
+    expect(results[0].osmType).toBe('way');
+  });
+
+  test('lifts entrances off the payload leaflet-control-geocoder preserves', async () => {
+    jest.doMock('leaflet', () => leafletMock({
+      reverse: () => Promise.resolve([{
+        name: 'Flughafen BER',
+        center: { lat: 52.3657974, lng: 13.4888906 },
+        properties: { osm_type: 'way', osm_id: 859790021, entrances: BER_ENTRANCES }
+      }])
+    }));
+
+    const g = require('../src/geocoder').coordPreserving('https://nominatim.example/');
+    const results = await g.reverse({ lat: 52.3657974, lng: 13.4888906 }, 1);
+
+    expect(results[0].entrances).toHaveLength(2);
+    expect(results[0].osmId).toBe(859790021);
+  });
+
+  test('a marker dropped by hand gets whatever entrances its place has', async () => {
+    // This is the drag/click path: reverse geocoding is how a hand-placed
+    // waypoint learns what it landed on, so the picker must work there too.
+    jest.doMock('leaflet', () => leafletMock({
+      reverse: () => Promise.resolve([{
+        name: 'Pergamonmuseum',
+        center: { lat: 52.5209336, lng: 13.3956302 },
+        properties: { osm_type: 'way', osm_id: 313659704, entrances: [BER_ENTRANCES[0]] }
+      }])
+    }));
+
+    const g = require('../src/geocoder').coordPreserving('https://nominatim.example/');
+    const results = await g.reverse({ lat: 52.52, lng: 13.39 }, 1, undefined, undefined);
+    expect(results[0].entrances[0].type).toBe('main');
+  });
+});
+
+describe('persistence across a reload', () => {
+  const RESPONSE = [{
+    display_name: 'Flughafen BER',
+    osm_type: 'way',
+    osm_id: 859790021,
+    lat: '52.3657974',
+    lon: '13.4888906',
+    boundingbox: ['52.3408173', '52.3907136', '13.4549773', '13.5388427'],
+    entrances: BER_ENTRANCES
+  }];
+
+  test('entrances are written to storage in a portable shape', async () => {
+    jest.doMock('leaflet', () => leafletMock({}));
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve(RESPONSE)
+    }));
+
+    await require('../src/geocoder').coordPreserving('https://nominatim.example/').geocode('BER');
+
+    const raw = readStore()['osrm_nominatim_cache_v2'];
+    expect(raw).toBeTruthy();
+    const cached = JSON.parse(raw)[0][1].value[0];
+    expect(cached.osmType).toBe('way');
+    expect(cached.osmId).toBe(859790021);
+    // Plain lat/lng objects, not whatever Leaflet happens to construct.
+    expect(cached.entrances).toEqual([
+      { osmId: 9942967218, type: 'main', center: { lat: 52.36361, lng: 13.5100542 } },
+      { osmId: 9959231437, type: 'exit', center: { lat: 52.3641971, lng: 13.5096892 } }
+    ]);
+  });
+
+  test('a cached result comes back with Leaflet coordinates and needs no request', async () => {
+    jest.doMock('leaflet', () => leafletMock({}));
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve(RESPONSE)
+    }));
+    await require('../src/geocoder').coordPreserving('https://nominatim.example/').geocode('BER');
+
+    // A fresh module instance, reading the store the first one wrote. Its fetch
+    // throws, which asserts "served from cache" far more plainly than a call
+    // count would — jest.resetModules() clears mock call records anyway.
+    jest.resetModules();
+    jest.doMock('leaflet', () => leafletMock({}));
+    global.fetch = () => { throw new Error('the cache should have answered this'); };
+
+    const results = await require('../src/geocoder')
+      .coordPreserving('https://nominatim.example/').geocode('BER');
+
+    expect(results[0].entrances).toHaveLength(2);
+    expect(results[0].entrances.map((e) => e.type)).toEqual(['main', 'exit']);
+    // Rehydrated through L.latLng, so the picker can measure and place them.
+    expect(results[0].entrances[0].center._leaflet).toBe(true);
+    expect(results[0].entrances[0].center.lat).toBeCloseTo(52.36361);
+    expect(results[0].osmId).toBe(859790021);
+  });
+
+  test('a v1 entry without entrances is simply ignored by the v2 key', async () => {
+    // The cache key was bumped precisely because older entries predate these
+    // fields; a stale one must not be served as a place with no entrances.
+    global.localStorage.setItem('osrm_nominatim_cache_v1', JSON.stringify([
+      ['https://nominatim.example/search?x', { ts: Date.now(), value: [{ name: 'stale' }] }]
+    ]));
+    jest.doMock('leaflet', () => leafletMock({}));
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve(RESPONSE)
+    }));
+
+    const results = await require('../src/geocoder')
+      .coordPreserving('https://nominatim.example/').geocode('BER');
+    expect(results[0].entrances).toHaveLength(2);
+  });
+});
+
+// Nominatim returns each entrance node's own tag set as `extratags`, without
+// being asked for it. Those tags carry the OSM access keys the mode filter
+// needs, so they have to survive the whole way to the picker.
+describe('entrance tags', () => {
+  const TAGGED = [
+    { osm_id: 1, type: 'main', lat: '52.4', lon: '13.5',
+      extratags: { access: 'permissive', wheelchair: 'yes' } },
+    { osm_id: 2, type: 'yes', lat: '52.41', lon: '13.51',
+      extratags: { motor_vehicle: 'no', foot: 'yes' } },
+    { osm_id: 3, type: 'yes', lat: '52.42', lon: '13.52' }
+  ];
+
+  function respond(entrances) {
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true, status: 200,
+      json: () => Promise.resolve([{
+        display_name: 'X', osm_type: 'way', osm_id: 1,
+        lat: '52.4', lon: '13.5', entrances
+      }])
+    }));
+  }
+
+  test('are carried through as the entrance tags', async () => {
+    jest.doMock('leaflet', () => leafletMock({}));
+    respond(TAGGED);
+    const results = await require('../src/geocoder')
+      .coordPreserving('https://nominatim.example/').geocode('X');
+
+    expect(results[0].entrances[0].tags).toEqual({ access: 'permissive', wheelchair: 'yes' });
+    expect(results[0].entrances[1].tags).toEqual({ motor_vehicle: 'no', foot: 'yes' });
+    // An untagged door carries no tags at all rather than an empty object.
+    expect(results[0].entrances[2].tags).toBeUndefined();
+  });
+
+  test('survive the cache, or a reloaded place would lose its access rules', async () => {
+    jest.doMock('leaflet', () => leafletMock({}));
+    respond(TAGGED);
+    await require('../src/geocoder').coordPreserving('https://nominatim.example/').geocode('X');
+
+    jest.resetModules();
+    jest.doMock('leaflet', () => leafletMock({}));
+    global.fetch = () => { throw new Error('the cache should have answered this'); };
+    const results = await require('../src/geocoder')
+      .coordPreserving('https://nominatim.example/').geocode('X');
+
+    expect(results[0].entrances[1].tags).toEqual({ motor_vehicle: 'no', foot: 'yes' });
+    expect(results[0].entrances[2].tags).toBeUndefined();
+  });
+});

--- a/test/simplify.test.js
+++ b/test/simplify.test.js
@@ -1,0 +1,247 @@
+'use strict';
+
+const simplify = require('../src/simplify');
+
+// A square with a deep notch cut into its north edge — the U shape a museum or a
+// terminal building has. Every vertex here carries real shape.
+function notchedSquare() {
+  return [
+    [0, 0], [10, 0], [10, 10],
+    [6, 10], [6, 4], [4, 4], [4, 10],
+    [0, 10], [0, 0]
+  ];
+}
+
+// The same U, but with each edge sampled at extra collinear points. Those extras
+// contribute zero area and are exactly what simplification should take.
+function notchedSquareOversampled(perEdge) {
+  const base = notchedSquare();
+  const out = [];
+  for (let i = 0; i < base.length - 1; i++) {
+    const [x1, y1] = base[i];
+    const [x2, y2] = base[i + 1];
+    for (let s = 0; s < perEdge; s++) {
+      const t = s / perEdge;
+      out.push([x1 + (x2 - x1) * t, y1 + (y2 - y1) * t]);
+    }
+  }
+  out.push(base[0]);
+  return out;
+}
+
+const AGGRESSIVE = {minDoubleArea: 1e9};
+
+describe('negligibleDoubleArea', () => {
+  test('scales with the shape, so the same fraction means the same pixels', () => {
+    const big = simplify.negligibleDoubleArea({width: 0.084, height: 0.05});
+    const small = simplify.negligibleDoubleArea({width: 0.0025, height: 0.0015});
+    // A 34x smaller shape tolerates a ~34^2 smaller triangle.
+    expect(big / small).toBeCloseTo(Math.pow(0.084 / 0.0025, 2), 0);
+  });
+
+  test('is zero for a degenerate extent, which removes nothing at all', () => {
+    expect(simplify.negligibleDoubleArea({width: 0, height: 0})).toBe(0);
+    expect(simplify.negligibleDoubleArea(null)).toBe(0);
+  });
+});
+
+describe('simplifyLine', () => {
+  test('removes nothing when no vertex is negligible', () => {
+    const pts = [[0, 0], [1, 5], [2, 0], [3, 5]];
+    expect(simplify.simplifyLine(pts, {minDoubleArea: 0})).toBe(pts);
+  });
+
+  test('keeps the first and last point exactly', () => {
+    const pts = notchedSquareOversampled(6);
+    const out = simplify.simplifyLine(pts, AGGRESSIVE);
+    expect(out[0]).toEqual(pts[0]);
+    expect(out[out.length - 1]).toEqual(pts[pts.length - 1]);
+  });
+
+  test('drops only the vertices that carry no shape', () => {
+    const pts = [[0, 0], [1, 0], [2, 0], [3, 5], [4, 0], [5, 0], [6, 0]];
+    const out = simplify.simplifyLine(pts, {minDoubleArea: 1});
+    // [1,0] and [5,0] are collinear with their neighbours and go. [2,0] and
+    // [4,0] are the feet of the spike — their triangles have real area — so they
+    // stay, and with them the spike's actual shape.
+    expect(out).toEqual([[0, 0], [2, 0], [3, 5], [4, 0], [6, 0]]);
+  });
+
+  test('a run of genuinely collinear points collapses to its endpoints', () => {
+    const pts = [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0], [5, 0]];
+    expect(simplify.simplifyLine(pts, {minDoubleArea: 1})).toEqual([[0, 0], [5, 0]]);
+  });
+
+  test('stops at the first visible vertex rather than running to a budget', () => {
+    const pts = [[0, 0], [1, 0], [2, 0], [3, 5], [4, 0], [5, 0], [6, 0]];
+    const out = simplify.simplifyLine(pts, {minDoubleArea: 1, maxPoints: 3});
+    // The spike survives because it is not negligible, even though the cap is met.
+    expect(out).toContainEqual([3, 5]);
+  });
+
+  test('the hard cap still bites on pathological input', () => {
+    const pts = [];
+    for (let i = 0; i < 200; i++) pts.push([i, i % 2 === 0 ? 0 : 5]);
+    const out = simplify.simplifyLine(pts, {minDoubleArea: 0, maxPoints: 20});
+    expect(out.length).toBeLessThanOrEqual(20);
+  });
+
+  test('never goes below the floor', () => {
+    const out = simplify.simplifyLine(notchedSquareOversampled(6), {minDoubleArea: 1e9, floor: 4});
+    expect(out.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test('tolerates short and non-array input', () => {
+    expect(simplify.simplifyLine(null, AGGRESSIVE)).toBeNull();
+    const two = [[0, 0], [1, 1]];
+    expect(simplify.simplifyLine(two, AGGRESSIVE)).toBe(two);
+  });
+});
+
+describe('simplifyRing', () => {
+  test('keeps the ring closed', () => {
+    const out = simplify.simplifyRing(notchedSquareOversampled(6), {minDoubleArea: 1});
+    expect(out[0]).toEqual(out[out.length - 1]);
+  });
+
+  test('returns the original ring when nothing is negligible', () => {
+    const ring = notchedSquare();
+    expect(simplify.simplifyRing(ring, {minDoubleArea: 0})).toBe(ring);
+  });
+
+  test('recovers the exact U shape from an oversampled one', () => {
+    const out = simplify.simplifyRing(notchedSquareOversampled(8), {minDoubleArea: 0.001});
+    expect(out).toEqual(notchedSquare());
+  });
+
+  test('never reduces a ring below a valid four points', () => {
+    const out = simplify.simplifyRing(notchedSquareOversampled(4), {minDoubleArea: 1e9});
+    expect(out.length).toBeGreaterThanOrEqual(4);
+    expect(out[0]).toEqual(out[out.length - 1]);
+  });
+
+  test('leaves short rings untouched', () => {
+    const tiny = [[0, 0], [1, 0], [0, 1], [0, 0]];
+    expect(simplify.simplifyRing(tiny, AGGRESSIVE)).toBe(tiny);
+  });
+});
+
+describe('simplifyGeometry', () => {
+  test('judges a hole at the whole shape’s scale, not its own', () => {
+    // A large outer ring with a small oversampled hole. Were the hole judged
+    // against its own extent it would keep detail invisible at the drawn scale.
+    const outer = notchedSquareOversampled(8);
+    const hole = notchedSquareOversampled(8).map(([x, y]) => [x / 100 + 4, y / 100 + 4]);
+    const out = simplify.simplifyGeometry({type: 'Polygon', coordinates: [outer, hole]});
+    expect(out.coordinates[1].length).toBeLessThan(hole.length);
+  });
+
+  test('walks every ring of a MultiPolygon', () => {
+    const geometry = {
+      type: 'MultiPolygon',
+      coordinates: [[notchedSquareOversampled(8)], [notchedSquareOversampled(8)]]
+    };
+    const out = simplify.simplifyGeometry(geometry);
+    expect(out.type).toBe('MultiPolygon');
+    expect(out.coordinates[0][0].length).toBeLessThan(geometry.coordinates[0][0].length);
+  });
+
+  test('does not mutate the input', () => {
+    const geometry = {type: 'Polygon', coordinates: [notchedSquareOversampled(8)]};
+    const before = geometry.coordinates[0].length;
+    simplify.simplifyGeometry(geometry);
+    expect(geometry.coordinates[0]).toHaveLength(before);
+  });
+
+  test('passes through anything that is not a polygon', () => {
+    const point = {type: 'Point', coordinates: [1, 2]};
+    expect(simplify.simplifyGeometry(point)).toBe(point);
+    expect(simplify.simplifyGeometry(null)).toBeNull();
+  });
+});
+
+// The regression this module exists for. Nominatim's polygon_threshold is an
+// absolute tolerance in degrees, so the value that thinned BER collapsed the
+// Pergamonmuseum's 32-point outline to 5 stray corners. These are the real
+// coordinates of both.
+describe('real outlines keep their shape', () => {
+  const PERGAMON = [
+    [13.395229, 52.520969], [13.395579, 52.520719], [13.396513, 52.521217],
+    [13.396635, 52.521133], [13.396428, 52.521025], [13.396523, 52.520957],
+    [13.396617, 52.520889], [13.396829, 52.521], [13.396958, 52.520911],
+    [13.396009, 52.520411], [13.39636, 52.52016], [13.396605, 52.520287],
+    [13.39658, 52.520305], [13.397322, 52.520691], [13.397344, 52.520675],
+    [13.397438, 52.520724], [13.397708, 52.520864], [13.397673, 52.520889],
+    [13.397333, 52.521112], [13.397421, 52.521159], [13.397319, 52.52123],
+    [13.397452, 52.521299], [13.397214, 52.521468], [13.397076, 52.521397],
+    [13.396976, 52.521466], [13.396908, 52.52143], [13.396579, 52.521664],
+    [13.396243, 52.52149], [13.396275, 52.521467], [13.39549, 52.521059],
+    [13.395452, 52.521085], [13.395229, 52.520969]
+  ];
+
+  test('the museum survives essentially intact', () => {
+    const out = simplify.simplifyGeometry({type: 'Polygon', coordinates: [PERGAMON]});
+    const kept = out.coordinates[0].length;
+    // The old absolute threshold left 5 points out of 32.
+    expect(kept).toBeGreaterThan(25);
+    expect(out.coordinates[0][0]).toEqual(PERGAMON[0]);
+  });
+
+  test('its extent is preserved to within a pixel of the drawn scale', () => {
+    const out = simplify.simplifyGeometry({type: 'Polygon', coordinates: [PERGAMON]});
+    const before = simplify.geometryExtent({type: 'Polygon', coordinates: [PERGAMON]});
+    const after = simplify.geometryExtent(out);
+    const perPixel = Math.max(before.width, before.height) / simplify.ASSUMED_RENDER_SPAN_PX;
+    expect(Math.abs(after.width - before.width)).toBeLessThan(perPixel);
+    expect(Math.abs(after.height - before.height)).toBeLessThan(perPixel);
+  });
+
+  test('a shape 34x larger is thinned by the same call, not the museum', () => {
+    // Same outline scaled up to airport size, oversampled along every edge.
+    const scaled = PERGAMON.map(([x, y]) => [
+      13.4 + (x - 13.395229) * 34, 52.34 + (y - 52.520969) * 34
+    ]);
+    const dense = [];
+    for (let i = 0; i < scaled.length - 1; i++) {
+      for (let s = 0; s < 12; s++) {
+        const t = s / 12;
+        dense.push([
+          scaled[i][0] + (scaled[i + 1][0] - scaled[i][0]) * t,
+          scaled[i][1] + (scaled[i + 1][1] - scaled[i][1]) * t
+        ]);
+      }
+    }
+    dense.push(scaled[0]);
+    const out = simplify.simplifyGeometry({type: 'Polygon', coordinates: [dense]});
+    expect(out.coordinates[0].length).toBeLessThan(dense.length / 3);
+  });
+});
+
+describe('geometryExtent and countPoints', () => {
+  const RING = [[0, 0], [10, 0], [10, 5], [0, 0]];
+
+  test('measure a Polygon', () => {
+    const g = { type: 'Polygon', coordinates: [RING] };
+    expect(simplify.geometryExtent(g)).toEqual({ width: 10, height: 5 });
+    expect(simplify.countPoints(g)).toBe(4);
+  });
+
+  test('measure a MultiPolygon across all its parts', () => {
+    const g = { type: 'MultiPolygon', coordinates: [[RING], [RING.map(([x, y]) => [x + 20, y])]] };
+    expect(simplify.geometryExtent(g)).toEqual({ width: 30, height: 5 });
+    expect(simplify.countPoints(g)).toBe(8);
+  });
+
+  test('report nothing for a geometry with no rings', () => {
+    expect(simplify.geometryExtent({ type: 'Point', coordinates: [1, 2] })).toBeNull();
+    expect(simplify.geometryExtent(null)).toBeNull();
+    expect(simplify.countPoints({ type: 'Point', coordinates: [1, 2] })).toBe(0);
+    expect(simplify.countPoints(null)).toBe(0);
+  });
+
+  test('ignore malformed rings rather than throwing', () => {
+    const g = { type: 'Polygon', coordinates: [RING, null, [[1], 'nonsense']] };
+    expect(simplify.geometryExtent(g)).toEqual({ width: 10, height: 5 });
+    expect(() => simplify.countPoints(g)).not.toThrow();
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> **Being split into reviewable pieces — please review those instead.** This PR stays open as the reference implementation and the place to discuss the feature as a whole, but it is ~5,000 lines and should not be merged as one.
>
> 1. ~~#517~~ — entrance nodes through the geocoder (the data) ✅ merged
> 2. ~~#519~~ — offer them as routing targets (the feature in miniature) ✅ merged
> 3. ~~#520~~ — labels for named doors, merged where they collide ✅ merged
> 4. ~~#521~~ — access filtering and marks per travel mode ✅ merged
> 5. ~~#522~~ — one offer per waypoint ✅ merged
> 6. ~~#525~~ — the site outline ✅ merged
> 7. ~~#523~~ — the bbox-versus-doors framing decision ✅ merged, and ~~#524~~ — the reverse-geocode notifier ✅ merged
>
> **All slices are merged.** This PR can be closed: everything in it now lives on `gh-pages` as #517, #519, #520, #521, #522, #523, #524 and #525.

A geocoded place drops its waypoint on the centroid. For a large site that is nowhere a traveller can reach — BER's centroid sits on the airfield, 1.5 km from the terminal doors, and the route ends on a slip road — Nominatim's entrance nodes are now offered as an alternative.

Clicking a door **routes to it while the pin stays on the place** that was searched for, joined by a dashed line. Every door stays on the map, the chosen one marked; clicking it again routes back to the place.

| | before | after |
|---|---|---|
| BER, driving | 23.1 km, 34 min, ends on the A 113 slip road | 24.5 km, **29 min**, at the terminal door |
| Pergamonmuseum, walking | 1.6 km, 22 min, behind the museum | 1.5 km, **20 min**, at the entrance |

## Nothing is chosen for the user

`entrance=main` records how a building is laid out, not what a router can reach. The Pergamonmuseum tags a main door that the walking network stops 90 m short of, while its side door is on the path — so acting on the tag would be confidently wrong about as often as right. Every door is offered; the waypoint stays put until one is clicked.

## Which doors are offered

**Direction**, from the wiki's one-way values:

| value | wiki | usable at |
|---|---|---|
| `exit` | *"a one-way out of a building"* | origin only |
| `entrance` | *"an entrance only, a one-way in"* | destination only |
| `main`, `yes`, `secondary`, `shop`, `home`, `staircase` | enter or leave | anywhere |
| `service`, `emergency`, `garage`, `no` | — | never |

`staircase` is *"Door to staircase"* — the door of a stairwell, which is how residents and visitors of an apartment building get in. It belongs with `home` rather than with the interior doors, and is the third most common value on entrance nodes after `yes` and `main`. (Raised in review by @1ec5; it was wrongly excluded at first.)

A via point is both arrived at and left from, so it takes only the two-way doors. Hardenbergstraße 36 has six mapped doors and offers 5 / 5 / 4 as origin / destination / via.

**Travel mode**, from the door's own OSM access tags, following the access hierarchy (`motor_vehicle` → `vehicle` → `access`; `foot` → `access`). Only `no` and `private` forbid — `permissive`, `customers` and `designated` are usable, and an untagged door is open to everyone. Read live, so switching profile re-applies the rules to what is already on screen.

## Labels

Doors take their OSM `name` where they have one (Alexa Berlin: *Haupteingang Alexanderplatz*, *Eingang Ravelinplatz*…), shown permanently rather than on hover. Where labels collide the whole colliding run collapses into one listing every door in it; zooming in separates them again. Overlap is transitive — showing A and C while hiding B would be arbitrary.

A label is clickable and does what clicking its door does. That is what makes a merged label usable: the doors it lists are the ones too close together to aim at, so their names are the only way to pick one apart. The chosen door's line is marked to match its filled dot. Labels stay in a pane beneath the dots, so a click that lands on a dot still goes to the dot.

Labels sit in a pane **below** the marker pane. A `zIndexOffset` cannot do this: Leaflet derives a marker's z-index from its latitude, so a label on a northerly door outranks a dot on a southerly one however the offsets are set.

## Marks

A door can carry a small mark in its label, and which one depends on the travel mode — what is worth pointing out about a door depends entirely on how you are arriving. Step-free access matters on foot and says nothing to a driver; which door swallows cars matters when driving and is noise to everyone else.

| mode | mark | from |
|---|---|---|
| foot | ♿ | `wheelchair=yes` or `designated` |
| car | 🅿 | `amenity=parking_entrance` |
| bike | — | — |

Nominatim returns an entrance node's OSM tags in `extratags` without being asked, so both arrive for free. `refresh()` already re-shows an open picker when the profile changes, so the marks follow the mode rather than describing the one the user has left.

Cycling has no mark deliberately. Its natural candidate, `bicycle` on an entrance node, does not reach 0.05% of them globally — against 4.7% for `wheelchair` — so it would be an icon nobody ever sees.

Marks never filter, and `routableEntrances` is untouched by them. In a dense Berlin-Mitte sample, 271 of 2246 entrance nodes carry `wheelchair` at all — **12%**, split almost evenly between `yes` (125) and `no` (131) — so an absent value means nobody surveyed the door, not that it has a step. Filtering on it would hide most usable doors, the Pergamonmuseum's included, which return no extratags whatsoever. `limited` does not earn the mark either: it means passable only with help, or under conditions the tag leaves unsaid.

Parking marks are rarer still: only about 7% of `amenity=parking_entrance` nodes also carry `entrance=*`, which is the only way Nominatim surfaces them. Where they do appear they are usually `entrance=exit`, so they show at an origin rather than a destination — which is the right way round for leaving a car park.

Where labels merge, a mark stays on the line that earned it rather than being hoisted onto the group. Screen readers get words instead of the symbol — the dot's alt text reads *"Nord (Wheelchair accessible)"* — and the mark is `aria-hidden`, so it is not announced twice.

Values are taken from OSM verbatim. Nothing is inferred from ramps, kerbs or the path leading to the door, so a marked door may still sit behind steps the router knows nothing about.

## One offer per waypoint

Each waypoint keeps its own offer, with its own selection, mode and outline. Naming a start does not withdraw the destination's doors, and a place with no usable doors withdraws only its own dots rather than clearing the map. The view frames the newest offer; the rest stay where they are.

## The view

Opening a picker frames its doors, and the route that follows the geocode stands down rather than fitting itself over them — that route, and only that one. The picker claims the view when a fresh geocode frames its doors; `index.js` consumes the claim on the next `routesfound` (or `routingerror`). A picker that is merely still open has no claim: adding a via point, switching profile or reordering the list recomputes the route, and the map used to jump back to the entrances on every one of those. The re-shows for a mode or role change redraw the doors where they are (`frame: false`).

Reverse-geocoded waypoints reach the picker too. LRM fires `geocoded` only from the autocomplete, so a waypoint that arrives with coordinates and no name — restored from a shared URL, dropped by a map click, dragged somewhere new — was named by `GeocoderElement.update()` calling `geocoder.reverse` directly, and its entrance list went in the bin with the result. LRM's own 200 m tolerance is applied.

This does not survive a reload, and no wiring can make it: reverse geocoding a stored coordinate returns the nearest address — at Potsdamer Platz, a fountain node — not the place that was searched for, and those carry no entrances. Recovering the offer across a reload means persisting the place, not re-deriving it.

## Also here

- **Site outline** beneath the doors, fetched only when the picker opens. Thinned with **Visvalingam–Whyatt**, stopping as soon as the smallest surviving triangle would be visible on screen, rather than with Nominatim's `polygon_threshold` — that tolerance is absolute degrees, so a value that usefully thins a 5 km airport flattens a 170 m building into five stray corners. Measured: the museum keeps 31 of 32 points, BER sheds 33%, neither bounding box moves by a pixel.
- **The gap between where a route can reach and its waypoint is dashed throughout.** LRM's default draws it as a solid black casing and solid white core with thin dashes on top, which against this app's heavy blue route reads as more route.
- **`continue_straight=true`**, so OSRM leaves a via by a different way rather than doubling back — 1575 m against 1524 m on a via at Hardenbergstraße 36. A no-op without via points, and it still routes where the u-turn is unavoidable.
- **Cache key → v2.** Existing entries predate the entrance data, the OSM identifiers and the access tags.

## Tests

613 tests, 36 suites. New modules are at **100% line coverage** (`entrance_picker`, `entrance_waypoints`, `simplify`, `lrm_options`); the remaining branch misses are defensive fallbacks. The entrance-specific geocoder paths — both request paths, forward and reverse, and the persisted-cache round trip — are covered too.

Verified against the live Nominatim and OSRM services throughout, not only against fakes. Latest pass: BER offered as start, a via added by cmd-click leaves the map on the route rather than jumping to the doors; at a zoom where the five labels merge, clicking the second line routes to that door, marks its line, and clicking it again releases it, with the map still throughout.

## Known gap

A waypoint that becomes a via — by appending a waypoint after it — keeps a door the via rules would not have offered. The role changes; the existing selection is not re-validated. Re-typing the address recovers it. Fixing it properly means retaining per-waypoint place state across splices, which the picker deliberately does not keep today, so I have left it rather than bolt on a half-measure.

🤖 Claude Code, Claude Opus 5












