### PR TITLE
fix: show each waypoint's pin next to its input

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -288,6 +288,7 @@
 .leaflet-routing-waypoint-handle {
   display: inline-block;
   vertical-align: middle;
+  flex: none;
   box-sizing: border-box;
   /* The dots are 12x18; the padding round them makes the target 24x30,
      which is what a finger or a quick mouse needs. background-clip keeps
@@ -563,9 +564,41 @@
   max-height: 75%;
 }
 
+/* A row is pin, input, grip, remove button in a line; the input takes what
+   the other three leave. */
+.leaflet-routing-geocoders.osrm-directions-inputs .leaflet-routing-geocoder {
+  display: flex;
+  align-items: center;
+}
+
 .leaflet-routing-geocoders.osrm-directions-inputs .leaflet-routing-geocoder input {
   border: 0px;
   height: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.leaflet-routing-geocoders.osrm-directions-inputs .leaflet-routing-remove-waypoint {
+  /* The button is an empty span whose cross is drawn by :after. Inline
+     layout gave it a line box to hang from and the input's fixed width left
+     it room; in the flex row it needs a box of its own, and none of the
+     nudge. */
+  flex: none;
+  width: 24px;
+  height: 30px;
+  padding-left: 0;
+  margin-top: 0;
+}
+
+.leaflet-routing-geocoders.osrm-directions-inputs .leaflet-routing-remove-waypoint:after {
+  /* Centred in that box rather than hung off its bottom edge. */
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  line-height: 30px;
+  text-align: center;
 }
 
 /* The waypoint's pin, as the map and the directions pane draw it, so the row
@@ -573,6 +606,7 @@
 .leaflet-routing-waypoint-pin {
   display: inline-block;
   vertical-align: middle;
+  flex: none;
   width: 20px;
   height: 28px;
   margin-left: 4px;
@@ -583,8 +617,7 @@
 
 .osrm-directions-inputs input {
   font-size: 12px;
-  /* The pin and the grip and remove button either side of it. */
-  width: calc(100% - 79px);
+  width: auto;
   background-color: transparent;
   color: rgba(0, 0, 0, 0.5);
   height: 30px;
@@ -1042,10 +1075,6 @@ td.distance {
 
 .osrm-directions-inputs {
   min-width: 175px;
-}
-
-.leaflet-routing-remove-waypoint:after {
-  margin-left: 19px;
 }
 
 .leaflet-routing-container.dark {

--- a/css/site.css
+++ b/css/site.css
@@ -563,41 +563,32 @@
   max-height: 75%;
 }
 
-.leaflet-routing-geocoders.osrm-directions-inputs .leaflet-routing-geocoder:first-child input {
-  border-top: 0px;
-  border-right: 0px;
-  border-bottom: 0px;
-  height: 100%;
-  /* Okabe-Ito, matching the map pins; see src/waypoint_marker.js for why. */
-  border-left-color: #0072b2;
-  border-left-width: thick;
-}
-
-.leaflet-routing-geocoders.osrm-directions-inputs .leaflet-routing-geocoder:last-of-type input {
-  border-top: 0px;
-  border-right: 0px;
-  border-bottom: 0px;
-  height: 100%;
-  border-left-color: #d55e00;
-  border-left-width: thick;
-}
-
 .leaflet-routing-geocoders.osrm-directions-inputs .leaflet-routing-geocoder input {
-  border-top: 0px;
-  border-right: 0px;
-  border-bottom: 0px;
+  border: 0px;
   height: 100%;
-  border-left-color: #595959;
-  border-left-width: thick;
+}
+
+/* The waypoint's pin, as the map and the directions pane draw it, so the row
+   can be matched to its marker. The image is set on the element. */
+.leaflet-routing-waypoint-pin {
+  display: inline-block;
+  vertical-align: middle;
+  width: 20px;
+  height: 28px;
+  margin-left: 4px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
 }
 
 .osrm-directions-inputs input {
   font-size: 12px;
-  width: calc(100% - 55px);
+  /* The pin and the grip and remove button either side of it. */
+  width: calc(100% - 79px);
   background-color: transparent;
   color: rgba(0, 0, 0, 0.5);
   height: 30px;
-  padding: 10px 10px 10px 20px;
+  padding: 10px 10px 10px 8px;
 }
 
 .osrm-directions-route-summary {

--- a/src/waypoint_marker.js
+++ b/src/waypoint_marker.js
@@ -155,9 +155,16 @@ function panelIconUrl(kind, position) {
   return dataUri(pinMarkup(kind, position, PIN_HEIGHT));
 }
 
+// The same panel pin for waypoint i of n, for a row that does know how many
+// waypoints there are: the input rows.
+function panelIconUrlFor(i, n) {
+  return panelIconUrl(kindOf(i, n), i);
+}
+
 module.exports = {
   waypointIconOptions: waypointIconOptions,
   panelIconUrl: panelIconUrl,
+  panelIconUrlFor: panelIconUrlFor,
   START: START,
   VIA: VIA,
   END: END,

--- a/src/waypoint_marker.js
+++ b/src/waypoint_marker.js
@@ -156,9 +156,10 @@ function panelIconUrl(kind, position) {
 }
 
 // The same panel pin for waypoint i of n, for a row that does know how many
-// waypoints there are: the input rows.
+// waypoints there are: the input rows. Only a via has a position.
 function panelIconUrlFor(i, n) {
-  return panelIconUrl(kindOf(i, n), i);
+  var kind = kindOf(i, n);
+  return panelIconUrl(kind, kind === VIA ? i : 0);
 }
 
 module.exports = {

--- a/src/waypoint_reorder.js
+++ b/src/waypoint_reorder.js
@@ -14,9 +14,11 @@
 
 var L = require('leaflet');
 var localization = require('./localization');
+var waypointMarker = require('./waypoint_marker');
 
 var ROW_CLASS = 'leaflet-routing-geocoder';
 var HANDLE_CLASS = 'leaflet-routing-waypoint-handle';
+var PIN_CLASS = 'leaflet-routing-waypoint-pin';
 var DRAGGING_ROW_CLASS = 'leaflet-routing-geocoder-dragging';
 var DRAGGING_LIST_CLASS = 'leaflet-routing-geocoders-dragging';
 
@@ -40,9 +42,17 @@ function setHandleLabel(handle, language) {
 
 // Drop-in for Leaflet Routing Machine's createGeocoder option: the same row
 // (input and remove button, with the same class names the stylesheet keys on)
-// plus the grip between them.
+// with the waypoint's pin before the input and the grip after it.
+//
+// The pin is the one the map and the directions pane draw for this waypoint,
+// so the row can be matched to its marker: vias are numbered from 1 while the
+// rows count the start too, so the third row is via 2, and a coloured stripe
+// alone could not say so.
 function createGeocoder(i, nWps, options) {
   var container = L.DomUtil.create('div', ROW_CLASS);
+  var pin = L.DomUtil.create('span', PIN_CLASS, container);
+  pin.style.backgroundImage = 'url("' + waypointMarker.panelIconUrlFor(i, nWps) + '")';
+  pin.setAttribute('aria-hidden', 'true');
   var input = L.DomUtil.create('input', '', container);
   var handle = L.DomUtil.create('span', HANDLE_CLASS, container);
   var remove = options.addWaypoints ? L.DomUtil.create('span', 'leaflet-routing-remove-waypoint', container) : undefined;
@@ -265,6 +275,7 @@ module.exports = {
   attachToPlan: attachToPlan,
   updateLabels: updateLabels,
   HANDLE_CLASS: HANDLE_CLASS,
+  PIN_CLASS: PIN_CLASS,
   DRAGGING_ROW_CLASS: DRAGGING_ROW_CLASS,
   DRAGGING_LIST_CLASS: DRAGGING_LIST_CLASS,
   DRAG_THRESHOLD_PX: DRAG_THRESHOLD_PX

--- a/test/waypoint_marker.test.js
+++ b/test/waypoint_marker.test.js
@@ -152,3 +152,20 @@ describe('the markup is a usable SVG', () => {
     expect(marker.panelIconUrl(marker.VIA, 2)).not.toMatch(/[()]/);
   });
 });
+
+describe('panel pin for row i of n', () => {
+  test('is the start, the numbered via, or the end, on the panel canvas', () => {
+    expect(marker.panelIconUrlFor(0, 4)).toBe(marker.panelIconUrl(marker.START, 0));
+    expect(marker.panelIconUrlFor(1, 4)).toBe(marker.panelIconUrl(marker.VIA, 1));
+    expect(marker.panelIconUrlFor(2, 4)).toBe(marker.panelIconUrl(marker.VIA, 2));
+    expect(marker.panelIconUrlFor(3, 4)).toBe(marker.panelIconUrl(marker.END, 0));
+  });
+
+  test('numbers a via by its position among all waypoints, matching the map', () => {
+    // The map pin for waypoint 2 of 4 shows a 2; the row for it must too.
+    const mapMarkup = markup(2, 4);
+    const rowMarkup = decodeURIComponent(marker.panelIconUrlFor(2, 4).slice('data:image/svg+xml,'.length));
+    expect(/<text[^>]*>(\d)<\/text>/.exec(mapMarkup)[1]).toBe('2');
+    expect(/<text[^>]*>(\d)<\/text>/.exec(rowMarkup)[1]).toBe('2');
+  });
+});

--- a/test/waypoint_reorder.test.js
+++ b/test/waypoint_reorder.test.js
@@ -117,11 +117,25 @@ describe('createGeocoder', () => {
   test('the grip is a focusable, labelled button between input and remove', () => {
     const g = reorder.createGeocoder(1, 3, { addWaypoints: true, language: 'en' });
     const grip = g.container.querySelector('.' + reorder.HANDLE_CLASS);
+    const pin = g.container.querySelector('.' + reorder.PIN_CLASS);
     expect(grip.getAttribute('role')).toBe('button');
     expect(grip.getAttribute('tabindex')).toBe('0');
     expect(grip.getAttribute('aria-label')).toMatch(/Drag to reorder/);
     expect(grip.getAttribute('title')).toBe(grip.getAttribute('aria-label'));
-    expect(Array.from(g.container.children)).toEqual([g.input, grip, g.closeButton]);
+    expect(Array.from(g.container.children)).toEqual([pin, g.input, grip, g.closeButton]);
+  });
+
+  test('each row carries the pin the map draws for its waypoint', () => {
+    const marker = require('../src/waypoint_marker');
+    const pinOf = (i, n) => reorder.createGeocoder(i, n, { addWaypoints: true, language: 'en' })
+      .container.querySelector('.' + reorder.PIN_CLASS);
+    const urlOf = (i, n) => /url\("([^"]+)"\)/.exec(pinOf(i, n).style.backgroundImage)[1];
+    expect(urlOf(0, 4)).toBe(marker.panelIconUrl(marker.START, 0));
+    expect(urlOf(1, 4)).toBe(marker.panelIconUrl(marker.VIA, 1));
+    expect(urlOf(2, 4)).toBe(marker.panelIconUrl(marker.VIA, 2));
+    expect(urlOf(3, 4)).toBe(marker.panelIconUrl(marker.END, 0));
+    // Decoration for the eye; the placeholder already says start, via or end.
+    expect(pinOf(0, 2).getAttribute('aria-hidden')).toBe('true');
   });
 
   test('the grip is labelled in the interface language', () => {

--- a/test/waypoint_reorder.test.js
+++ b/test/waypoint_reorder.test.js
@@ -129,7 +129,8 @@ describe('createGeocoder', () => {
     const marker = require('../src/waypoint_marker');
     const pinOf = (i, n) => reorder.createGeocoder(i, n, { addWaypoints: true, language: 'en' })
       .container.querySelector('.' + reorder.PIN_CLASS);
-    const urlOf = (i, n) => /url\("([^"]+)"\)/.exec(pinOf(i, n).style.backgroundImage)[1];
+    // Quoting of the url() differs between engines.
+    const urlOf = (i, n) => /url\(["']?([^"')]+)["']?\)/.exec(pinOf(i, n).style.backgroundImage)[1];
     expect(urlOf(0, 4)).toBe(marker.panelIconUrl(marker.START, 0));
     expect(urlOf(1, 4)).toBe(marker.panelIconUrl(marker.VIA, 1));
     expect(urlOf(2, 4)).toBe(marker.panelIconUrl(marker.VIA, 2));


### PR DESCRIPTION
The input rows marked start, via and end with a thick coloured stripe on the input's left edge. That could not say which via a row was: vias are numbered from 1 on the map while the rows count the start too, so the third row is via 2, and reading across from a row to its marker meant counting.

## Pins in the rows

Each row now carries the pin the map and the directions pane already draw for its waypoint — disc, via number, chequered flag — in place of the stripe, as komoot's planner labels its rows A, 1, 2, B. The pin is `waypointMarker.panelIconUrlFor(i, n)`, a new one-liner over `panelIconUrl` and `kindOf` for a caller that knows how many waypoints there are; the itinerary keeps calling `panelIconUrl` since it does not. The rows are rebuilt on every waypoint change, so a reorder renumbers them.

The pin is `aria-hidden`: the input's placeholder already says start, via or end.

The three stripe rules in `site.css` collapse into one borderless rule. The row is a flex line: pin, grip and remove button are `flex: none` and the input takes what they leave, so nothing reserves a width in pixels. The input's left padding goes from 20px to 8px since the pin now provides the lead-in.

The remove button is an empty span whose cross was drawn by `:after`, hung off the span's bottom edge by absolute positioning and relying on the inline line box and on the input's fixed width leaving it room. In the flex row it gets a 24×30 box of its own with the cross centred, which also retires the small-screen `margin-left: 19px` nudge for it.

## Tests

`panelIconUrlFor` returns the start, the numbered vias and the end on the panel canvas, and numbers via 2 of 4 with a 2 like the map pin does. The row places the pin before the input, sets the same URL the marker module produces for that waypoint, and hides it from assistive technology.

355 tests, 31 suites, lint clean. Verified in the app: a four-waypoint route shows disc, 1, 2, flag matching its markers; dragging a row renumbers the pins; at 660px and at a 360px viewport pin, input, grip and cross all sit on the row without overlap; a click on the cross removes the waypoint; the map does not move on drop.

🤖 Claude Code, Claude Fable 5.1
