### PR TITLE
fix: stop hammering the routing service while dragging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 var L = require('leaflet');
 var routerPatches = require('./router_patches');
+var routeThrottle = require('./route_throttle');
 var createGeocoder = require('./geocoder');
 require('leaflet-control-geocoder');
 var geocoderPatches = require('./geocoder_patches');
@@ -376,6 +377,15 @@ controlOptions.profile = services[activeProfileIndex].profile;
 
 var router = (new L.Routing.OSRMv1(controlOptions));
 routerPatches.applyPatches(router);
+// Dragging routes continuously, and the public demo servers answer a burst of
+// that with 429s that LRM turns into a cleared route line. Back off the live
+// preview when the service starts refusing; the route on drag end still runs.
+routeThrottle.throttleOnRateLimit(router, {
+  onBackoff: function(coolOffMs) {
+    console.warn('Routing service is refusing requests; pausing the drag preview for ' +
+      Math.round(coolOffMs / 1000) + 's');
+  }
+});
 
 router._convertRouteOriginal = router._convertRoute;
 router._convertRoute = function(responseRoute) {

--- a/src/lrm_options.js
+++ b/src/lrm_options.js
@@ -31,7 +31,10 @@ module.exports = {
     createGeocoder: createGeocoder,
     showAlternatives: true,
     useZoomParameter: false,
-    routeDragInterval: 200,
+    // 200ms is five requests a second per drag, which the public demo servers
+    // rate-limit. Slower still feels live, and route_throttle backs off further
+    // if the service starts refusing anyway.
+    routeDragInterval: 500,
     collapsible: true
   },
   popup: {

--- a/src/route_throttle.js
+++ b/src/route_throttle.js
@@ -24,8 +24,13 @@
 // deliberate drag recovers its preview without the user wondering why.
 var COOLOFF_MS = 4000;
 var MAX_COOLOFF_MS = 30000;
-// One failure is a hiccup — a dropped connection, an aborted request. Two in a
-// row while dragging is the service saying no.
+// One failure is a hiccup — a dropped connection, a transient 5xx. Two in a row
+// is the service saying no.
+//
+// Only failures of drag previews count. A one-off route that fails for its own
+// reasons — no route between the waypoints, a malformed request — says nothing
+// about the request rate, and letting it feed the counter would throttle a drag
+// that had not yet been refused anything.
 var FAILURES_BEFORE_BACKOFF = 2;
 
 /**
@@ -72,14 +77,18 @@ function throttleOnRateLimit(router, options) {
     // already has, because the callback it would clear it from never runs.
     if (preview && now() < quietUntil) return undefined;
 
-    return original.call(router, waypoints, function(err, routes) {
+    return original.call(router, waypoints, function(err) {
       // An abort is LRM superseding its own request, not the service refusing.
       if (err && err.type !== 'abort') {
-        failed();
+        if (preview) failed();
       } else if (!err) {
+        // Any success shows the service is answering again, whoever asked.
         succeeded();
       }
-      if (typeof callback === 'function') callback.call(context, err, routes);
+      // `context || callback` is what the OSRM router itself passes, and the
+      // wrapper is meant to be invisible; arguments are forwarded whole so a
+      // router with more to say than (err, routes) keeps saying it.
+      if (typeof callback === 'function') callback.apply(context || callback, arguments);
     }, context, routeOptions);
   };
 

--- a/src/route_throttle.js
+++ b/src/route_throttle.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Backs a router off when the routing service starts refusing requests.
+ *
+ * Dragging a waypoint routes continuously — LRM issues one request every
+ * `routeDragInterval` — and the public demo servers answer a burst of those
+ * with HTTP 429. Each failure makes LRM clear the route line, so a rate-limited
+ * drag both spams the service and flickers.
+ *
+ * The status cannot be trusted to identify it: a 429 served without CORS headers
+ * is indistinguishable from a network failure to XMLHttpRequest, and arrives as
+ * `status: -1` with `message: "HTTP request failed: undefined"`. Repeated
+ * failure in quick succession is therefore the only usable signal.
+ *
+ * Only the live preview is dropped while backed off. LRM's request on drag end
+ * is not marked `geometryOnly`, so it always goes through and the route still
+ * settles on wherever the user let go.
+ *
+ * @module route_throttle
+ */
+
+// Long enough for a demo server's window to roll over, short enough that a
+// deliberate drag recovers its preview without the user wondering why.
+var COOLOFF_MS = 4000;
+var MAX_COOLOFF_MS = 30000;
+// One failure is a hiccup — a dropped connection, an aborted request. Two in a
+// row while dragging is the service saying no.
+var FAILURES_BEFORE_BACKOFF = 2;
+
+/**
+ * @param {object} router — an LRM router; its `route` is replaced in place
+ * @param {object} [options]
+ * @param {function} [options.now] — () => ms, for tests
+ * @param {function} [options.onBackoff] — (coolOffMs) => void, called once each
+ *   time a new back-off starts
+ * @returns {object} the same router
+ */
+function throttleOnRateLimit(router, options) {
+  options = options || {};
+  if (!router || typeof router.route !== 'function') return router;
+  var now = typeof options.now === 'function' ? options.now : function() {
+    return Date.now();
+  };
+  var onBackoff = typeof options.onBackoff === 'function' ? options.onBackoff : function() {};
+
+  var original = router.route;
+  var failures = 0;
+  var coolOff = COOLOFF_MS;
+  var quietUntil = 0;
+
+  function succeeded() {
+    failures = 0;
+    coolOff = COOLOFF_MS;
+    quietUntil = 0;
+  }
+
+  function failed() {
+    failures++;
+    if (failures < FAILURES_BEFORE_BACKOFF) return;
+    quietUntil = now() + coolOff;
+    onBackoff(coolOff);
+    // Each further failure waits longer, so a service that is still refusing is
+    // not asked again at the same rate.
+    coolOff = Math.min(coolOff * 2, MAX_COOLOFF_MS);
+  }
+
+  router.route = function(waypoints, callback, context, routeOptions) {
+    var preview = !!(routeOptions && routeOptions.geometryOnly);
+    // Skipped rather than queued: by the time a cool-off ends the pointer has
+    // moved on, and a stale preview is worse than none. LRM keeps the line it
+    // already has, because the callback it would clear it from never runs.
+    if (preview && now() < quietUntil) return undefined;
+
+    return original.call(router, waypoints, function(err, routes) {
+      // An abort is LRM superseding its own request, not the service refusing.
+      if (err && err.type !== 'abort') {
+        failed();
+      } else if (!err) {
+        succeeded();
+      }
+      if (typeof callback === 'function') callback.call(context, err, routes);
+    }, context, routeOptions);
+  };
+
+  return router;
+}
+
+module.exports = {
+  throttleOnRateLimit: throttleOnRateLimit,
+  COOLOFF_MS: COOLOFF_MS,
+  MAX_COOLOFF_MS: MAX_COOLOFF_MS,
+  FAILURES_BEFORE_BACKOFF: FAILURES_BEFORE_BACKOFF
+};

--- a/test/route_throttle.test.js
+++ b/test/route_throttle.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+/**
+ * Backing off a routing service that has started refusing requests. The failures
+ * arrive indistinguishable from network errors, so the policy is driven by
+ * repetition rather than by status codes.
+ */
+
+const routeThrottle = require('../src/route_throttle');
+
+function makeRouter(behaviour) {
+  const calls = [];
+  const router = {
+    route(waypoints, callback, context, options) {
+      calls.push({ waypoints, options });
+      const outcome = behaviour(calls.length);
+      if (outcome !== 'never') callback.call(context, outcome, outcome ? null : ['route']);
+      return { id: calls.length };
+    }
+  };
+  return { router, calls };
+}
+
+const fails = () => ({ status: -1, message: 'HTTP request failed: undefined' });
+const PREVIEW = { geometryOnly: true };
+const FINAL = {};
+
+describe('throttleOnRateLimit', () => {
+  let clock;
+  const now = () => clock;
+
+  beforeEach(() => { clock = 1000; });
+
+  test('passes requests through while the service is answering', () => {
+    const { router, calls } = makeRouter(() => null);
+    routeThrottle.throttleOnRateLimit(router, { now });
+    const seen = [];
+    router.route([], (err, routes) => seen.push([err, routes]), null, PREVIEW);
+    router.route([], (err, routes) => seen.push([err, routes]), null, PREVIEW);
+    expect(calls).toHaveLength(2);
+    expect(seen).toEqual([[null, ['route']], [null, ['route']]]);
+  });
+
+  test('one failure is a hiccup, not a rate limit', () => {
+    const { router, calls } = makeRouter((n) => (n === 1 ? fails() : null));
+    routeThrottle.throttleOnRateLimit(router, { now });
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+    expect(calls).toHaveLength(2);
+  });
+
+  test('two failures in a row stop the drag preview', () => {
+    const { router, calls } = makeRouter(() => fails());
+    const backoffs = [];
+    routeThrottle.throttleOnRateLimit(router, { now, onBackoff: (ms) => backoffs.push(ms) });
+
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+    expect(backoffs).toEqual([routeThrottle.COOLOFF_MS]);
+
+    router.route([], () => {}, null, PREVIEW);
+    expect(calls).toHaveLength(2);
+  });
+
+  test('a skipped preview never calls back, so LRM keeps the line it has', () => {
+    // LRM clears the route line from the error path of that callback.
+    const { router } = makeRouter(() => fails());
+    routeThrottle.throttleOnRateLimit(router, { now });
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+
+    let calledBack = false;
+    const out = router.route([], () => { calledBack = true; }, null, PREVIEW);
+    expect(calledBack).toBe(false);
+    expect(out).toBeUndefined();
+  });
+
+  test('the request on drag end still goes through while backed off', () => {
+    // It is not marked geometryOnly, and dropping it would leave the route
+    // showing somewhere the waypoint no longer is.
+    const { router, calls } = makeRouter(() => fails());
+    routeThrottle.throttleOnRateLimit(router, { now });
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, FINAL);
+    expect(calls).toHaveLength(3);
+  });
+
+  test('a request with no options at all is treated as a final one', () => {
+    const { router, calls } = makeRouter(() => fails());
+    routeThrottle.throttleOnRateLimit(router, { now });
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {});
+    expect(calls).toHaveLength(3);
+  });
+
+  test('previews resume once the cool-off has passed', () => {
+    const { router, calls } = makeRouter(() => fails());
+    routeThrottle.throttleOnRateLimit(router, { now });
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+
+    clock += routeThrottle.COOLOFF_MS - 1;
+    router.route([], () => {}, null, PREVIEW);
+    expect(calls).toHaveLength(2);
+
+    clock += 2;
+    router.route([], () => {}, null, PREVIEW);
+    expect(calls).toHaveLength(3);
+  });
+
+  test('each further failure waits longer, up to a ceiling', () => {
+    const { router } = makeRouter(() => fails());
+    const backoffs = [];
+    routeThrottle.throttleOnRateLimit(router, { now, onBackoff: (ms) => backoffs.push(ms) });
+    for (let i = 0; i < 12; i++) {
+      clock += routeThrottle.MAX_COOLOFF_MS;
+      router.route([], () => {}, null, PREVIEW);
+    }
+    expect(backoffs[0]).toBe(routeThrottle.COOLOFF_MS);
+    expect(backoffs[1]).toBe(routeThrottle.COOLOFF_MS * 2);
+    expect(backoffs[backoffs.length - 1]).toBe(routeThrottle.MAX_COOLOFF_MS);
+    expect(Math.max.apply(null, backoffs)).toBe(routeThrottle.MAX_COOLOFF_MS);
+  });
+
+  test('a success clears the back-off and resets the wait', () => {
+    let failing = true;
+    const { router, calls } = makeRouter(() => (failing ? fails() : null));
+    const backoffs = [];
+    routeThrottle.throttleOnRateLimit(router, { now, onBackoff: (ms) => backoffs.push(ms) });
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+
+    failing = false;
+    clock += routeThrottle.COOLOFF_MS;
+    router.route([], () => {}, null, PREVIEW);
+    expect(calls).toHaveLength(3);
+
+    failing = true;
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+    // Back to the first, shortest wait rather than continuing to double.
+    expect(backoffs).toEqual([routeThrottle.COOLOFF_MS, routeThrottle.COOLOFF_MS]);
+  });
+
+  test('an abort is LRM superseding its own request, not a refusal', () => {
+    const { router, calls } = makeRouter(() => ({ type: 'abort' }));
+    const backoffs = [];
+    routeThrottle.throttleOnRateLimit(router, { now, onBackoff: (ms) => backoffs.push(ms) });
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+    expect(backoffs).toEqual([]);
+    expect(calls).toHaveLength(3);
+  });
+
+  test('the callback keeps its context and arguments', () => {
+    const { router } = makeRouter(() => null);
+    routeThrottle.throttleOnRateLimit(router, { now });
+    const ctx = { seen: null };
+    router.route([], function(err, routes) { this.seen = { err, routes }; }, ctx, FINAL);
+    expect(ctx.seen).toEqual({ err: null, routes: ['route'] });
+  });
+
+  test('the router is returned, and a router without route is left alone', () => {
+    const { router } = makeRouter(() => null);
+    expect(routeThrottle.throttleOnRateLimit(router, { now })).toBe(router);
+    const bare = { name: 'no route method' };
+    expect(routeThrottle.throttleOnRateLimit(bare)).toBe(bare);
+    expect(routeThrottle.throttleOnRateLimit(null)).toBeNull();
+  });
+
+  test('works without callbacks or options supplied', () => {
+    const { router, calls } = makeRouter(() => null);
+    routeThrottle.throttleOnRateLimit(router);
+    expect(() => router.route([], undefined, null, PREVIEW)).not.toThrow();
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/test/route_throttle.test.js
+++ b/test/route_throttle.test.js
@@ -144,6 +144,67 @@ describe('throttleOnRateLimit', () => {
     expect(backoffs).toEqual([routeThrottle.COOLOFF_MS, routeThrottle.COOLOFF_MS]);
   });
 
+  test('a failed one-off route does not count towards the back-off', () => {
+    // No route between the waypoints, or a malformed request, says nothing
+    // about the request rate; only drag previews feed the counter.
+    const { router, calls } = makeRouter(() => fails());
+    const backoffs = [];
+    routeThrottle.throttleOnRateLimit(router, { now, onBackoff: (ms) => backoffs.push(ms) });
+    router.route([], () => {}, null, FINAL);
+    router.route([], () => {}, null, FINAL);
+    router.route([], () => {}, null, FINAL);
+    expect(backoffs).toEqual([]);
+    expect(calls).toHaveLength(3);
+  });
+
+  test('a one-off failure does not prime the counter for a later preview', () => {
+    const { router } = makeRouter(() => fails());
+    const backoffs = [];
+    routeThrottle.throttleOnRateLimit(router, { now, onBackoff: (ms) => backoffs.push(ms) });
+    router.route([], () => {}, null, FINAL);
+    router.route([], () => {}, null, PREVIEW);
+    expect(backoffs).toEqual([]);
+  });
+
+  test('a one-off success still clears a back-off', () => {
+    // Whoever asked, an answer means the service is talking again.
+    let failing = true;
+    const { router, calls } = makeRouter(() => (failing ? fails() : null));
+    routeThrottle.throttleOnRateLimit(router, { now });
+    router.route([], () => {}, null, PREVIEW);
+    router.route([], () => {}, null, PREVIEW);
+
+    failing = false;
+    router.route([], () => {}, null, FINAL);
+    const before = calls.length;
+    router.route([], () => {}, null, PREVIEW);
+    expect(calls).toHaveLength(before + 1);
+  });
+
+  test("the callback's this matches what the router itself would pass", () => {
+    // OSRMv1 calls back with `context || callback`, and the wrapper is meant to
+    // be invisible.
+    const { router } = makeRouter(() => null);
+    routeThrottle.throttleOnRateLimit(router, { now });
+    let seen = null;
+    const cb = function() { seen = this; };
+    router.route([], cb, undefined, FINAL);
+    expect(seen).toBe(cb);
+  });
+
+  test('every argument the router passes is forwarded', () => {
+    const router = {
+      route(waypoints, callback) {
+        callback.call(undefined, null, ['route'], 'extra');
+        return {};
+      }
+    };
+    routeThrottle.throttleOnRateLimit(router, { now });
+    let args = null;
+    router.route([], function() { args = Array.prototype.slice.call(arguments); }, null, FINAL);
+    expect(args).toEqual([null, ['route'], 'extra']);
+  });
+
   test('an abort is LRM superseding its own request, not a refusal', () => {
     const { router, calls } = makeRouter(() => ({ type: 'abort' }));
     const backoffs = [];


### PR DESCRIPTION
Dragging a waypoint routes continuously, and at `routeDragInterval: 200` that is five requests a second. The public demo servers answer a burst of those with HTTP 429, and because LRM clears the route line from the error path of its drag callback, a rate-limited drag both spams the service and leaves the user watching the route flicker in and out.

Reported against `routed-foot` on `routing.openstreetmap.de`:

```
Failed to load resource: the server responded with a status of 429 ()
Routing error: {message: "HTTP request failed: undefined", status: -1, …}
```

## Two changes

**`routeDragInterval` 200ms → 500ms.** Still reads as live, 2.5× fewer requests.

**The router backs off when the service starts refusing.** After two consecutive failures the live preview is skipped for 4s, doubling to a 30s ceiling while the refusals continue and resetting on the first success.

## Why it counts failures rather than checking for 429

It cannot check. A 429 served without CORS headers is indistinguishable from a network failure to `XMLHttpRequest`, and reaches the callback as `status: -1` with `message: "HTTP request failed: undefined"` — the `429` in the console above is the browser's own network log, not something the callback ever sees. Repeated failure in quick succession is the only usable signal.

Aborts are excluded: LRM supersedes its own in-flight request on every drag step, and those would otherwise look like refusals.

## Only the preview is dropped

LRM's request on drag end is not marked `geometryOnly`, so it always goes through and the route still settles on wherever the waypoint was let go. A skipped preview deliberately never calls back, because that callback is what would clear the line.

## Tests

286 tests, 27 suites. `route_throttle` is at **100% coverage** — pass-through while healthy, one failure tolerated, back-off after two, the drag-end request surviving a back-off, a skipped preview not calling back, doubling to the ceiling, reset on success, and aborts ignored.

Not verified against a live 429: reproducing that means deliberately hammering the public demo server, which is the behaviour being fixed. The policy is tested against a fake router instead.

Both thresholds are single constants — `routeDragInterval` in `src/lrm_options.js`, `COOLOFF_MS` in `src/route_throttle.js` — if reviewers want them more or less aggressive.

🤖 Claude Code, Claude Opus 5
