### PR TITLE
feat: reorder waypoints by dragging them in the input panel

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -281,6 +281,54 @@
   transition: background-color 0.2s ease;
 }
 
+/* Waypoint reorder grip: a six-dot handle between the input and the remove
+   button. Dragging it moves the row; it also takes focus for the arrow keys. */
+.leaflet-routing-waypoint-handle {
+  display: inline-block;
+  vertical-align: middle;
+  width: 12px;
+  height: 18px;
+  margin-top: 6px;
+  cursor: grab;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  /* A 2x3 grid of dots drawn with gradients rather than a glyph, so it does
+     not depend on which fonts the device has. */
+  background-image: radial-gradient(circle, rgba(37,72,127, 0.6) 1.5px, transparent 2px);
+  background-size: 6px 6px;
+  background-position: 0 0;
+  background-repeat: repeat;
+}
+
+.leaflet-routing-waypoint-handle:hover,
+.leaflet-routing-waypoint-handle:focus {
+  background-image: radial-gradient(circle, rgba(37,72,127, 1) 1.5px, transparent 2px);
+}
+
+.leaflet-routing-waypoint-handle:focus-visible {
+  outline: 2px solid #0072b2;
+  outline-offset: 2px;
+}
+
+.leaflet-routing-geocoders .leaflet-routing-geocoder {
+  transition: transform 0.15s ease;
+}
+
+.leaflet-routing-geocoders-dragging,
+.leaflet-routing-geocoders-dragging * {
+  cursor: grabbing;
+}
+
+.leaflet-routing-geocoder-dragging {
+  transition: none;
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  background-color: white;
+}
+
 .leaflet-routing-alternatives-container {
   position: fixed;
   right: 0px;
@@ -535,7 +583,7 @@
 
 .osrm-directions-inputs input {
   font-size: 12px;
-  width: 90%;
+  width: calc(100% - 55px);
   background-color: transparent;
   color: rgba(0, 0, 0, 0.5);
   height: 30px;

--- a/css/site.css
+++ b/css/site.css
@@ -187,6 +187,8 @@
 
 .leaflet-routing-geocoders .leaflet-routing-geocoder {
   padding: 4px 0px 4px 0px;
+  /* Rows slide aside while another is dragged past them. */
+  transition: transform 0.15s ease;
 }
 
 .leaflet-routing-geocoder {
@@ -293,7 +295,6 @@
   width: 24px;
   height: 30px;
   padding: 6px;
-  margin-top: 0;
   background-clip: content-box;
   cursor: grab;
   touch-action: none;
@@ -304,8 +305,6 @@
      not depend on which fonts the device has. */
   background-image: radial-gradient(circle, rgba(37,72,127, 0.6) 1.5px, transparent 2px);
   background-size: 6px 6px;
-  background-position: 0 0;
-  background-repeat: repeat;
 }
 
 .leaflet-routing-waypoint-handle:hover,
@@ -325,17 +324,13 @@
   outline: none;
 }
 
-.leaflet-routing-geocoders .leaflet-routing-geocoder {
-  transition: transform 0.15s ease;
-}
-
 .leaflet-routing-geocoders-dragging,
 .leaflet-routing-geocoders-dragging * {
   cursor: grabbing;
 }
 
-/* Same specificity as the transition rule above and later in the file, so
-   the lifted row follows the pointer at once rather than easing after it. */
+/* Same specificity as the row's transition rule, so the lifted row follows
+   the pointer at once rather than easing after it. */
 .leaflet-routing-geocoders .leaflet-routing-geocoder-dragging {
   transition: none;
   position: relative;

--- a/css/site.css
+++ b/css/site.css
@@ -307,9 +307,16 @@
   background-image: radial-gradient(circle, rgba(37,72,127, 1) 1.5px, transparent 2px);
 }
 
-.leaflet-routing-waypoint-handle:focus-visible {
+/* The ring shows for keyboard focus only. A browser without :focus-visible
+   drops the second rule, and so shows the ring for every focus, which is the
+   safe way round. */
+.leaflet-routing-waypoint-handle:focus {
   outline: 2px solid #0072b2;
   outline-offset: 2px;
+}
+
+.leaflet-routing-waypoint-handle:focus:not(:focus-visible) {
+  outline: none;
 }
 
 .leaflet-routing-geocoders .leaflet-routing-geocoder {
@@ -1037,10 +1044,6 @@ td.distance {
 .osrm-directions-summary h3 {
   font-size: 12px;
   margin-left: -25px;
-}
-
-.osrm-directions-inputs input {
-  width: 70%;
 }
 
 .osrm-directions-inputs {

--- a/css/site.css
+++ b/css/site.css
@@ -286,9 +286,15 @@
 .leaflet-routing-waypoint-handle {
   display: inline-block;
   vertical-align: middle;
-  width: 12px;
-  height: 18px;
-  margin-top: 6px;
+  box-sizing: border-box;
+  /* The dots are 12x18; the padding round them makes the target 24x30,
+     which is what a finger or a quick mouse needs. background-clip keeps
+     the dots inside the content box. */
+  width: 24px;
+  height: 30px;
+  padding: 6px;
+  margin-top: 0;
+  background-clip: content-box;
   cursor: grab;
   touch-action: none;
   -webkit-user-select: none;
@@ -328,7 +334,9 @@
   cursor: grabbing;
 }
 
-.leaflet-routing-geocoder-dragging {
+/* Same specificity as the transition rule above and later in the file, so
+   the lifted row follows the pointer at once rather than easing after it. */
+.leaflet-routing-geocoders .leaflet-routing-geocoder-dragging {
   transition: none;
   position: relative;
   z-index: 1;

--- a/i18n/de.js
+++ b/i18n/de.js
@@ -13,6 +13,7 @@ module.exports = {
   'Start - press enter to drop marker': 'Start - drücken um einen Marker zu plazieren',
   'End - press enter to drop marker': 'Ende - drücken um einen Marker zu plazieren',
   'Via point - press enter to drop marker': 'Zwischenstop - drücken um einen Marker zu plazieren',
+  'Drag to reorder': 'Zum Umsortieren ziehen oder die Pfeiltasten hoch/runter drücken',
   'Bike': 'Fahrrad',
   'Car': 'Auto',
   'Foot': 'Fussgänger',

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -13,6 +13,7 @@ module.exports = {
   'Start - press enter to drop marker': 'Start - press enter to drop marker',
   'End - press enter to drop marker': 'End - press enter to drop marker',
   'Via point - press enter to drop marker': 'Via point - press enter to drop marker',
+  'Drag to reorder': 'Drag to reorder, or press the up and down arrow keys',
   'Bike': 'Bike',
   'Car': 'Car',
   'Foot': 'Foot',

--- a/src/index.js
+++ b/src/index.js
@@ -678,6 +678,12 @@ plan.on('waypointdragstart', function() {
   routeFitTracker.waypointDragStarted();
 });
 
+// Reordering from the panel rearranges places already on the map; the view
+// stays where it is.
+plan.on('waypointsreorder', function() {
+  routeFitTracker.waypointsReordered();
+});
+
 lrmControl.on('routingerror', function() {
   routeFitTracker.routingFailed();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ var layerUtils = require('./layer_utils');
 var routeZoom = require('./route_zoom');
 var resolveInitialAlternative = require('./route_alternative');
 var waypointMarker = require('./waypoint_marker');
+var waypointReorder = require('./waypoint_reorder');
 require('./polyfill');
 
 var parsedOptions = urlState.parse(window.location.search.slice(1));
@@ -260,6 +261,12 @@ var ReversablePlan = L.Routing.Plan.extend({
       }
     }
     return container;
+  },
+  // The rows are rebuilt on every waypoint change, so the reorder grips are
+  // wired again after each rebuild.
+  _updateGeocoders: function() {
+    L.Routing.Plan.prototype._updateGeocoders.call(this);
+    waypointReorder.attachToPlan(this);
   }
 });
 
@@ -292,6 +299,7 @@ var plan = new ReversablePlan([], {
   reverseWaypoints: true,
   dragStyles: options.lrm.dragStyles,
   geocodersClassName: options.lrm.geocodersClassName,
+  createGeocoder: waypointReorder.createGeocoder,
   geocoderPlaceholder: function(i, n, geocoderElement) {
     var activeLanguage = geocoderElement && geocoderElement.options ? geocoderElement.options.language : mergedOptions.language;
     var startend = [localization.t(activeLanguage, 'Start - press enter to drop marker'), localization.t(activeLanguage, 'End - press enter to drop marker')];

--- a/src/route_zoom.js
+++ b/src/route_zoom.js
@@ -62,6 +62,14 @@ function createRouteFitTracker() {
       routeRequestFromDrag = true;
       geocodeFromDrag = true;
     },
+    // Reordering from the panel is a rearrangement of places the user has
+    // already put on the map, so the view stays put like it does for a drag.
+    // No reverse geocode follows (the names travel with the waypoints), so
+    // only the route request is marked; marking the geocode too would swallow
+    // the pan of the next typed address.
+    waypointsReordered: function() {
+      routeRequestFromDrag = true;
+    },
     waypointPlaced: function() {
       routeRequestFromDrag = false;
       geocodeFromDrag = false;

--- a/src/state.js
+++ b/src/state.js
@@ -3,6 +3,7 @@
 var L = require('leaflet');
 var links = require('./links');
 var urlState = require('./url_state');
+var waypointReorder = require('./waypoint_reorder');
 
 var State = L.Class.extend({
   options: { },
@@ -54,6 +55,7 @@ var State = L.Class.extend({
             );
           }
         });
+        waypointReorder.updateLabels(plan._geocoderContainer, e.language);
       }
       
       // Re-render directions with new language if routes exist.

--- a/src/waypoint_reorder.js
+++ b/src/waypoint_reorder.js
@@ -24,26 +24,16 @@ var DRAGGING_LIST_CLASS = 'leaflet-routing-geocoders-dragging';
 // drag rather than a click, so focusing the grip does not twitch the row.
 var DRAG_THRESHOLD_PX = 3;
 
-var LABEL_KEY = 'Drag to reorder';
-
-// Returns a copy of `list` with the item at `from` moved to `to`. Indexes
-// outside the list are clamped, so the callers need not check.
+// Returns a copy of `list` with the item at `from` moved to `to`.
 function moveWaypoint(list, from, to) {
-  var last = list.length - 1;
-  from = Math.max(0, Math.min(last, from));
-  to = Math.max(0, Math.min(last, to));
   var moved = list.slice();
   var item = moved.splice(from, 1)[0];
   moved.splice(to, 0, item);
   return moved;
 }
 
-function handleLabel(language) {
-  return localization.t(language, LABEL_KEY);
-}
-
 function setHandleLabel(handle, language) {
-  var label = handleLabel(language);
+  var label = localization.t(language, 'Drag to reorder');
   handle.setAttribute('title', label);
   handle.setAttribute('aria-label', label);
 }
@@ -141,7 +131,7 @@ function wirePointerDrag(container, row, from, onMove) {
     var to = from;
 
     function isThisPointer(e) {
-      return e.pointerId === undefined || e.pointerId === pointerId;
+      return e.pointerId === pointerId;
     }
 
     function move(e) {
@@ -163,7 +153,7 @@ function wirePointerDrag(container, row, from, onMove) {
       document.removeEventListener('pointermove', move);
       document.removeEventListener('pointerup', drop);
       document.removeEventListener('pointercancel', cancel);
-      document.removeEventListener('keydown', escape);
+      document.removeEventListener('keydown', onEscape);
       if (handle.releasePointerCapture) {
         try {
           handle.releasePointerCapture(pointerId);
@@ -182,12 +172,11 @@ function wirePointerDrag(container, row, from, onMove) {
     }
 
     function cancel(e) {
-      if (e && !isThisPointer(e)) return;
-      finish();
+      if (isThisPointer(e)) finish();
     }
 
-    function escape(e) {
-      if (e.key === 'Escape' || e.key === 'Esc') finish();
+    function onEscape(e) {
+      if (e.key === 'Escape') finish();
     }
 
     // preventDefault stops the press selecting text and, on a touch screen,
@@ -207,16 +196,16 @@ function wirePointerDrag(container, row, from, onMove) {
     document.addEventListener('pointermove', move);
     document.addEventListener('pointerup', drop);
     document.addEventListener('pointercancel', cancel);
-    document.addEventListener('keydown', escape);
+    document.addEventListener('keydown', onEscape);
   });
 }
 
 function wireKeyboard(row, from, count, onMove) {
   L.DomEvent.on(handleOf(row), 'keydown', function(e) {
     var to;
-    if (e.key === 'ArrowUp' || e.key === 'Up') {
+    if (e.key === 'ArrowUp') {
       to = from - 1;
-    } else if (e.key === 'ArrowDown' || e.key === 'Down') {
+    } else if (e.key === 'ArrowDown') {
       to = from + 1;
     } else {
       return;
@@ -274,7 +263,6 @@ module.exports = {
   createGeocoder: createGeocoder,
   attach: attach,
   attachToPlan: attachToPlan,
-  focusHandle: focusHandle,
   updateLabels: updateLabels,
   HANDLE_CLASS: HANDLE_CLASS,
   DRAGGING_ROW_CLASS: DRAGGING_ROW_CLASS,

--- a/src/waypoint_reorder.js
+++ b/src/waypoint_reorder.js
@@ -1,0 +1,253 @@
+'use strict';
+
+// Reordering waypoints from the input panel (issue #19).
+//
+// Each waypoint row carries a grip at its right-hand end. Dragging the grip
+// with a mouse, pen or finger lifts the row and slides the others out of its
+// way; dropping it moves the waypoint to where the row landed. The grip also
+// takes keyboard focus, and the up and down arrow keys move the waypoint one
+// row at a time, so reordering does not depend on a pointer.
+//
+// The rows themselves are rebuilt by Leaflet Routing Machine every time the
+// waypoints change, so nothing here holds on to a row: attachToPlan runs after
+// every rebuild and wires whatever rows are there now.
+
+var L = require('leaflet');
+var localization = require('./localization');
+
+var ROW_CLASS = 'leaflet-routing-geocoder';
+var HANDLE_CLASS = 'leaflet-routing-waypoint-handle';
+var DRAGGING_ROW_CLASS = 'leaflet-routing-geocoder-dragging';
+var DRAGGING_LIST_CLASS = 'leaflet-routing-geocoders-dragging';
+
+// How far the pointer has to travel before a press on the grip counts as a
+// drag rather than a click, so focusing the grip does not twitch the row.
+var DRAG_THRESHOLD_PX = 3;
+
+var LABEL_KEY = 'Drag to reorder';
+
+// Returns a copy of `list` with the item at `from` moved to `to`. Indexes
+// outside the list are clamped, so the callers need not check.
+function moveWaypoint(list, from, to) {
+  var last = list.length - 1;
+  from = Math.max(0, Math.min(last, from));
+  to = Math.max(0, Math.min(last, to));
+  var moved = list.slice();
+  var item = moved.splice(from, 1)[0];
+  moved.splice(to, 0, item);
+  return moved;
+}
+
+function handleLabel(language) {
+  return localization.t(language, LABEL_KEY);
+}
+
+function setHandleLabel(handle, language) {
+  var label = handleLabel(language);
+  handle.setAttribute('title', label);
+  handle.setAttribute('aria-label', label);
+}
+
+// Drop-in for Leaflet Routing Machine's createGeocoder option: the same row
+// (input and remove button, with the same class names the stylesheet keys on)
+// plus the grip between them.
+function createGeocoder(i, nWps, options) {
+  var container = L.DomUtil.create('div', ROW_CLASS);
+  var input = L.DomUtil.create('input', '', container);
+  var handle = L.DomUtil.create('span', HANDLE_CLASS, container);
+  var remove = options.addWaypoints ? L.DomUtil.create('span', 'leaflet-routing-remove-waypoint', container) : undefined;
+
+  input.disabled = !options.addWaypoints;
+
+  handle.setAttribute('role', 'button');
+  handle.setAttribute('tabindex', '0');
+  setHandleLabel(handle, options.language);
+
+  return {
+    container: container,
+    input: input,
+    closeButton: remove
+  };
+}
+
+function rowsOf(container) {
+  return Array.prototype.slice.call(container.querySelectorAll('.' + ROW_CLASS));
+}
+
+function handleOf(row) {
+  return row.querySelector('.' + HANDLE_CLASS);
+}
+
+// The row the dragged one would land on: how many of the other rows have
+// their middle above the dragged row's current middle.
+function dropIndexFor(rects, from, draggedCentreY) {
+  var index = 0;
+  for (var i = 0; i < rects.length; i++) {
+    if (i === from) continue;
+    if (rects[i].top + rects[i].height / 2 < draggedCentreY) index++;
+  }
+  return index;
+}
+
+// Slides the rows between the dragged row and its drop target out of the way,
+// so the gap the row will drop into is visible while it is still in the air.
+function shiftRows(rows, from, to, draggedHeight) {
+  for (var i = 0; i < rows.length; i++) {
+    if (i === from) continue;
+    var shift = 0;
+    if (to > from && i > from && i <= to) shift = -draggedHeight;
+    if (to < from && i >= to && i < from) shift = draggedHeight;
+    rows[i].style.transform = shift ? 'translateY(' + shift + 'px)' : '';
+  }
+}
+
+function clearShifts(rows) {
+  for (var i = 0; i < rows.length; i++) {
+    rows[i].style.transform = '';
+  }
+}
+
+function wirePointerDrag(container, row, from, onMove) {
+  var handle = handleOf(row);
+
+  L.DomEvent.on(handle, 'pointerdown', function(e) {
+    // Only the primary button: a right-click on the grip is a context menu.
+    if (e.button) return;
+
+    var rows = rowsOf(container);
+    var rects = rows.map(function(r) {
+      return r.getBoundingClientRect();
+    });
+    var startY = e.clientY;
+    var centreY = rects[from].top + rects[from].height / 2;
+    var dragging = false;
+    var to = from;
+
+    function move(e) {
+      var dy = e.clientY - startY;
+      if (!dragging) {
+        if (Math.abs(dy) < DRAG_THRESHOLD_PX) return;
+        dragging = true;
+        L.DomUtil.addClass(row, DRAGGING_ROW_CLASS);
+        L.DomUtil.addClass(container, DRAGGING_LIST_CLASS);
+      }
+      row.style.transform = 'translateY(' + dy + 'px)';
+      to = dropIndexFor(rects, from, centreY + dy);
+      shiftRows(rows, from, to, rects[from].height);
+    }
+
+    function finish() {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', drop);
+      document.removeEventListener('pointercancel', cancel);
+      document.removeEventListener('keydown', escape);
+      if (handle.releasePointerCapture) {
+        try {
+          handle.releasePointerCapture(e.pointerId);
+        } catch (err) {}
+      }
+      clearShifts(rows);
+      L.DomUtil.removeClass(row, DRAGGING_ROW_CLASS);
+      L.DomUtil.removeClass(container, DRAGGING_LIST_CLASS);
+    }
+
+    function drop() {
+      var moved = dragging && to !== from;
+      finish();
+      if (moved) onMove(from, to, false);
+    }
+
+    function cancel() {
+      finish();
+    }
+
+    function escape(e) {
+      if (e.key === 'Escape' || e.key === 'Esc') cancel();
+    }
+
+    // preventDefault stops the press selecting text and, on a touch screen,
+    // stops the compatibility mouse events that would otherwise reach the
+    // map. Stopping propagation keeps Leaflet's own handlers out of it.
+    L.DomEvent.stop(e);
+    // preventDefault also stops the press giving the grip focus, which it
+    // needs so the arrow keys work after a click.
+    handle.focus();
+    if (handle.setPointerCapture) {
+      try {
+        handle.setPointerCapture(e.pointerId);
+      } catch (err) {}
+    }
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', drop);
+    document.addEventListener('pointercancel', cancel);
+    document.addEventListener('keydown', escape);
+  });
+}
+
+function wireKeyboard(row, from, count, onMove) {
+  L.DomEvent.on(handleOf(row), 'keydown', function(e) {
+    var to;
+    if (e.key === 'ArrowUp' || e.key === 'Up') {
+      to = from - 1;
+    } else if (e.key === 'ArrowDown' || e.key === 'Down') {
+      to = from + 1;
+    } else {
+      return;
+    }
+    L.DomEvent.stop(e);
+    if (to < 0 || to >= count) return;
+    onMove(from, to, true);
+  });
+}
+
+// Wires the grips of the rows currently in `container`. onMove(from, to,
+// viaKeyboard) is called once per completed reorder.
+function attach(container, onMove) {
+  var rows = rowsOf(container);
+  rows.forEach(function(row, i) {
+    if (!handleOf(row)) return;
+    wirePointerDrag(container, row, i, onMove);
+    wireKeyboard(row, i, rows.length, onMove);
+  });
+}
+
+function focusHandle(container, index) {
+  var row = rowsOf(container)[index];
+  var handle = row && handleOf(row);
+  if (handle) handle.focus();
+}
+
+// Call after the plan has rebuilt its geocoder rows. A reorder re-orders the
+// plan's waypoints, which rebuilds the rows again; a keyboard reorder then
+// puts focus back on the grip it left, in its new row.
+function attachToPlan(plan) {
+  var container = plan._geocoderContainer;
+  if (!container) return;
+  attach(container, function(from, to, viaKeyboard) {
+    plan.setWaypoints(moveWaypoint(plan.getWaypoints(), from, to));
+    if (viaKeyboard) focusHandle(plan._geocoderContainer, to);
+  });
+}
+
+// Re-labels the grips when the interface language changes; the rows are not
+// rebuilt for that.
+function updateLabels(container, language) {
+  if (!container) return;
+  rowsOf(container).forEach(function(row) {
+    var handle = handleOf(row);
+    if (handle) setHandleLabel(handle, language);
+  });
+}
+
+module.exports = {
+  moveWaypoint: moveWaypoint,
+  createGeocoder: createGeocoder,
+  attach: attach,
+  attachToPlan: attachToPlan,
+  focusHandle: focusHandle,
+  updateLabels: updateLabels,
+  HANDLE_CLASS: HANDLE_CLASS,
+  DRAGGING_ROW_CLASS: DRAGGING_ROW_CLASS,
+  DRAGGING_LIST_CLASS: DRAGGING_LIST_CLASS,
+  DRAG_THRESHOLD_PX: DRAG_THRESHOLD_PX
+};

--- a/src/waypoint_reorder.js
+++ b/src/waypoint_reorder.js
@@ -78,13 +78,23 @@ function handleOf(row) {
   return row.querySelector('.' + HANDLE_CLASS);
 }
 
-// The row the dragged one would land on: how many of the other rows have
-// their middle above the dragged row's current middle.
-function dropIndexFor(rects, from, draggedCentreY) {
-  var index = 0;
-  for (var i = 0; i < rects.length; i++) {
-    if (i === from) continue;
-    if (rects[i].top + rects[i].height / 2 < draggedCentreY) index++;
+// The row the dragged one would land on. Moving down, it passes a row once
+// its bottom edge is past that row's middle; moving up, once its top edge
+// is. So a neighbour swaps after half a row of travel, and the end rows are
+// reachable with the row pinned to the list's ends.
+function dropIndexFor(rects, from, dy) {
+  var top = rects[from].top + dy;
+  var bottom = top + rects[from].height;
+  var index = from;
+  var i;
+  if (dy > 0) {
+    for (i = from + 1; i < rects.length; i++) {
+      if (rects[i].top + rects[i].height / 2 < bottom) index = i;
+    }
+  } else {
+    for (i = from - 1; i >= 0; i--) {
+      if (rects[i].top + rects[i].height / 2 > top) index = i;
+    }
   }
   return index;
 }
@@ -122,7 +132,11 @@ function wirePointerDrag(container, row, from, onMove) {
     // pen, must not steer or drop the row this one lifted.
     var pointerId = e.pointerId;
     var startY = e.clientY;
-    var centreY = rects[from].top + rects[from].height / 2;
+    // The row stays within the list: past its ends there is nowhere to drop,
+    // and the list clips (or scrolls) whatever leaves it.
+    var last = rects[rects.length - 1];
+    var minDy = rects[0].top - rects[from].top;
+    var maxDy = (last.top + last.height) - (rects[from].top + rects[from].height);
     var dragging = false;
     var to = from;
 
@@ -139,8 +153,9 @@ function wirePointerDrag(container, row, from, onMove) {
         L.DomUtil.addClass(row, DRAGGING_ROW_CLASS);
         L.DomUtil.addClass(container, DRAGGING_LIST_CLASS);
       }
+      dy = Math.max(minDy, Math.min(maxDy, dy));
       row.style.transform = 'translateY(' + dy + 'px)';
-      to = dropIndexFor(rects, from, centreY + dy);
+      to = dropIndexFor(rects, from, dy);
       shiftRows(rows, from, to, rects[from].height);
     }
 
@@ -180,8 +195,10 @@ function wirePointerDrag(container, row, from, onMove) {
     // map. Stopping propagation keeps Leaflet's own handlers out of it.
     L.DomEvent.stop(e);
     // preventDefault also stops the press giving the grip focus, which it
-    // needs so the arrow keys work after a click.
-    handle.focus();
+    // needs so the arrow keys work after a click. preventScroll: focusing
+    // must not scroll the list, or the row positions measured above are
+    // wrong for the whole drag.
+    handle.focus({preventScroll: true});
     if (handle.setPointerCapture) {
       try {
         handle.setPointerCapture(pointerId);

--- a/src/waypoint_reorder.js
+++ b/src/waypoint_reorder.js
@@ -251,6 +251,9 @@ function attachToPlan(plan) {
   var container = plan._geocoderContainer;
   if (!container) return;
   attach(container, function(from, to, viaKeyboard) {
+    // Fired before the change so a listener can decide how to treat the
+    // waypointschanged and route that follow.
+    plan.fire('waypointsreorder', {from: from, to: to});
     plan.setWaypoints(moveWaypoint(plan.getWaypoints(), from, to));
     if (viaKeyboard) focusHandle(plan._geocoderContainer, to);
   });

--- a/src/waypoint_reorder.js
+++ b/src/waypoint_reorder.js
@@ -118,12 +118,20 @@ function wirePointerDrag(container, row, from, onMove) {
     var rects = rows.map(function(r) {
       return r.getBoundingClientRect();
     });
+    // Every pointer has its own id; a second finger, or a mouse alongside a
+    // pen, must not steer or drop the row this one lifted.
+    var pointerId = e.pointerId;
     var startY = e.clientY;
     var centreY = rects[from].top + rects[from].height / 2;
     var dragging = false;
     var to = from;
 
+    function isThisPointer(e) {
+      return e.pointerId === undefined || e.pointerId === pointerId;
+    }
+
     function move(e) {
+      if (!isThisPointer(e)) return;
       var dy = e.clientY - startY;
       if (!dragging) {
         if (Math.abs(dy) < DRAG_THRESHOLD_PX) return;
@@ -143,7 +151,7 @@ function wirePointerDrag(container, row, from, onMove) {
       document.removeEventListener('keydown', escape);
       if (handle.releasePointerCapture) {
         try {
-          handle.releasePointerCapture(e.pointerId);
+          handle.releasePointerCapture(pointerId);
         } catch (err) {}
       }
       clearShifts(rows);
@@ -151,18 +159,20 @@ function wirePointerDrag(container, row, from, onMove) {
       L.DomUtil.removeClass(container, DRAGGING_LIST_CLASS);
     }
 
-    function drop() {
+    function drop(e) {
+      if (!isThisPointer(e)) return;
       var moved = dragging && to !== from;
       finish();
       if (moved) onMove(from, to, false);
     }
 
-    function cancel() {
+    function cancel(e) {
+      if (e && !isThisPointer(e)) return;
       finish();
     }
 
     function escape(e) {
-      if (e.key === 'Escape' || e.key === 'Esc') cancel();
+      if (e.key === 'Escape' || e.key === 'Esc') finish();
     }
 
     // preventDefault stops the press selecting text and, on a touch screen,
@@ -174,7 +184,7 @@ function wirePointerDrag(container, row, from, onMove) {
     handle.focus();
     if (handle.setPointerCapture) {
       try {
-        handle.setPointerCapture(e.pointerId);
+        handle.setPointerCapture(pointerId);
       } catch (err) {}
     }
     document.addEventListener('pointermove', move);

--- a/test/route_zoom.test.js
+++ b/test/route_zoom.test.js
@@ -210,6 +210,33 @@ describe('route fit tracker', function() {
     expect(tracker.isFitPending()).toBe(false);
   });
 
+  test('suppresses the fit for the route that follows a reorder', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointsReordered();
+    tracker.routesFound();
+
+    expect(tracker.isFitPending()).toBe(false);
+  });
+
+  test('fits again on the first route after a reorder', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointsReordered();
+    tracker.routesFound();
+    tracker.routesFound();
+
+    expect(tracker.isFitPending()).toBe(true);
+  });
+
+  test('a reorder does not swallow the pan of the next typed address', function() {
+    var tracker = routeZoom.createRouteFitTracker();
+
+    tracker.waypointsReordered();
+
+    expect(tracker.waypointGeocoded()).toBe(true);
+  });
+
   test('centers a clicked waypoint after an unfinished drag', function() {
     var tracker = routeZoom.createRouteFitTracker();
 

--- a/test/waypoint_reorder.test.js
+++ b/test/waypoint_reorder.test.js
@@ -58,6 +58,10 @@ function centreOf(i) {
 function fakePlan(count) {
   const plan = {
     _waypoints: Array.from({ length: count }, (_, i) => ({ name: 'wp' + i })),
+    events: [],
+    fire(type, data) {
+      this.events.push({ type, data, order: this._waypoints.map(wp => wp.name) });
+    },
     getWaypoints() {
       return this._waypoints.slice();
     },
@@ -321,6 +325,14 @@ describe('attachToPlan', () => {
     pointer(document, 'pointermove', centreOf(0));
     pointer(document, 'pointerup', centreOf(0));
     expect(plan.getWaypoints().map(wp => wp.name)).toEqual(['wp2', 'wp1', 'wp0']);
+  });
+
+  test('announces the reorder on the plan before changing the waypoints', () => {
+    const plan = fakePlan(3);
+    key(handle(plan._geocoderContainer, 0), 'ArrowDown');
+    expect(plan.events).toEqual([
+      { type: 'waypointsreorder', data: { from: 0, to: 1 }, order: ['wp0', 'wp1', 'wp2'] }
+    ]);
   });
 
   test('a plan without rows yet is left alone', () => {

--- a/test/waypoint_reorder.test.js
+++ b/test/waypoint_reorder.test.js
@@ -12,11 +12,11 @@ const ROW_HEIGHT = 40;
 
 // Builds the rows the plan would build for `count` waypoints and lays them
 // out as a column, since jsdom does not do layout.
-function buildRows(count, options) {
+function buildRows(count) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   for (let i = 0; i < count; i++) {
-    const row = reorder.createGeocoder(i, count, options || { addWaypoints: true, language: 'en' }).container;
+    const row = reorder.createGeocoder(i, count, { addWaypoints: true, language: 'en' }).container;
     row.querySelector('input').value = 'wp' + i;
     row.getBoundingClientRect = () => ({ top: i * ROW_HEIGHT, height: ROW_HEIGHT, bottom: (i + 1) * ROW_HEIGHT });
     container.appendChild(row);
@@ -96,11 +96,6 @@ describe('moveWaypoint', () => {
 
   test('a move onto itself is a copy', () => {
     expect(reorder.moveWaypoint(['a', 'b'], 1, 1)).toEqual(['a', 'b']);
-  });
-
-  test('clamps indexes to the list', () => {
-    expect(reorder.moveWaypoint(['a', 'b', 'c'], 0, 99)).toEqual(['b', 'c', 'a']);
-    expect(reorder.moveWaypoint(['a', 'b', 'c'], -5, 1)).toEqual(['b', 'a', 'c']);
   });
 });
 

--- a/test/waypoint_reorder.test.js
+++ b/test/waypoint_reorder.test.js
@@ -171,6 +171,16 @@ describe('dragging a grip', () => {
     expect(rows(container).map(r => r.style.transform)).toEqual(['', '', '', '']);
   });
 
+  test('the row cannot be dragged past either end of the list', () => {
+    pointer(handle(container, 0), 'pointerdown', centreOf(0));
+    pointer(document, 'pointermove', centreOf(0) - 100);
+    expect(rows(container)[0].style.transform).toBe('translateY(0px)');
+    pointer(document, 'pointermove', centreOf(0) + 1000);
+    expect(rows(container)[0].style.transform).toBe('translateY(' + 3 * ROW_HEIGHT + 'px)');
+    pointer(document, 'pointerup', centreOf(0) + 1000);
+    expect(moves).toEqual([[0, 3, false]]);
+  });
+
   test('a press that barely moves is a click, not a drag', () => {
     pointer(handle(container, 1), 'pointerdown', centreOf(1));
     pointer(document, 'pointermove', centreOf(1) + reorder.DRAG_THRESHOLD_PX - 1);

--- a/test/waypoint_reorder.test.js
+++ b/test/waypoint_reorder.test.js
@@ -37,9 +37,12 @@ function order(container) {
 }
 
 // jsdom has no PointerEvent; the handlers only read clientY, button and
-// pointerId, which MouseEvent carries.
+// pointerId, so a MouseEvent carrying a pointerId stands in for one.
 function pointer(target, type, clientY, extra) {
-  target.dispatchEvent(new window.MouseEvent(type, Object.assign({ bubbles: true, clientY: clientY, button: 0 }, extra)));
+  const init = Object.assign({ bubbles: true, clientY: clientY, button: 0, pointerId: 1 }, extra);
+  const event = new window.MouseEvent(type, init);
+  Object.defineProperty(event, 'pointerId', { value: init.pointerId });
+  target.dispatchEvent(event);
 }
 
 function key(target, keyName) {
@@ -201,6 +204,20 @@ describe('dragging a grip', () => {
     pointer(document, 'pointerup', centreOf(2));
     expect(moves).toEqual([]);
     expect(rows(container).map(r => r.style.transform)).toEqual(['', '', '', '']);
+  });
+
+  test('another pointer cannot steer or drop the row this one lifted', () => {
+    pointer(handle(container, 0), 'pointerdown', centreOf(0), { pointerId: 1 });
+    pointer(document, 'pointermove', centreOf(2) + 1, { pointerId: 2 });
+    expect(rows(container)[0].style.transform).toBe('');
+    pointer(document, 'pointerup', centreOf(2) + 1, { pointerId: 2 });
+    expect(moves).toEqual([]);
+    pointer(document, 'pointercancel', centreOf(2) + 1, { pointerId: 2 });
+
+    // The drag is still live for the pointer that started it.
+    pointer(document, 'pointermove', centreOf(2) + 1, { pointerId: 1 });
+    pointer(document, 'pointerup', centreOf(2) + 1, { pointerId: 1 });
+    expect(moves).toEqual([[0, 2, false]]);
   });
 
   test('only the primary button starts a drag', () => {

--- a/test/waypoint_reorder.test.js
+++ b/test/waypoint_reorder.test.js
@@ -1,0 +1,320 @@
+/**
+ * @jest-environment jsdom
+ */
+'use strict';
+
+// Waypoints can be reordered from the input panel, by dragging a row's grip
+// or by moving it with the arrow keys (issue #19).
+
+const reorder = require('../src/waypoint_reorder');
+
+const ROW_HEIGHT = 40;
+
+// Builds the rows the plan would build for `count` waypoints and lays them
+// out as a column, since jsdom does not do layout.
+function buildRows(count, options) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  for (let i = 0; i < count; i++) {
+    const row = reorder.createGeocoder(i, count, options || { addWaypoints: true, language: 'en' }).container;
+    row.querySelector('input').value = 'wp' + i;
+    row.getBoundingClientRect = () => ({ top: i * ROW_HEIGHT, height: ROW_HEIGHT, bottom: (i + 1) * ROW_HEIGHT });
+    container.appendChild(row);
+  }
+  return container;
+}
+
+function rows(container) {
+  return Array.from(container.querySelectorAll('.leaflet-routing-geocoder'));
+}
+
+function handle(container, i) {
+  return rows(container)[i].querySelector('.' + reorder.HANDLE_CLASS);
+}
+
+function order(container) {
+  return rows(container).map(row => row.querySelector('input').value);
+}
+
+// jsdom has no PointerEvent; the handlers only read clientY, button and
+// pointerId, which MouseEvent carries.
+function pointer(target, type, clientY, extra) {
+  target.dispatchEvent(new window.MouseEvent(type, Object.assign({ bubbles: true, clientY: clientY, button: 0 }, extra)));
+}
+
+function key(target, keyName) {
+  target.dispatchEvent(new window.KeyboardEvent('keydown', { key: keyName, bubbles: true }));
+}
+
+function centreOf(i) {
+  return i * ROW_HEIGHT + ROW_HEIGHT / 2;
+}
+
+// A plan that does what the real one does on setWaypoints: rebuilds its rows
+// and wires them again.
+function fakePlan(count) {
+  const plan = {
+    _waypoints: Array.from({ length: count }, (_, i) => ({ name: 'wp' + i })),
+    getWaypoints() {
+      return this._waypoints.slice();
+    },
+    setWaypoints(waypoints) {
+      this._waypoints = waypoints;
+      this.rebuild();
+    },
+    rebuild() {
+      if (this._geocoderContainer) this._geocoderContainer.remove();
+      this._geocoderContainer = buildRows(this._waypoints.length);
+      rows(this._geocoderContainer).forEach((row, i) => {
+        row.querySelector('input').value = this._waypoints[i].name;
+      });
+      reorder.attachToPlan(this);
+    }
+  };
+  plan.rebuild();
+  return plan;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('moveWaypoint', () => {
+  test('moves an item forward and backward without touching the input', () => {
+    const list = ['a', 'b', 'c', 'd'];
+    expect(reorder.moveWaypoint(list, 0, 2)).toEqual(['b', 'c', 'a', 'd']);
+    expect(reorder.moveWaypoint(list, 3, 1)).toEqual(['a', 'd', 'b', 'c']);
+    expect(list).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('a move onto itself is a copy', () => {
+    expect(reorder.moveWaypoint(['a', 'b'], 1, 1)).toEqual(['a', 'b']);
+  });
+
+  test('clamps indexes to the list', () => {
+    expect(reorder.moveWaypoint(['a', 'b', 'c'], 0, 99)).toEqual(['b', 'c', 'a']);
+    expect(reorder.moveWaypoint(['a', 'b', 'c'], -5, 1)).toEqual(['b', 'a', 'c']);
+  });
+});
+
+describe('createGeocoder', () => {
+  test('keeps the input and remove button Leaflet Routing Machine expects', () => {
+    const g = reorder.createGeocoder(0, 2, { addWaypoints: true, language: 'en' });
+    expect(g.container.className).toBe('leaflet-routing-geocoder');
+    expect(g.input.tagName).toBe('INPUT');
+    expect(g.input.disabled).toBe(false);
+    expect(g.closeButton.className).toBe('leaflet-routing-remove-waypoint');
+  });
+
+  test('without addWaypoints the input is disabled and there is no remove button', () => {
+    const g = reorder.createGeocoder(0, 2, { addWaypoints: false, language: 'en' });
+    expect(g.input.disabled).toBe(true);
+    expect(g.closeButton).toBeUndefined();
+  });
+
+  test('the grip is a focusable, labelled button between input and remove', () => {
+    const g = reorder.createGeocoder(1, 3, { addWaypoints: true, language: 'en' });
+    const grip = g.container.querySelector('.' + reorder.HANDLE_CLASS);
+    expect(grip.getAttribute('role')).toBe('button');
+    expect(grip.getAttribute('tabindex')).toBe('0');
+    expect(grip.getAttribute('aria-label')).toMatch(/Drag to reorder/);
+    expect(grip.getAttribute('title')).toBe(grip.getAttribute('aria-label'));
+    expect(Array.from(g.container.children)).toEqual([g.input, grip, g.closeButton]);
+  });
+
+  test('the grip is labelled in the interface language', () => {
+    const g = reorder.createGeocoder(0, 2, { addWaypoints: true, language: 'de' });
+    const grip = g.container.querySelector('.' + reorder.HANDLE_CLASS);
+    expect(grip.getAttribute('aria-label')).toMatch(/Umsortieren/);
+  });
+});
+
+describe('dragging a grip', () => {
+  let container, moves;
+
+  beforeEach(() => {
+    container = buildRows(4);
+    moves = [];
+    reorder.attach(container, (from, to, viaKeyboard) => moves.push([from, to, viaKeyboard]));
+  });
+
+  test('drops the row where its middle ends up', () => {
+    const grip = handle(container, 0);
+    pointer(grip, 'pointerdown', centreOf(0));
+    pointer(document, 'pointermove', centreOf(2) + 1);
+    pointer(document, 'pointerup', centreOf(2) + 1);
+    expect(moves).toEqual([[0, 2, false]]);
+  });
+
+  test('can move a row up', () => {
+    pointer(handle(container, 3), 'pointerdown', centreOf(3));
+    pointer(document, 'pointermove', centreOf(1) - 1);
+    pointer(document, 'pointerup', centreOf(1) - 1);
+    expect(moves).toEqual([[3, 1, false]]);
+  });
+
+  test('lifts the row and slides the rows it passes out of the way', () => {
+    pointer(handle(container, 0), 'pointerdown', centreOf(0));
+    pointer(document, 'pointermove', centreOf(0) + 50);
+    expect(rows(container)[0].classList.contains(reorder.DRAGGING_ROW_CLASS)).toBe(true);
+    expect(container.classList.contains(reorder.DRAGGING_LIST_CLASS)).toBe(true);
+    expect(rows(container).map(r => r.style.transform)).toEqual([
+      'translateY(50px)', 'translateY(-' + ROW_HEIGHT + 'px)', '', ''
+    ]);
+
+    pointer(document, 'pointerup', centreOf(0) + 50);
+    expect(rows(container)[0].classList.contains(reorder.DRAGGING_ROW_CLASS)).toBe(false);
+    expect(container.classList.contains(reorder.DRAGGING_LIST_CLASS)).toBe(false);
+    expect(rows(container).map(r => r.style.transform)).toEqual(['', '', '', '']);
+  });
+
+  test('a press that barely moves is a click, not a drag', () => {
+    pointer(handle(container, 1), 'pointerdown', centreOf(1));
+    pointer(document, 'pointermove', centreOf(1) + reorder.DRAG_THRESHOLD_PX - 1);
+    expect(rows(container)[1].style.transform).toBe('');
+    pointer(document, 'pointerup', centreOf(1) + reorder.DRAG_THRESHOLD_PX - 1);
+    expect(moves).toEqual([]);
+  });
+
+  test('dropping a row back where it was reorders nothing', () => {
+    pointer(handle(container, 1), 'pointerdown', centreOf(1));
+    pointer(document, 'pointermove', centreOf(1) + 10);
+    pointer(document, 'pointerup', centreOf(1) + 10);
+    expect(moves).toEqual([]);
+  });
+
+  test('Escape abandons the drag and puts the rows back', () => {
+    pointer(handle(container, 0), 'pointerdown', centreOf(0));
+    pointer(document, 'pointermove', centreOf(2));
+    key(document, 'Escape');
+    expect(rows(container).map(r => r.style.transform)).toEqual(['', '', '', '']);
+    expect(rows(container)[0].classList.contains(reorder.DRAGGING_ROW_CLASS)).toBe(false);
+    // The listeners are gone: a later release does nothing.
+    pointer(document, 'pointerup', centreOf(2));
+    expect(moves).toEqual([]);
+  });
+
+  test('a cancelled pointer abandons the drag', () => {
+    pointer(handle(container, 0), 'pointerdown', centreOf(0));
+    pointer(document, 'pointermove', centreOf(2));
+    pointer(document, 'pointercancel', centreOf(2));
+    pointer(document, 'pointerup', centreOf(2));
+    expect(moves).toEqual([]);
+    expect(rows(container).map(r => r.style.transform)).toEqual(['', '', '', '']);
+  });
+
+  test('only the primary button starts a drag', () => {
+    pointer(handle(container, 0), 'pointerdown', centreOf(0), { button: 2 });
+    pointer(document, 'pointermove', centreOf(2));
+    pointer(document, 'pointerup', centreOf(2));
+    expect(moves).toEqual([]);
+  });
+
+  test('the press does not reach the map and gives the grip focus', () => {
+    const grip = handle(container, 0);
+    const event = new window.MouseEvent('pointerdown', { bubbles: true, cancelable: true, clientY: 0, button: 0 });
+    let reachedDocument = false;
+    document.addEventListener('pointerdown', () => { reachedDocument = true; }, { once: true });
+    grip.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(reachedDocument).toBe(false);
+    expect(document.activeElement).toBe(grip);
+    pointer(document, 'pointerup', 0);
+  });
+});
+
+describe('moving a row with the keyboard', () => {
+  test('the arrow keys move the row one step and report it as a keyboard move', () => {
+    const container = buildRows(3);
+    const moves = [];
+    reorder.attach(container, (from, to, viaKeyboard) => moves.push([from, to, viaKeyboard]));
+    key(handle(container, 1), 'ArrowDown');
+    key(handle(container, 1), 'ArrowUp');
+    expect(moves).toEqual([[1, 2, true], [1, 0, true]]);
+  });
+
+  test('the first row cannot move up and the last cannot move down', () => {
+    const container = buildRows(3);
+    const moves = [];
+    reorder.attach(container, (from, to, viaKeyboard) => moves.push([from, to, viaKeyboard]));
+    key(handle(container, 0), 'ArrowUp');
+    key(handle(container, 2), 'ArrowDown');
+    expect(moves).toEqual([]);
+  });
+
+  test('other keys are left alone', () => {
+    const container = buildRows(3);
+    const moves = [];
+    reorder.attach(container, (from, to, viaKeyboard) => moves.push([from, to, viaKeyboard]));
+    const event = new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    handle(container, 1).dispatchEvent(event);
+    expect(moves).toEqual([]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test('the arrow keys do not reach the map, which would pan it', () => {
+    const container = buildRows(3);
+    reorder.attach(container, () => {});
+    const event = new window.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true });
+    let reachedDocument = false;
+    document.addEventListener('keydown', () => { reachedDocument = true; }, { once: true });
+    handle(container, 1).dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(reachedDocument).toBe(false);
+  });
+});
+
+describe('attachToPlan', () => {
+  test('a drag reorders the plan and the rebuilt rows follow', () => {
+    const plan = fakePlan(4);
+    pointer(handle(plan._geocoderContainer, 0), 'pointerdown', centreOf(0));
+    pointer(document, 'pointermove', centreOf(3) + 1);
+    pointer(document, 'pointerup', centreOf(3) + 1);
+    expect(plan.getWaypoints().map(wp => wp.name)).toEqual(['wp1', 'wp2', 'wp3', 'wp0']);
+    expect(order(plan._geocoderContainer)).toEqual(['wp1', 'wp2', 'wp3', 'wp0']);
+  });
+
+  test('a keyboard move keeps focus on the grip that moved, in its new row', () => {
+    const plan = fakePlan(3);
+    const grip = handle(plan._geocoderContainer, 0);
+    grip.focus();
+    key(grip, 'ArrowDown');
+    expect(plan.getWaypoints().map(wp => wp.name)).toEqual(['wp1', 'wp0', 'wp2']);
+    expect(document.activeElement).toBe(handle(plan._geocoderContainer, 1));
+
+    key(document.activeElement, 'ArrowDown');
+    expect(plan.getWaypoints().map(wp => wp.name)).toEqual(['wp1', 'wp2', 'wp0']);
+    expect(document.activeElement).toBe(handle(plan._geocoderContainer, 2));
+  });
+
+  test('the rebuilt rows can be dragged again', () => {
+    const plan = fakePlan(3);
+    key(handle(plan._geocoderContainer, 0), 'ArrowDown');
+    pointer(handle(plan._geocoderContainer, 2), 'pointerdown', centreOf(2));
+    pointer(document, 'pointermove', centreOf(0));
+    pointer(document, 'pointerup', centreOf(0));
+    expect(plan.getWaypoints().map(wp => wp.name)).toEqual(['wp2', 'wp1', 'wp0']);
+  });
+
+  test('a plan without rows yet is left alone', () => {
+    expect(() => reorder.attachToPlan({})).not.toThrow();
+  });
+});
+
+describe('updateLabels', () => {
+  test('relabels every grip in the new language', () => {
+    const container = buildRows(2);
+    reorder.updateLabels(container, 'de');
+    rows(container).forEach(row => {
+      const grip = row.querySelector('.' + reorder.HANDLE_CLASS);
+      expect(grip.getAttribute('aria-label')).toMatch(/Umsortieren/);
+      expect(grip.getAttribute('title')).toMatch(/Umsortieren/);
+    });
+    reorder.updateLabels(container, 'en');
+    expect(handle(container, 0).getAttribute('title')).toMatch(/Drag to reorder/);
+  });
+
+  test('tolerates a plan whose rows are not built yet', () => {
+    expect(() => reorder.updateLabels(null, 'de')).not.toThrow();
+  });
+});


### PR DESCRIPTION
Waypoints could only be reordered by removing and re-adding them, or by reversing the whole list. Closes #19.

## The grip

Each waypoint row gets a six-dot grip between the input and the remove button, as komoot's planner has. It is drawn with CSS gradients rather than a glyph, so it does not depend on the device's fonts. The dots are 12×18px inside a 24×30px target. The input's width goes from `90%` to `calc(100% - 55px)` to make room for it.

## Dragging

Pressing the grip and moving lifts the row (shadow, raised z-index) and slides the rows it passes out of the way, so the gap it will drop into is visible while it is still in the air. A neighbour swaps once the dragged row's edge passes its middle, so half a row of travel is enough; the row is pinned to the ends of the list rather than leaving it. The lifted row has no transition, so it follows the pointer at once. Dropping moves the waypoint with `plan.setWaypoints`, which is the same path the reverse button takes: the markers, route, URL and directions all follow. Dropping the row where it started, pressing Escape, or a `pointercancel` puts the rows back without a reroute.

Pointer events with `touch-action: none` on the grip cover mouse, pen and touch in one code path. `pointerdown` is `preventDefault`ed so the press neither selects text nor produces the compatibility mouse events that would reach the map, and its propagation is stopped so Leaflet's own handlers stay out of it. A press has to travel 3px before it counts as a drag, so clicking the grip to focus it does not twitch the row.

## The map stays put

The route that follows a reorder is not refit. A reorder rearranges places the user has already put on the map, so it is treated like a marker drag: the plan fires `waypointsreorder` before the change and `routeFitTracker.waypointsReordered()` suppresses the fit for the route that follows. Only the route request is marked, since no reverse geocode follows a reorder (the names travel with the waypoints); marking the geocode too would swallow the pan of the next typed address.

## Keyboard

The grip is `role="button"` with `tabindex="0"` and an `aria-label`/`title` (new i18n key `Drag to reorder`, English and German; the other languages fall back to English, as they do for the other keys). With the grip focused, the up and down arrow keys move the waypoint one row. Leaflet Routing Machine rebuilds every row on a waypoint change, so after a keyboard move focus is put back on the grip in its new row; without that, each arrow press would drop focus to the body.

The arrow keydown is stopped so it does not also pan the map.

## Wiring

`ReversablePlan` overrides `_updateGeocoders` to call the base and then `waypointReorder.attachToPlan`, since the rows are rebuilt on every splice. The plan gets `createGeocoder: waypointReorder.createGeocoder`, which builds the same row as Leaflet Routing Machine's default (same class names, `input.disabled` when `addWaypoints` is off) plus the grip. `state.js` relabels the grips on a language change alongside the placeholders it already updates.

## Tests

`test/waypoint_reorder.test.js` (28 tests, jsdom): pure `moveWaypoint`; the row markup; drag drop index up and down, the lift-and-slide transforms and their cleanup, the click threshold, no-op drop, Escape and `pointercancel`, non-primary buttons ignored, `pointerdown` not reaching the document and focusing the grip; arrow keys moving one step, stopping at the ends, leaving other keys alone and not reaching the document; `attachToPlan` against a fake plan that rebuilds its rows, including focus following a keyboard move; `updateLabels`.

352 tests, 31 suites, lint clean. Verified in the app: mouse drags of half a row, of the last row to the top and of the first row past the end reorder the inputs, markers, route and `loc=` parameters; during a drag the map container receives no `mousedown`, `pointerdown` or `mouseup` from the grip and never enters `leaflet-dragging`; across two drops the map pane's transform, centre and zoom do not change; clicking a grip and pressing the arrow keys moves the row with the focus ring following it; the lifted row and the sliding rows render as intended; Escape mid-drag restores the list.

🤖 Claude Code, Claude Fable 5.1



