### PR TITLE
feat: key the CARTO basemap so tiles stop being watermarked

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,9 @@ OSRM_ZOOM="${OSRM_ZOOM:-13}"
 OSRM_LANGUAGE="${OSRM_LANGUAGE:-en}"
 OSRM_DEFAULT_LAYER="${OSRM_DEFAULT_LAYER:-streets}"
 OSRM_ENVIRONMENT="${OSRM_ENVIRONMENT:-docker}"
+# Empty by default: a self-hosted deployment gets watermarked CARTO tiles until
+# it supplies a key of its own.
+OSRM_CARTO_KEY="${OSRM_CARTO_KEY:-}"
 
 # Validate OSRM_ZOOM is numeric (for valid JSON output)
 case "$OSRM_ZOOM" in
@@ -61,6 +64,7 @@ cat > /usr/share/nginx/html/config.json << EOF
   "OSRM_LANGUAGE": "$(escape_json "$OSRM_LANGUAGE")",
   "OSRM_DEFAULT_LAYER": "$(escape_json "$OSRM_DEFAULT_LAYER")",
   "OSRM_ENVIRONMENT": "$(escape_json "$OSRM_ENVIRONMENT")",
+  "OSRM_CARTO_KEY": "$(escape_json "$OSRM_CARTO_KEY")",
   "OSRM_MODES": "$(escape_json "$MODES_JSON")"
 }
 EOF

--- a/index.html
+++ b/index.html
@@ -22,7 +22,11 @@
         // In all other cases (dev, browser), leave it undefined to use public services
         OSRM_CENTER: '38.8995,-77.0269',
         OSRM_ZOOM: 13,
-        OSRM_DEFAULT_LAYER: 'streets'
+        OSRM_DEFAULT_LAYER: 'streets',
+        // CARTO basemap key for project-osrm.org. Public by necessity: it is
+        // sent with every tile request. Without it CARTO watermarks the tiles.
+        // A fork serving its own domain should use its own key here.
+        OSRM_CARTO_KEY: 'cb1_2qvg_1_8e87c8903d178ccf6f862d52'
         // OSRM_BACKEND and OSRM_MODES will be set by config.json if available
       };
 

--- a/index.html
+++ b/index.html
@@ -24,8 +24,13 @@
         OSRM_ZOOM: 13,
         OSRM_DEFAULT_LAYER: 'streets',
         // CARTO basemap key for project-osrm.org. Public by necessity: it is
-        // sent with every tile request. Without it CARTO watermarks the tiles.
-        // A fork serving its own domain should use its own key here.
+        // sent with every tile request. Without it CARTO watermarks the tiles,
+        // which still render.
+        //
+        // A fork serving its own domain wants its own key. Editing it here
+        // covers a static deployment; in Docker this whole object is replaced
+        // by config.json, so set the OSRM_CARTO_KEY environment variable
+        // instead and the entrypoint will pass it through.
         OSRM_CARTO_KEY: 'cb1_2qvg_1_8e87c8903d178ccf6f862d52'
         // OSRM_BACKEND and OSRM_MODES will be set by config.json if available
       };

--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -6,12 +6,30 @@ var L = require('leaflet');
 // In Node/test environments, window won't exist, so use empty config
 var config = (typeof window !== 'undefined' ? window.osrmConfig : null) || {};
 
+/**
+ * The CARTO Voyager raster tile URL, keyed when a key is configured.
+ *
+ * Unkeyed tiles still render, but CARTO stamps them with an "API KEY REQUIRED"
+ * watermark, so a deployment without a key of its own is degraded rather than
+ * broken. The key is necessarily public — it travels in every tile request the
+ * browser makes — so it is deployment configuration rather than a secret, and
+ * lives with the rest of it in `window.osrmConfig`.
+ *
+ * @returns {string} a Leaflet tile URL template
+ */
+function cartoVoyagerUrl() {
+  var base = 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png';
+  var key = config.OSRM_CARTO_KEY;
+  if (typeof key !== 'string' || !key.trim()) return base;
+  return base + '?key=' + encodeURIComponent(key.trim());
+}
+
 var osmAttribution = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
   cartoAttribution = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attribution">CARTO</a>',
   esriAttribution = 'Tiles © <a href="https://www.esri.com/">Esri</a> — Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AeroGRID, IGN, and the GIS User Community',
   waymarkedtrailsAttribution = '© <a href="https://waymarkedtrails.org/">Sarah Hoffmann</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)';
 
-var streets = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+var streets = L.tileLayer(cartoVoyagerUrl(), {
     attribution: cartoAttribution,
     subdomains: 'abcd',
     maxZoom: 19

--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -468,6 +468,7 @@ function buildServices() {
  * | `OSRM_DEFAULT_LAYER`   | `'streets'`                      | Default base layer key: `streets`, `outdoors`, `satellite`, `osm`, or `osm_de`. |
  * | `OSRM_LABEL`           | `'Car (fastest)'`                | Label for the default routing service. |
  * | `OSRM_ENVIRONMENT`     | —                                | Set to `'docker'` to use Docker-mode backend defaults. |
+ * | `OSRM_CARTO_KEY`       | — (bundled key on project-osrm.org) | CARTO Basemaps key for the Streets layer. Without one CARTO watermarks the tiles; they still render. |
  *
  * @module leaflet_options
  */

--- a/test/leaflet_options.test.js
+++ b/test/leaflet_options.test.js
@@ -10,6 +10,39 @@ const leafletOptions = require('../src/leaflet_options');
 
 describe('leaflet_options — tileset migration', () => {
   describe('base layer URLs', () => {
+    test('the streets layer carries the configured CARTO key', () => {
+      // Unkeyed tiles render but CARTO watermarks them, so the key is what
+      // makes the default basemap presentable.
+      jest.resetModules();
+      global.window = { osrmConfig: { OSRM_CARTO_KEY: 'test_key_123' } };
+      const keyed = require('../src/leaflet_options');
+      expect(keyed.layer[0]['Streets']._url).toContain('?key=test_key_123');
+      delete global.window;
+      jest.resetModules();
+    });
+
+    test('an absent, blank or non-string key leaves the URL unkeyed', () => {
+      // A fork with no key of its own gets watermarked tiles rather than a
+      // broken URL with an empty key parameter in it.
+      [undefined, '', '   ', 42].forEach((value) => {
+        jest.resetModules();
+        global.window = { osrmConfig: { OSRM_CARTO_KEY: value } };
+        const opts = require('../src/leaflet_options');
+        expect(opts.layer[0]['Streets']._url).not.toContain('key=');
+        delete global.window;
+      });
+      jest.resetModules();
+    });
+
+    test('a key with URL-significant characters is escaped', () => {
+      jest.resetModules();
+      global.window = { osrmConfig: { OSRM_CARTO_KEY: 'a b&c' } };
+      const opts = require('../src/leaflet_options');
+      expect(opts.layer[0]['Streets']._url).toContain('?key=a%20b%26c');
+      delete global.window;
+      jest.resetModules();
+    });
+
     test('streets layer uses CartoDB Voyager (not Mapbox)', () => {
       expect(leafletOptions.layer[0]['Streets']._url).toContain('cartocdn.com');
       expect(leafletOptions.layer[0]['Streets']._url).toContain('voyager');


### PR DESCRIPTION
CARTO now stamps **API KEY REQUIRED** across unkeyed raster tiles, which is what the default Streets basemap has been showing. Appending the key issued to project-osrm.org clears it.

Verified against CARTO rather than by eye — the same tile, fetched twice:

| | HTTP | bytes | watermark |
|---|---|---|---|
| `…/15/17604/10746.png` | 200 | 28038 | yes |
| `…/15/17604/10746.png?key=…` | 200 | 32934 | no |

## Where the key lives

In `window.osrmConfig` as `OSRM_CARTO_KEY`, alongside the rest of the runtime configuration, with the Docker entrypoint passing it through to `config.json`.

It is deployment configuration rather than a secret: it travels in every tile request the browser makes and cannot be hidden, whatever we do with it. What it *is* worth doing is keeping it out of library code, so:

- `index.html` carries the project-osrm.org key as the shipped default.
- `docker/entrypoint.sh` defaults `OSRM_CARTO_KEY` to **empty**, so a self-hosted deployment gets watermarked tiles until it supplies its own key rather than silently borrowing this one.

## Behaviour without a key

An absent, blank or non-string key leaves the URL unkeyed rather than appending an empty `key=` parameter. Unkeyed tiles still render — they are watermarked, not refused — so a fork with no key is degraded, never broken.

## Tests

272 tests, 26 suites. New cases cover the keyed URL, the unkeyed fallback across `undefined` / `''` / whitespace / non-string, and escaping of URL-significant characters in a key.

Worth a maintainer's eye: whether CARTO has domain-restricted this key. If it has not, it can be lifted from the bundle and used elsewhere, and only CARTO can scope it.

🤖 Claude Code, Claude Opus 5
