### PR TITLE
fix: stop the waypoint connector reading as part of the route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,11 @@ OSRM Frontend is the browser-based routing interface served at https://map.proje
 - **Conventional Commits** for commit messages and PR titles. Format: `type(scope): description`. Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
 - **Never commit directly to `gh-pages` (the default branch).** All changes go through a pull request.
 - **All CI checks must pass before creating a PR.** CI runs lint (`npm run test:lint`), build (`npm run build`), and tests (`npm test`) — run all three locally first.
-- **Strip all AI/harness advertising from commits.** Drop any `Co-Authored-By`, `Generated with`, or similar trailers — no ads, no co-author lines, no attribution footers in commit messages.
-- **Disclose AI assistance on the PR only.** Describe what the agent helped with in the PR body (not in commits).
+- **No AI attribution in commit messages.** Drop any `Co-Authored-By`, `Generated with`, or similar trailers — no ads, no co-author lines, no attribution footers.
+- **Disclose AI participation in the PR description only**, matching the convention in [osrm-backend](https://github.com/Project-OSRM/osrm-backend/blob/master/AGENTS.md): state only the harness name and the model, prefixed with a robot emoji — for example `🤖 Claude Code, Claude Opus 5`.
+- **Do not advertise the tool.** No marketing links, no "Generated with …" banners, no vendor URLs. The disclosure is a statement of fact, not a credit.
+- **Never publish session identifiers or session-log links** (e.g. `Claude-Session:` trailers, `claude.ai/code/session_…` URLs) in commits, PR descriptions, or comments. These repositories are public and git history is permanent.
+- Beyond the disclosure line, describe in the PR body what the agent actually helped with.
 
 ### Review Comments
 

--- a/src/lrm_options.js
+++ b/src/lrm_options.js
@@ -3,20 +3,39 @@
 var mapView = require('./leaflet_options');
 var createGeocoder = require('./geocoder');
 
+// The connector takes the colour of the route it belongs to, so an alternative's
+// gap is not mistaken for the selected route's. The halo is dashed on the
+// identical pattern as the line it sits under, so the whole connector stays
+// visibly broken rather than reading as a solid casing with dashes on top.
+function missingRouteStyles(color) {
+  return [
+    {color: 'white', opacity: 0.75, weight: 7, dashArray: '3,9', lineCap: 'round'},
+    {color: color, opacity: 0.85, weight: 3, dashArray: '3,9', lineCap: 'round'}
+  ];
+}
+
 module.exports = {
   lrm: {
     lineOptions: {
       styles: [
         {color: '#022bb1', opacity: 0.8, weight: 8},
         {color: 'white', opacity: 0.3, weight: 6}
-      ]
+      ],
+      // The gap between where the route can actually reach and the waypoint
+      // itself — the walk across a forecourt to a door, say. Leaflet Routing
+      // Machine's default draws this as a solid black casing and a solid white
+      // core with thin dashes laid over them, which against this app's heavy
+      // blue route reads as more route. Every style here is dashed on the same
+      // pattern, so the connector can only ever read as "not part of the route".
+      missingRouteStyles: missingRouteStyles('#022bb1')
     },
     altLineOptions: {
       styles: [
         {color: '#40007d', opacity: 0.4, weight: 8},
         {color: 'black', opacity: 0.5, weight: 2, dashArray: '2,4' },
         {color: 'white', opacity: 0.3, weight: 6}
-      ]
+      ],
+      missingRouteStyles: missingRouteStyles('#40007d')
     },
     dragStyles: [
       {color: 'black', opacity: 0.35, weight: 9},

--- a/test/lrm_options.test.js
+++ b/test/lrm_options.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * The connector Leaflet Routing Machine draws between a waypoint and the point
+ * the route actually reaches — the walk across a forecourt, or from a pin
+ * dropped on a building set back from the road. Its default is a solid black
+ * casing and a solid white core with thin dashes laid over them, which against
+ * this app's heavy blue route reads as more route.
+ */
+
+jest.mock('leaflet', () => ({
+  tileLayer: () => ({}),
+  latLng: (lat, lng) => ({ lat, lng }),
+  Control: { Geocoder: { nominatim: () => ({}) } },
+  CRS: { EPSG3857: { scale: () => 1 } },
+  extend: Object.assign
+}));
+
+const options = require('../src/lrm_options');
+
+describe('missing-route connector styling', () => {
+  const forRoute = options.lrm.lineOptions.missingRouteStyles;
+  const forAlternative = options.lrm.altLineOptions.missingRouteStyles;
+
+  test('the selected route and its alternatives both get one', () => {
+    expect(Array.isArray(forRoute)).toBe(true);
+    expect(Array.isArray(forAlternative)).toBe(true);
+  });
+
+  test('every layer of the connector is dashed, so none of it reads as solid', () => {
+    [forRoute, forAlternative].forEach((styles) => {
+      expect(styles.length).toBeGreaterThan(0);
+      styles.forEach((style) => {
+        expect(style.dashArray).toBeTruthy();
+      });
+    });
+  });
+
+  test('the halo is dashed on the same pattern as the line it sits under', () => {
+    // Different patterns would make the halo read as a second, solid line.
+    const patterns = forRoute.map((s) => s.dashArray);
+    expect(new Set(patterns).size).toBe(1);
+  });
+
+  test('the halo is the wider of the two, so the line stays legible on any basemap', () => {
+    const [halo, line] = forRoute;
+    expect(halo.color).toBe('white');
+    expect(halo.weight).toBeGreaterThan(line.weight);
+  });
+
+  test('the connector takes the colour of the route it belongs to', () => {
+    // An alternative's gap must not be mistaken for the selected route's.
+    const routeColour = options.lrm.lineOptions.styles[0].color;
+    const altColour = options.lrm.altLineOptions.styles[0].color;
+    expect(forRoute.some((s) => s.color === routeColour)).toBe(true);
+    expect(forAlternative.some((s) => s.color === altColour)).toBe(true);
+    expect(forRoute).not.toEqual(forAlternative);
+  });
+
+  test('the connector is thinner than the route, so it never competes with it', () => {
+    const routeWeight = options.lrm.lineOptions.styles[0].weight;
+    forRoute.forEach((style) => {
+      expect(style.weight).toBeLessThan(routeWeight);
+    });
+  });
+});


### PR DESCRIPTION
Leaflet Routing Machine draws a connector whenever a waypoint sits farther than `missingRouteTolerance` from the point the route actually reaches — a pin dropped on a building set back from the road, a waypoint across a forecourt, a stop in a pedestrian zone (`leaflet-routing-machine/src/line.js:85`).

Its default styles that gap as a solid black casing and a solid white core with thin dashes laid over them. Against this app's heavy blue route the solid layers dominate and the connector reads as more route, so the line appears to reach somewhere it cannot.

## Change

`missingRouteStyles` for both the selected route and its alternatives:

- every layer dashed on the same pattern, so no part of it reads as solid
- thinner than the route, so it never competes with it
- coloured to match the route it belongs to, so an alternative's gap is not mistaken for the selected route's
- white halo wider than the line, so it stays legible on any basemap

## Testing

`test/lrm_options.test.js` — six tests asserting the above. Lint, build and the full suite pass locally.

Also brings AGENTS.md's AI-disclosure wording in line with [osrm-backend](https://github.com/Project-OSRM/osrm-backend/blob/master/AGENTS.md): harness and model named in the PR description only, and no session identifiers or log links in a public, permanent history.

🤖 Claude Code, Claude Opus 5
