### PR TITLE
feat: stop routes doubling back at a via point

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -343,6 +343,13 @@ var controlOptions = {
   units: mergedOptions.units,
   serviceUrl: services[0].path,
   useHints: false,
+  // Left to itself OSRM will u-turn at a via point rather than take a slightly
+  // longer way round, so the route is drawn back over the leg it just arrived
+  // on. Asking it to keep going straight leaves the stop by a different way:
+  // measured on a via off Hardenbergstraße, 1180 m round the block instead of
+  // 1150 m doubled back. It is a no-op on a route without via points, and OSRM
+  // relaxes the constraint rather than failing when a reversal is unavoidable.
+  requestParameters: {continue_straight: true},
   services: services,
   useZoomParameter: options.lrm.useZoomParameter,
   routeDragInterval: options.lrm.routeDragInterval,


### PR DESCRIPTION
Without `continue_straight`, OSRM is free to u-turn at a via point rather than take a slightly longer way round. The route then runs back over the leg it just arrived on, and the two overlap on the map — it looks like one line where there are two.

Requesting `continue_straight` makes the route leave the stop by a different way where one exists.

## Measurement

A via off Hardenbergstraße, foot profile, verified against `routing.openstreetmap.de`:

| | distance |
|---|---|
| `continue_straight=false` (current) | 1150 m, doubled back |
| `continue_straight=true` | 1180.3 m, round the block |

30 m for a route that no longer draws over itself.

## Scope

- No-op on routes without via points — the parameter only constrains behaviour *at* a via.
- OSRM relaxes the constraint rather than failing when a reversal is genuinely unavoidable; both requests above returned `Ok`.

## Testing

Config-only change to `controlOptions`, alongside the existing untested entries (`useHints`, `units`). No unit test — `src/index.js` is the entry point and is not imported by the suite. Verified against the live router as above; lint, build and the full suite pass locally.

🤖 Claude Code, Claude Opus 5
