### PR TITLE
feat: turn U-turn icons the way left-hand traffic drives them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ bundle.js
 bundle.js.LICENSE.txt
 bundle.js.map
 bundle*raw*
+gauche_rs.wasm
 dist/

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ Then compile assets and start the local server with
 npm start
 ```
 
+The build copies `gauche_rs.wasm` from the [gauche-rs](https://www.npmjs.com/package/gauche-rs) package next to
+`bundle.js`. The app loads it at startup to tell left-hand from right-hand traffic, so U-turn icons in the
+directions swing the way the maneuver is driven. Deployments must serve that file alongside `bundle.js`; without
+it the app falls back to the `driving_side` reported by the routing service.
+
 On Windows with no Unix tools installed (`bash` and `cp`) the server could be started with two other commands
 executed by `npm start` internally:
 

--- a/css/site.css
+++ b/css/site.css
@@ -770,6 +770,18 @@ td.distance {
 .leaflet-routing-icon-merge-right      { background-position: -403px 0px; }
 .leaflet-routing-icon-end              { background-position: -429px 0px; }
 
+/* The sprite draws the U-turn swinging to the right, which is how it is driven
+   where traffic keeps left. Everywhere else a U-turn swings to the left, so
+   the arrow is mirrored unless the row's maneuver is in left-hand traffic. */
+.leaflet-routing-icon-u-turn {
+    -webkit-transform: scaleX(-1);
+    transform: scaleX(-1);
+}
+.osrm-left-hand-traffic .leaflet-routing-icon-u-turn {
+    -webkit-transform: none;
+    transform: none;
+}
+
 /* Lane indications */
 .osrm-lane-icon {
   background-image: url('../images/osrm.lanes.icons.svg');
@@ -793,7 +805,8 @@ td.distance {
 .osrm-lane-icon.sharp-left    { background-position: -40px 0px; }
 .osrm-lane-icon.slight-left   { background-position: -60px 0px; }
 .osrm-lane-icon.uturn         { background-position: -80px 0px; }
-.osrm-lane-icon.uturn-right   { background-position: -100px 0px; }
+.osrm-lane-icon.uturn-right,
+.osrm-left-hand-traffic .osrm-lane-icon.uturn { background-position: -100px 0px; }
 .osrm-lane-icon.slight-right  { background-position: -120px 0px; }
 .osrm-lane-icon.sharp-right   { background-position: -140px 0px; }
 .osrm-lane-icon.right         { background-position: -160px 0px; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@mapbox/corslite": "^0.0.7",
         "file-saver": "^2.0.5",
+        "gauche-rs": "^0.1.0",
         "jsonp": "^0.2.1",
         "leaflet": "~1.9.4",
         "leaflet-control-geocoder": "^4.0.0",
@@ -3758,6 +3759,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/gauche-rs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/gauche-rs/-/gauche-rs-0.1.0.tgz",
+      "integrity": "sha512-VI48yTdD2CNZvZNgpU7gPD6DzJHfj7Nkv1ooRoHaxPFWdYUs4VxJ+Vt5JGwkn4ezOYbLgHrwklxmYUBSw6Uhog==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "test": "node --no-warnings node_modules/.bin/jest",
     "test:lint": "eslint src/*.js i18n/*.js",
     "replace": "node ./scripts/replace.js",
-    "clean": "rm -f bundle.raw.js",
-    "compile": "vite build && cp dist/bundle.js bundle.js && cp dist/bundle.js.map bundle.js.map",
-    "build": "npm run clean && npm run replace && npm run compile && cp node_modules/leaflet/dist/leaflet.css css/leaflet.css && cp -r index.html favicon.ico css fonts images i18n debug dist/",
+    "clean": "rm -f bundle.raw.js gauche_rs.wasm",
+    "compile": "vite build && cp dist/bundle.js bundle.js && cp dist/bundle.js.map bundle.js.map && cp node_modules/gauche-rs/gauche_rs.wasm gauche_rs.wasm",
+    "build": "npm run clean && npm run replace && npm run compile && cp node_modules/leaflet/dist/leaflet.css css/leaflet.css && cp -r index.html favicon.ico css fonts images i18n debug gauche_rs.wasm dist/",
     "start": "npm run build && vite preview",
     "start-prod": "npm run build && vite preview",
     "prepub": "npm run build"
@@ -46,6 +46,7 @@
   "dependencies": {
     "@mapbox/corslite": "^0.0.7",
     "file-saver": "^2.0.5",
+    "gauche-rs": "^0.1.0",
     "jsonp": "^0.2.1",
     "leaflet": "~1.9.4",
     "leaflet-control-geocoder": "^4.0.0",

--- a/src/driving_side.js
+++ b/src/driving_side.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// Which side of the road traffic keeps at a location, answered offline by
+// gauche-rs: the OSM driving-side polygons compiled into a WebAssembly module.
+// The itinerary needs this to draw a U-turn the way it is actually driven.
+//
+// The gauche-rs module is passed in rather than required here so the logic can
+// be exercised with a stand-in; the real module is ESM plus a .wasm fetch.
+
+var LEFT = 'left';
+var RIGHT = 'right';
+
+// Return values of gauche-rs' classify functions.
+var RIGHT_HAND_TRAFFIC = 0;
+var LEFT_HAND_TRAFFIC = 1;
+
+function createDrivingSideClassifier(gauche) {
+  var ready = false;
+  var loading = null;
+
+  return {
+    // Fetches and instantiates the WebAssembly module. Resolves once
+    // classifyPoint can answer; repeated calls share the first load.
+    load: function(wasmUrl) {
+      if (!loading) {
+        loading = Promise.resolve()
+          .then(function() {
+            return gauche.init(wasmUrl);
+          })
+          .then(function() {
+            ready = true;
+          });
+      }
+      return loading;
+    },
+
+    isReady: function() {
+      return ready;
+    },
+
+    // 'left' or 'right', or undefined while the module is still loading or
+    // when gauche-rs cannot classify the location.
+    classifyPoint: function(lat, lng) {
+      if (!ready) return undefined;
+      var result = gauche.classifyPoint(lat, lng);
+      if (result === LEFT_HAND_TRAFFIC) return LEFT;
+      if (result === RIGHT_HAND_TRAFFIC) return RIGHT;
+      return undefined;
+    }
+  };
+}
+
+// The driving side at an OSRM route step's maneuver. gauche-rs decides when it
+// is loaded; until then the backend's own driving_side stands in, and a backend
+// too old to report one leaves the side unknown.
+function stepDrivingSide(step, classifier) {
+  var location = step && step.maneuver && step.maneuver.location;
+  if (classifier && location && location.length >= 2) {
+    // OSRM locations are [longitude, latitude].
+    var side = classifier.classifyPoint(location[1], location[0]);
+    if (side) return side;
+  }
+  if (step && (step.driving_side === LEFT || step.driving_side === RIGHT)) {
+    return step.driving_side;
+  }
+  return undefined;
+}
+
+module.exports = {
+  LEFT: LEFT,
+  RIGHT: RIGHT,
+  createDrivingSideClassifier: createDrivingSideClassifier,
+  stepDrivingSide: stepDrivingSide
+};

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,8 @@ var initialLayers = require('./initial_layers');
 var layerUtils = require('./layer_utils');
 var routeZoom = require('./route_zoom');
 var resolveInitialAlternative = require('./route_alternative');
+var drivingSide = require('./driving_side');
+var gauche = require('gauche-rs');
 require('./polyfill');
 
 var parsedOptions = urlState.parse(window.location.search.slice(1));
@@ -61,8 +63,12 @@ for (var i = 0, len = services.length; i < len; i++) {
 }
 var modeSelector = modeSelectorModule.createModeSelector(localization.get(language), services);
 
+// Left-hand traffic detection for U-turn icons, backed by gauche-rs.
+var drivingSideClassifier = drivingSide.createDrivingSideClassifier(gauche);
+
 // load only after language was chosen
-var ItineraryBuilder = require('./itinerary_builder')(mergedOptions.language);
+var ItineraryBuilder = require('./itinerary_builder')(mergedOptions.language, drivingSideClassifier);
+var itineraryBuilder = new ItineraryBuilder();
 
 var mapLayer = leafletOptions.layer;
 var overlay = leafletOptions.overlay;
@@ -354,7 +360,7 @@ var controlOptions = {
   useZoomParameter: options.lrm.useZoomParameter,
   routeDragInterval: options.lrm.routeDragInterval,
   collapsible: options.lrm.collapsible,
-  itineraryBuilder: new ItineraryBuilder()
+  itineraryBuilder: itineraryBuilder
 };
 // profile labels already translated earlier
 
@@ -425,6 +431,16 @@ router._convertRoute = function(responseRoute) {
 var lrmControl = L.Routing.control(Object.assign(controlOptions, {
   router: router
 })).addTo(map);
+
+// The build puts gauche-rs' WebAssembly module next to bundle.js. It is
+// 1.7 MB, so a route requested from the URL is usually drawn before it has
+// loaded; those rows fall back to the backend's driving_side and are
+// classified again here. Without the module the fallback simply stays.
+drivingSideClassifier.load('gauche_rs.wasm').then(function() {
+  itineraryBuilder.refreshDrivingSide(lrmControl.getContainer());
+}, function(err) {
+  console.warn('Left-hand traffic detection unavailable, using the routing service\'s driving side', err);
+});
 
 // Workaround: Leaflet Routing Machine's itinerary adds a 'mousewheel' handler
 // that stops propagation in some browsers, which can prevent the directions pane

--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -1,8 +1,35 @@
 'use strict';
 
 var L = require('leaflet');
+var drivingSide = require('./driving_side');
 
-module.exports = function (language) {
+// Rows whose step keeps left carry this class; the stylesheet turns the
+// U-turn arrow and lane glyph the way the maneuver is driven off it.
+var LEFT_HAND_TRAFFIC_CLASS = 'osrm-left-hand-traffic';
+// Set on rows that show a U-turn, so they can be classified again once the
+// driving-side module has loaded.
+var MANEUVER_LOCATION_ATTRIBUTE = 'data-maneuver-location';
+
+function stepShowsUturn(step, icon) {
+  if (icon === 'u-turn') return true;
+  var lanes = step && step.intersections && step.intersections[0] && step.intersections[0].lanes;
+  if (!lanes) return false;
+  return lanes.some(function(lane) {
+    return lane.indications.indexOf('uturn') !== -1;
+  });
+}
+
+function applyDrivingSide(row, side) {
+  if (side === drivingSide.LEFT) {
+    L.DomUtil.addClass(row, LEFT_HAND_TRAFFIC_CLASS);
+  } else {
+    L.DomUtil.removeClass(row, LEFT_HAND_TRAFFIC_CLASS);
+  }
+}
+
+// drivingSideClassifier is the gauche-rs backed classifier from driving_side.js;
+// without one the backend's driving_side is all the itinerary has to go on.
+module.exports = function (language, drivingSideClassifier) {
   var osrmTextInstructions = require('osrm-text-instructions')('v5');
   var supportedCodes = require('osrm-text-instructions/languages').supportedCodes;
   // Fall back to English for directions text when the chosen language has no
@@ -63,10 +90,10 @@ module.exports = function (language) {
         }
         // transform lane indication into icon class
         var icon;
+        // A U-turn lane in left-hand traffic gets its glyph from the row's
+        // driving-side class, see markDrivingSide.
         if (indication === 'none' || indication === '')
           icon = 'straight'
-        else if (indication === 'uturn' && step.driving_side === 'left') // use u-turn icon for left driving side
-          icon = 'uturn-right';
         else
           icon = indication.replace(' ', '-');
         // calcuate offset to draw each next icons in the same lane on the same place
@@ -85,6 +112,14 @@ module.exports = function (language) {
         offset = indicationOffset;
       return spans;
     });
+  }
+
+  function markDrivingSide(row, step) {
+    var location = step.maneuver && step.maneuver.location;
+    if (location && location.length >= 2) {
+      row.setAttribute(MANEUVER_LOCATION_ATTRIBUTE, location[1] + ',' + location[0]);
+    }
+    applyDrivingSide(row, drivingSide.stepDrivingSide(step, drivingSideClassifier));
   }
 
   return L.Class.extend({
@@ -121,6 +156,10 @@ module.exports = function (language) {
       span = L.DomUtil.create('span', 'leaflet-routing-icon leaflet-routing-icon-' + icon, td);
       td.appendChild(span);
 
+      if (stepShowsUturn(text, icon)) {
+        markDrivingSide(row, text);
+      }
+
       // text instruction
       td = L.DomUtil.create('td', '', row);
       // keep HTML tags instead:
@@ -146,6 +185,19 @@ module.exports = function (language) {
       }
 
       return row;
+    },
+
+    // Classifies the U-turn rows under container again. Routes drawn before
+    // the driving-side module finished loading fell back to the backend's
+    // driving_side, or to nothing; this brings them in line with gauche-rs.
+    refreshDrivingSide: function(container) {
+      if (!drivingSideClassifier || !drivingSideClassifier.isReady()) return;
+      var rows = (container || document).querySelectorAll('tr[' + MANEUVER_LOCATION_ATTRIBUTE + ']');
+      for (var i = 0; i < rows.length; i++) {
+        var latLng = rows[i].getAttribute(MANEUVER_LOCATION_ATTRIBUTE).split(',');
+        var side = drivingSideClassifier.classifyPoint(parseFloat(latLng[0]), parseFloat(latLng[1]));
+        if (side) applyDrivingSide(rows[i], side);
+      }
     }
   });
 };

--- a/test/driving_side.test.js
+++ b/test/driving_side.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const {
+  createDrivingSideClassifier,
+  stepDrivingSide
+} = require('../src/driving_side');
+
+// A stand-in for the gauche-rs module: init() resolves, and classifyPoint
+// answers from a table keyed by "lat,lng" with gauche-rs' own return values
+// (0 right-hand traffic, 1 left-hand traffic, -1 invalid input).
+function fakeGauche(answers) {
+  const gauche = {
+    initCalls: 0,
+    init: jest.fn(function() {
+      gauche.initCalls++;
+      return Promise.resolve();
+    }),
+    classifyPoint: jest.fn(function(lat, lng) {
+      const key = lat + ',' + lng;
+      return key in answers ? answers[key] : -1;
+    })
+  };
+  return gauche;
+}
+
+const LONDON = { lat: 51.5074, lng: -0.1278 };
+const BERLIN = { lat: 52.52, lng: 13.405 };
+const ANSWERS = {
+  '51.5074,-0.1278': 1,
+  '52.52,13.405': 0
+};
+
+function uturnStep(latLng, drivingSide) {
+  const step = {
+    maneuver: { type: 'turn', modifier: 'uturn', location: [latLng.lng, latLng.lat] }
+  };
+  if (drivingSide) step.driving_side = drivingSide;
+  return step;
+}
+
+describe('createDrivingSideClassifier', () => {
+  test('answers nothing until the module has loaded', () => {
+    const classifier = createDrivingSideClassifier(fakeGauche(ANSWERS));
+    expect(classifier.isReady()).toBe(false);
+    expect(classifier.classifyPoint(LONDON.lat, LONDON.lng)).toBeUndefined();
+  });
+
+  test('maps gauche-rs results to left and right once loaded', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche(ANSWERS));
+    await classifier.load();
+    expect(classifier.isReady()).toBe(true);
+    expect(classifier.classifyPoint(LONDON.lat, LONDON.lng)).toBe('left');
+    expect(classifier.classifyPoint(BERLIN.lat, BERLIN.lng)).toBe('right');
+  });
+
+  test('leaves a location gauche-rs cannot classify undefined', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche(ANSWERS));
+    await classifier.load();
+    expect(classifier.classifyPoint(0, 0)).toBeUndefined();
+  });
+
+  test('passes the WebAssembly URL on and loads only once', async () => {
+    const gauche = fakeGauche(ANSWERS);
+    const classifier = createDrivingSideClassifier(gauche);
+    const first = classifier.load('gauche_rs.wasm');
+    const second = classifier.load('gauche_rs.wasm');
+    await Promise.all([first, second]);
+    expect(first).toBe(second);
+    expect(gauche.initCalls).toBe(1);
+    expect(gauche.init).toHaveBeenCalledWith('gauche_rs.wasm');
+  });
+
+  test('stays not ready when loading fails', async () => {
+    const gauche = fakeGauche(ANSWERS);
+    gauche.init = () => Promise.reject(new Error('HTTP 404'));
+    const classifier = createDrivingSideClassifier(gauche);
+    await expect(classifier.load()).rejects.toThrow('HTTP 404');
+    expect(classifier.isReady()).toBe(false);
+    expect(classifier.classifyPoint(LONDON.lat, LONDON.lng)).toBeUndefined();
+  });
+});
+
+describe('stepDrivingSide', () => {
+  test('classifies the maneuver location with gauche-rs when it is loaded', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche(ANSWERS));
+    await classifier.load();
+    expect(stepDrivingSide(uturnStep(LONDON), classifier)).toBe('left');
+    expect(stepDrivingSide(uturnStep(BERLIN), classifier)).toBe('right');
+  });
+
+  test('prefers gauche-rs over the driving_side the backend reports', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche(ANSWERS));
+    await classifier.load();
+    expect(stepDrivingSide(uturnStep(LONDON, 'right'), classifier)).toBe('left');
+  });
+
+  test('falls back to the driving_side the backend reports while loading', () => {
+    const classifier = createDrivingSideClassifier(fakeGauche(ANSWERS));
+    expect(stepDrivingSide(uturnStep(LONDON, 'left'), classifier)).toBe('left');
+    expect(stepDrivingSide(uturnStep(BERLIN, 'right'), classifier)).toBe('right');
+  });
+
+  test('falls back to the driving_side when gauche-rs cannot classify the location', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche(ANSWERS));
+    await classifier.load();
+    expect(stepDrivingSide(uturnStep({ lat: 0, lng: 0 }, 'left'), classifier)).toBe('left');
+  });
+
+  test('works without a classifier at all', () => {
+    expect(stepDrivingSide(uturnStep(LONDON, 'left'))).toBe('left');
+    expect(stepDrivingSide(uturnStep(LONDON))).toBeUndefined();
+  });
+
+  test('ignores a driving_side that is neither left nor right', () => {
+    expect(stepDrivingSide(uturnStep(LONDON, 'both'))).toBeUndefined();
+  });
+
+  test('copes with steps that have no maneuver location', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche(ANSWERS));
+    await classifier.load();
+    expect(stepDrivingSide({ maneuver: { type: 'turn' }, driving_side: 'left' }, classifier)).toBe('left');
+    expect(stepDrivingSide(undefined, classifier)).toBeUndefined();
+    expect(stepDrivingSide('Turn around', classifier)).toBeUndefined();
+  });
+});

--- a/test/itinerary_builder.test.js
+++ b/test/itinerary_builder.test.js
@@ -1,0 +1,179 @@
+/**
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+// A U-turn in left-hand traffic swings to the right, so the itinerary marks
+// the row and the stylesheet mirrors the arrow (and swaps the lane glyph).
+// The driving side comes from gauche-rs once it has loaded, and from the
+// backend's driving_side until then.
+
+const { createDrivingSideClassifier } = require('../src/driving_side');
+
+const LEFT_HAND_TRAFFIC_CLASS = 'osrm-left-hand-traffic';
+const LONDON = [-0.1278, 51.5074];   // [lng, lat], as OSRM reports locations
+const BERLIN = [13.405, 52.52];
+
+function fakeGauche() {
+  return {
+    init: () => Promise.resolve(),
+    classifyPoint: (lat, lng) => {
+      if (lat === LONDON[1] && lng === LONDON[0]) return 1;
+      if (lat === BERLIN[1] && lng === BERLIN[0]) return 0;
+      return -1;
+    }
+  };
+}
+
+function step(overrides) {
+  return Object.assign({
+    distance: 120,
+    duration: 20,
+    name: 'Whitehall',
+    mode: 'driving',
+    maneuver: { type: 'turn', modifier: 'uturn', location: LONDON, bearing_before: 0, bearing_after: 180 },
+    intersections: [{ location: LONDON, entry: [true], bearings: [0] }]
+  }, overrides);
+}
+
+function render(steps, classifier) {
+  const Builder = require('../src/itinerary_builder')('en', classifier);
+  const builder = new Builder();
+  const container = builder.createContainer();
+  const body = builder.createStepsContainer();
+  container.appendChild(body);
+  document.body.appendChild(container);
+  const rows = steps.map(([osrmStep, icon]) => builder.createStep(osrmStep, '120 m', icon, body));
+  return { builder, container, rows };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('U-turn rows', () => {
+  test('a U-turn in left-hand traffic marks the row once gauche-rs has loaded', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    await classifier.load();
+    const { rows } = render([[step(), 'u-turn']], classifier);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(true);
+    expect(rows[0].querySelector('.leaflet-routing-icon').className)
+      .toBe('leaflet-routing-icon leaflet-routing-icon-u-turn');
+  });
+
+  test('a U-turn in right-hand traffic leaves the row unmarked', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    await classifier.load();
+    const berlin = step({ maneuver: { type: 'turn', modifier: 'uturn', location: BERLIN } });
+    const { rows } = render([[berlin, 'u-turn']], classifier);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(false);
+  });
+
+  test('gauche-rs wins over the driving_side the backend reports', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    await classifier.load();
+    const { rows } = render([[step({ driving_side: 'right' }), 'u-turn']], classifier);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(true);
+  });
+
+  test('the backend driving_side stands in while gauche-rs is loading', () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    const { rows } = render([
+      [step({ driving_side: 'left' }), 'u-turn'],
+      [step({ driving_side: 'right' }), 'u-turn'],
+      [step(), 'u-turn']
+    ], classifier);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(true);
+    expect(rows[1].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(false);
+    expect(rows[2].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(false);
+  });
+
+  test('works without a classifier, from the backend driving_side alone', () => {
+    const { rows } = render([[step({ driving_side: 'left' }), 'u-turn']]);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(true);
+  });
+
+  test('other maneuvers are neither marked nor remembered for refresh', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    await classifier.load();
+    const left = step({ maneuver: { type: 'turn', modifier: 'left', location: LONDON } });
+    const { rows } = render([[left, 'turn-left']], classifier);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(false);
+    expect(rows[0].hasAttribute('data-maneuver-location')).toBe(false);
+  });
+});
+
+describe('refreshDrivingSide', () => {
+  test('classifies rows drawn before gauche-rs loaded', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    const berlin = step({ maneuver: { type: 'turn', modifier: 'uturn', location: BERLIN }, driving_side: 'left' });
+    const { builder, container, rows } = render([
+      [step(), 'u-turn'],   // London without a backend driving_side: unknown so far
+      [berlin, 'u-turn']    // backend says left, gauche-rs will say right
+    ], classifier);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(false);
+    expect(rows[1].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(true);
+
+    await classifier.load();
+    builder.refreshDrivingSide(container);
+
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(true);
+    expect(rows[1].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(false);
+  });
+
+  test('keeps the fallback where gauche-rs has no answer', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    const unknown = step({ maneuver: { type: 'turn', modifier: 'uturn', location: [0, 0] }, driving_side: 'left' });
+    const { builder, container, rows } = render([[unknown, 'u-turn']], classifier);
+    await classifier.load();
+    builder.refreshDrivingSide(container);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(true);
+  });
+
+  test('does nothing before gauche-rs has loaded or without a classifier', () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    const { builder, container, rows } = render([[step(), 'u-turn']], classifier);
+    builder.refreshDrivingSide(container);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(false);
+
+    const bare = render([[step(), 'u-turn']]);
+    expect(() => bare.builder.refreshDrivingSide(bare.container)).not.toThrow();
+  });
+});
+
+describe('U-turn lanes', () => {
+  function stepWithUturnLane(location) {
+    return step({
+      maneuver: { type: 'turn', modifier: 'left', location: location },
+      intersections: [{
+        location: location,
+        entry: [true],
+        bearings: [0],
+        lanes: [
+          { valid: true, indications: ['uturn'] },
+          { valid: true, indications: ['left'] },
+          { valid: false, indications: ['straight'] }
+        ]
+      }]
+    });
+  }
+
+  test('a lane allowing a U-turn marks the row in left-hand traffic', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    await classifier.load();
+    const { rows } = render([[stepWithUturnLane(LONDON), 'turn-left']], classifier);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(true);
+    const laneIcons = rows[0].querySelectorAll('.osrm-lane-icon');
+    expect(laneIcons[0].classList.contains('uturn')).toBe(true);
+    expect(laneIcons[1].classList.contains('left')).toBe(true);
+  });
+
+  test('and leaves it unmarked in right-hand traffic', async () => {
+    const classifier = createDrivingSideClassifier(fakeGauche());
+    await classifier.load();
+    const { rows } = render([[stepWithUturnLane(BERLIN), 'turn-left']], classifier);
+    expect(rows[0].classList.contains(LEFT_HAND_TRAFFIC_CLASS)).toBe(false);
+    expect(rows[0].querySelector('.osrm-lane-icon').classList.contains('uturn')).toBe(true);
+  });
+});

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,6 +1,28 @@
 import { defineConfig } from 'vite';
 
+// gauche-rs locates its WebAssembly module with new URL('./gauche_rs.wasm',
+// import.meta.url). That expression does not survive this build: in library
+// mode Vite inlines every such asset, growing bundle.js by 2.3 MB of base64,
+// and the UMD output has no import.meta to resolve against. The build script
+// places the module next to bundle.js instead, and index.js passes that URL to
+// init(), so the expression is dead code here: replace it with the same path.
+function keepGaucheWasmOutOfBundle() {
+  return {
+    name: 'osrm-frontend:keep-gauche-wasm-out-of-bundle',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!/gauche-rs[\\/]gauche\.js$/.test(id)) return null;
+      const wasmUrlExpression = "new URL('./gauche_rs.wasm', import.meta.url).href";
+      if (!code.includes(wasmUrlExpression)) {
+        this.error('gauche-rs no longer resolves its .wasm the way this plugin expects');
+      }
+      return { code: code.replace(wasmUrlExpression, "'gauche_rs.wasm'"), map: null };
+    }
+  };
+}
+
 export default defineConfig({
+  plugins: [keepGaucheWasmOutOfBundle()],
   build: {
     lib: {
       entry: './src/index.js',


### PR DESCRIPTION
Integrate gauche-rs, an offline WebAssembly classifier of OSM driving-side
areas, to tell whether a maneuver happens in left-hand traffic. Itinerary
rows with a U-turn (as the maneuver or as a lane indication) are marked
when gauche-rs says traffic keeps left there, and the stylesheet turns the
U-turn arrow and the lane glyph to swing right on those rows.

The maneuver sprite draws its U-turn swinging right, which is how it is
driven where traffic keeps left, so the arrow is now mirrored everywhere
else and shown as drawn in left-hand traffic. The lane sprite's right-hand
U-turn glyph, previously picked from the backend's driving_side, is chosen
by the same row marker.

gauche-rs decides once its 1.7 MB module has loaded; until then the
backend's driving_side stands in, and rows drawn in the meantime are
classified again when the module is ready. The build copies the .wasm
next to bundle.js rather than letting Vite inline it into the bundle.