### PR TITLE
feat: filter and mark entrance doors by travel mode

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -1272,6 +1272,18 @@ td.distance {
     color: #022bb1;
 }
 
+/* Marks something about a door worth knowing in the current travel mode:
+   step-free access on foot, a way in for a car when driving. A mark only, never
+   a filter — most doors carry neither tag, so an absent one says nothing about
+   the door. The per-mark classes carry no styling of their own yet; they exist
+   so a mark can be restyled without touching the others. */
+.osrm-entrance-mark {
+    margin-left: 5px;
+    font-size: 11px;
+    line-height: 1;
+    vertical-align: baseline;
+}
+
 /* A merged label lists one door per line, so it cannot stay on one. */
 .osrm-entrance-label-merged .osrm-entrance-label-inner div + div {
     border-top: 1px solid rgba(20, 36, 63, 0.12);

--- a/i18n/de.js
+++ b/i18n/de.js
@@ -17,6 +17,8 @@ module.exports = {
   'Main entrance': 'Haupteingang',
   'Entrance': 'Eingang',
   'Exit': 'Ausgang',
+  'Wheelchair accessible': 'Barrierefreier Eingang',
+  'Parking entrance': 'Parkhauseinfahrt',
   'main entrance': 'Haupteingang',
   'entrance': 'Eingang',
   'exit': 'Ausgang',

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -17,6 +17,8 @@ module.exports = {
   'Main entrance': 'Main entrance',
   'Entrance': 'Entrance',
   'Exit': 'Exit',
+  'Wheelchair accessible': 'Wheelchair accessible',
+  'Parking entrance': 'Parking entrance',
   'main entrance': 'main entrance',
   'entrance': 'entrance',
   'exit': 'exit',

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -54,15 +54,56 @@ var ENTRANCE_LINK_STYLE = {
   interactive: false
 };
 
+// The OSM access keys that govern each routing mode, most specific first. The
+// general `access` key is the fallback for all of them, and `vehicle` covers
+// both wheeled modes. This is the ordering OSM's access documentation
+// prescribes: the most specific tag present wins.
+var MODE_ACCESS_KEYS = {
+  foot: ['foot', 'access'],
+  bike: ['bicycle', 'vehicle', 'access'],
+  bicycle: ['bicycle', 'vehicle', 'access'],
+  driving: ['motor_vehicle', 'vehicle', 'access'],
+  car: ['motor_vehicle', 'vehicle', 'access']
+};
+
+// Values that put a door out of bounds. Everything else — `yes`, `permissive`,
+// `designated`, `destination`, `customers`, `permit` — is treated as usable:
+// somebody routing to a shop's door is the customer it is tagged for. An
+// unrecognised value is not read as a prohibition.
+var FORBIDDEN_ACCESS = {no: true, private: true};
+
 /**
- * The entrances usable at one end of a route.
+ * Whether a door's own tags permit the given travel mode. A door with nothing
+ * to say on the subject is allowed: absence of a tag is not a prohibition.
+ *
+ * @param {object} entrance — with an optional `tags` map from OSM
+ * @param {string} [mode] — 'foot', 'bike'/'bicycle', or 'driving'/'car'
+ */
+function allowsMode(entrance, mode) {
+  if (!mode) return true;
+  var keys = MODE_ACCESS_KEYS[mode];
+  if (!keys) return true;
+  var tags = entrance && entrance.tags;
+  if (!tags) return true;
+  for (var i = 0; i < keys.length; i++) {
+    var value = tags[keys[i]];
+    // The most specific tag present settles it; a broader one cannot override.
+    if (typeof value === 'string') return !FORBIDDEN_ACCESS[value.trim().toLowerCase()];
+  }
+  return true;
+}
+
+/**
+ * The entrances usable at one end of a route, for one travel mode.
  *
  * @param {Array} entrances
  * @param {string} [role] — 'origin' (the traveller leaves the building here),
  *   'destination' (arrives), or 'via' (both, and so the strictest). Defaults to
  *   'via', which offers only doors that work in either direction.
+ * @param {string} [mode] — the routing profile. Omitted, no access filtering is
+ *   applied.
  */
-function routableEntrances(entrances, role) {
+function routableEntrances(entrances, role, mode) {
   if (!Array.isArray(entrances)) return [];
   // A via point is both arrived at and left from, so it needs both directions.
   var needsEnter = role !== 'origin';
@@ -71,7 +112,8 @@ function routableEntrances(entrances, role) {
     if (!entrance || !entrance.center) return false;
     var use = ENTRANCE_USE[entrance.type];
     if (!use) return false;
-    return (!needsEnter || use.enter) && (!needsLeave || use.leave);
+    if (!((!needsEnter || use.enter) && (!needsLeave || use.leave))) return false;
+    return allowsMode(entrance, mode);
   });
 }
 
@@ -92,6 +134,78 @@ function entranceName(entrance) {
   if (typeof name !== 'string') return null;
   name = name.trim();
   return name.length ? name : null;
+}
+
+// OSM's wheelchair values that mean a door can actually be used. `designated`
+// marks one provided specifically for wheelchair users, so it qualifies at
+// least as much as `yes`. `limited` deliberately does not: it means passable
+// only with help, or under conditions the tag does not spell out, and a mark
+// promising step-free access there would be worse than no mark at all.
+var WHEELCHAIR_ACCESSIBLE = {yes: true, designated: true};
+
+// What is worth pointing out about a door depends entirely on how the traveller
+// is arriving, so each mark belongs to one travel mode and appears in no other.
+// Step-free access matters to someone on foot and says nothing to a driver;
+// which door swallows cars matters to a driver and is noise to everyone else.
+//
+// There is deliberately no mark for cycling. Its natural candidate, `bicycle`
+// on an entrance node, does not reach even 0.05% of them globally — far below
+// `wheelchair` at 4.7% — so a cycling mark would be an icon nobody ever sees.
+var MARKS = {
+  wheelchair: {
+    className: 'osrm-entrance-mark-wheelchair',
+    // U+267F, then U+FE0F. Both glyphs ask for the emoji form explicitly rather
+    // than relying on the font's default, because the two characters default
+    // differently: U+267F is Emoji_Presentation=Yes and renders in colour on its
+    // own, while U+1F17F below is No and falls back to a plain black-and-white
+    // glyph without the selector — which is how one mark ends up coloured and
+    // the other not.
+    glyph: '\u267F\uFE0F',
+    label: 'Wheelchair accessible',
+    applies: function(tags) {
+      var value = tags.wheelchair;
+      if (typeof value !== 'string') return false;
+      return WHEELCHAIR_ACCESSIBLE[value.trim().toLowerCase()] === true;
+    }
+  },
+  parking: {
+    className: 'osrm-entrance-mark-parking',
+    // U+1F17F as a surrogate pair — an escape this file's ES5 syntax cannot
+    // write directly — then U+FE0F. See the note above.
+    glyph: '\uD83C\uDD7F\uFE0F',
+    label: 'Parking entrance',
+    applies: function(tags) {
+      return tags.amenity === 'parking_entrance';
+    }
+  }
+};
+
+// Keyed by the same profile names as MODE_ACCESS_KEYS, so both tables agree on
+// what a mode is called.
+var MODE_MARK = {
+  foot: 'wheelchair',
+  driving: 'parking',
+  car: 'parking'
+};
+
+/**
+ * The mark a door earns for one travel mode, or null.
+ *
+ * A mark never filters. Roughly seven in eight entrance nodes carry no
+ * wheelchair tag and far fewer carry parking tags, so an absent value means
+ * nobody surveyed the door rather than that the door lacks the property, and
+ * `routableEntrances` stays untouched by any of this.
+ *
+ * @param {object} entrance
+ * @param {string} [mode] — the routing profile. A mode with no mark of its own,
+ *   or none at all, marks nothing.
+ * @returns {?{className: string, glyph: string, label: string}}
+ */
+function entranceMark(entrance, mode) {
+  var mark = MARKS[MODE_MARK[mode]];
+  var tags = entrance && entrance.tags;
+  if (!mark || !tags) return null;
+  return mark.applies(tags) ? mark : null;
 }
 
 // Where a waypoint sits in the route, which is what decides the direction a door
@@ -207,6 +321,10 @@ function choicePoints(choices, placeCenter) {
  *   latLng, markerLatLng, entrance}
  * @param {function} [options.paneWidth] — () => width in px of the directions
  *   pane, so the doors are framed into the part of the map it does not cover
+ *
+ * show() takes `frame: false` to redraw an offer without moving the view: a
+ * change of travel mode re-filters the doors already on screen, and the user
+ * did not ask to be taken to them.
  * @returns {{show: function, hide: function, focusView: function,
  *   isOpen: function, getWaypointIndex: function, getSelectedId: function}}
  */
@@ -280,11 +398,15 @@ function createEntrancePicker(map, options) {
     offer.choices.forEach(function(choice) {
       var chosen = choice.id === offer.selectedId;
       var text = label(choice);
+      var mark = entranceMark(choice.entrance, offer.mode);
       var className = 'osrm-entrance-marker osrm-entrance-marker-' + choice.kind +
         (chosen ? ' osrm-entrance-marker-selected' : '');
       var marker = L.marker(choice.center, {
         icon: L.divIcon({className: className, iconSize: [18, 18], iconAnchor: [9, 9], html: ''}),
-        alt: text,
+        // The label shows this as an icon; the alt spells it out, because the
+        // icon is marked aria-hidden and would otherwise be announced as
+        // nothing at all.
+        alt: mark ? text + ' (' + translate(mark.label) + ')' : text,
         keyboard: true,
         zIndexOffset: chosen ? 500 : 400
       });
@@ -293,6 +415,7 @@ function createEntrancePicker(map, options) {
       renderedDoors.push({
         latLng: choice.center,
         text: text,
+        mark: mark,
         selected: chosen,
         select: function() {
           select(choice);
@@ -354,8 +477,14 @@ function createEntrancePicker(map, options) {
   }
 
   function labelLine(entry) {
+    // Hidden from assistive tech on purpose: the dot's alt already says what the
+    // mark means in words, and announcing the symbol too would repeat it.
+    var mark = entry.mark
+      ? '<span class="osrm-entrance-mark ' + entry.mark.className +
+        '" aria-hidden="true">' + entry.mark.glyph + '</span>'
+      : '';
     return '<div' + (entry.selected ? ' class="osrm-entrance-label-selected"' : '') + '>' +
-      escapeText(entry.text) + '</div>';
+      escapeText(entry.text) + mark + '</div>';
   }
 
   // A label sits above the door it names, anchored on it. Zero-sized so the
@@ -510,12 +639,15 @@ function createEntrancePicker(map, options) {
       placeName: opts.placeName,
       placeCenter: opts.placeCenter || null,
       choices: choices,
+      // Which mark a door earns depends on it, and refresh() re-shows the
+      // picker with a new one whenever the travel mode changes.
+      mode: opts.mode || null,
       selectedId: opts.selectedId || null
     };
     attached = true;
     if (!map.hasLayer(layer)) layer.addTo(map);
     render();
-    focusViewWhenSettled();
+    if (opts.frame !== false) focusViewWhenSettled();
     // Which labels fit is a question of zoom, so the layout is redone after
     // every one. Detached first because show() runs again on an already-open
     // picker; Leaflet ignores a repeat registration of the same handler, but
@@ -563,6 +695,8 @@ function createEntrancePicker(map, options) {
 
 module.exports = {
   routableEntrances: routableEntrances,
+  allowsMode: allowsMode,
+  entranceMark: entranceMark,
   boxesOverlap: boxesOverlap,
   clusterOverlappingLabels: clusterOverlappingLabels,
   entranceName: entranceName,

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -67,9 +67,11 @@ function entranceWaypointName(placeName, entrance, translate) {
  * @param {object} options.routeFitTracker — from route_zoom
  * @param {function} [options.translate] — (key) => localized string
  * @param {function} [options.paneWidth] — () => width of the directions pane
+ * @param {function} [options.mode] — () => the active routing profile, read live
+ *   so switching between car, bike and foot re-applies the access rules
  * @param {function} [options.createPicker] — injection seam for tests
  * @returns {{onGeocodeResult: function, applySelection: function,
- *   hide: function, isOpen: function, claimView: function,
+ *   refresh: function, hide: function, isOpen: function, claimView: function,
  *   waypointName: function}}
  */
 function createEntranceWaypoints(options) {
@@ -80,6 +82,12 @@ function createEntranceWaypoints(options) {
     return key;
   };
   var createPicker = options.createPicker || entrancePicker.createEntrancePicker;
+  var mode = typeof options.mode === 'function' ? options.mode : function() {
+    return null;
+  };
+  // The last geocoding result seen, kept so a change of travel mode can
+  // re-apply the filters without a fresh geocode.
+  var lastEvent = null;
   // Set when a geocode opens an offer and the picker frames its doors. The
   // route that follows would otherwise be fitted over that framing; index.js
   // asks for the claim once per route and stands down if it is set.
@@ -128,15 +136,25 @@ function createEntranceWaypoints(options) {
     onSelect: applySelection
   });
 
-  function onGeocodeResult(e) {
+  // `frame` is false for the internal re-filter below; the plan's event handler
+  // passes only the event, and a fresh geocode frames its doors.
+  function onGeocodeResult(e, frame) {
+    frame = frame !== false;
     var result = e && e.value;
-    // Which end of the route this waypoint is decides the direction a door must
-    // work in: an entrance=exit can only be left through, an entrance=entrance
-    // only entered.
+    // Two independent filters. Which end of the route this waypoint is decides
+    // the direction a door must work in — an entrance=exit can only be left
+    // through, an entrance=entrance only entered. The travel mode then decides
+    // which of those the traveller may actually use, from the door's own OSM
+    // access tags.
     var count = plan && plan._waypoints ? plan._waypoints.length : 0;
     var role = entrancePicker.waypointRole(e.waypointIndex, count);
+    lastEvent = e;
+    // Read once: the mode is live, and filtering the doors by one value while
+    // marking them for another would mark a door the filter had just judged on
+    // different terms.
+    var activeMode = mode();
     var entrances = result
-      ? entrancePicker.routableEntrances(result.entrances, role)
+      ? entrancePicker.routableEntrances(result.entrances, role, activeMode)
       : [];
     if (!entrances.length) {
       picker.hide();
@@ -147,16 +165,36 @@ function createEntranceWaypoints(options) {
       waypointIndex: e.waypointIndex,
       placeName: result.name,
       placeCenter: result.center,
-      entrances: entrances
+      entrances: entrances,
+      // The picker marks doors differently per mode, so it gets the same value
+      // the filtering above used.
+      mode: activeMode,
+      frame: frame
     });
-    if (shown) viewClaimed = true;
+    if (shown && frame) viewClaimed = true;
     return shown;
+  }
+
+  // Re-applies the filters to the place last geocoded. Switching from foot to
+  // car can forbid the very door a waypoint sits on, and can equally make one
+  // usable that was not, so this runs whether or not the offer is currently on
+  // screen — a place whose doors are all shut to cars comes back when the
+  // traveller switches to walking. It is `hide()` that ends an offer for good,
+  // by forgetting the place along with it.
+  //
+  // The redraw stays where it is: the user asked for a different profile, not
+  // to be taken back to the doors.
+  function refresh() {
+    if (!lastEvent) return false;
+    return onGeocodeResult(lastEvent, false);
   }
 
   return {
     onGeocodeResult: onGeocodeResult,
     applySelection: applySelection,
+    refresh: refresh,
     hide: function() {
+      lastEvent = null;
       picker.hide();
     },
     isOpen: function() {

--- a/src/index.js
+++ b/src/index.js
@@ -723,10 +723,25 @@ var entranceWaypoints = createEntranceWaypoints({
   translate: function(key) {
     return localization.t(mergedOptions.language, key);
   },
-  paneWidth: directionsPaneWidth
+  paneWidth: directionsPaneWidth,
+  // Read live: a door forbidden to cars may be fine on foot, so the offer has to
+  // follow whatever profile is selected right now.
+  mode: function() {
+    var index = typeof state.options.profile === 'number'
+      ? state.options.profile : activeProfileIndex;
+    return services[index] && services[index].profile;
+  }
 });
 
 plan.on('waypointgeocoderesult', entranceWaypoints.onGeocodeResult);
+
+// The doors on offer depend on the travel mode, so an open picker is recomputed
+// rather than left showing ones the new profile forbids.
+if (modeSelector && modeSelector.select) {
+  L.DomEvent.on(modeSelector.select, 'change', function() {
+    entranceWaypoints.refresh();
+  });
+}
 
 // Adding, removing or reordering waypoints invalidates the index the offer is
 // pinned to; dragging the pin means the user has already chosen a spot.

--- a/test/entrance_picker.test.js
+++ b/test/entrance_picker.test.js
@@ -241,8 +241,10 @@ describe('access by travel mode', () => {
     expect(picker.allowsMode(tagged({ access: 'seasonal' }), 'foot')).toBe(true);
   });
 
-  test('the case of the value does not matter', () => {
+  test('the case of the value, and stray whitespace around it, do not matter', () => {
     expect(picker.allowsMode(tagged({ access: 'No' }), 'foot')).toBe(false);
+    expect(picker.allowsMode(tagged({ access: ' no ' }), 'foot')).toBe(false);
+    expect(picker.allowsMode(tagged({ motor_vehicle: 'no\n' }), 'driving')).toBe(false);
   });
 
   // OSM's own hierarchy: the most specific key present wins outright.

--- a/test/entrance_picker.test.js
+++ b/test/entrance_picker.test.js
@@ -211,3 +211,115 @@ describe('clusterOverlappingLabels', () => {
     expect(picker.clusterOverlappingLabels(null)).toEqual([]);
   });
 });
+
+describe('access by travel mode', () => {
+  const tagged = (tags) => door('main', { tags });
+
+  // Absence of a tag is not a prohibition: most doors say nothing at all.
+  test('a door with nothing to say is open to everyone', () => {
+    expect(picker.allowsMode(door('main'), 'driving')).toBe(true);
+    expect(picker.allowsMode(tagged({}), 'foot')).toBe(true);
+  });
+
+  test('no mode, or a mode with no rules, filters nothing', () => {
+    expect(picker.allowsMode(tagged({ access: 'no' }))).toBe(true);
+    expect(picker.allowsMode(tagged({ access: 'no' }), 'hovercraft')).toBe(true);
+  });
+
+  test('only no and private forbid', () => {
+    ['no', 'private'].forEach((value) => {
+      expect(picker.allowsMode(tagged({ access: value }), 'foot')).toBe(false);
+    });
+    // Somebody routing to a shop's door is the customer it is tagged for.
+    ['yes', 'permissive', 'designated', 'destination', 'customers', 'permit']
+      .forEach((value) => {
+        expect(picker.allowsMode(tagged({ access: value }), 'foot')).toBe(true);
+      });
+  });
+
+  test('an unrecognised value is not read as a prohibition', () => {
+    expect(picker.allowsMode(tagged({ access: 'seasonal' }), 'foot')).toBe(true);
+  });
+
+  test('the case of the value does not matter', () => {
+    expect(picker.allowsMode(tagged({ access: 'No' }), 'foot')).toBe(false);
+  });
+
+  // OSM's own hierarchy: the most specific key present wins outright.
+  test('the most specific key present settles it', () => {
+    expect(picker.allowsMode(tagged({ access: 'no', foot: 'yes' }), 'foot')).toBe(true);
+    expect(picker.allowsMode(tagged({ access: 'yes', foot: 'no' }), 'foot')).toBe(false);
+    expect(picker.allowsMode(tagged({ vehicle: 'no', motor_vehicle: 'yes' }), 'driving'))
+      .toBe(true);
+    expect(picker.allowsMode(tagged({ access: 'yes', vehicle: 'no' }), 'bike')).toBe(false);
+  });
+
+  test('each mode reads its own keys and ignores the others', () => {
+    const carsOnly = tagged({ foot: 'no' });
+    expect(picker.allowsMode(carsOnly, 'foot')).toBe(false);
+    expect(picker.allowsMode(carsOnly, 'driving')).toBe(true);
+    expect(picker.allowsMode(carsOnly, 'bike')).toBe(true);
+  });
+
+  test('the profile aliases agree with each other', () => {
+    const shut = tagged({ motor_vehicle: 'no' });
+    expect(picker.allowsMode(shut, 'driving')).toBe(picker.allowsMode(shut, 'car'));
+    const bikes = tagged({ bicycle: 'no' });
+    expect(picker.allowsMode(bikes, 'bike')).toBe(picker.allowsMode(bikes, 'bicycle'));
+  });
+
+  test('routableEntrances applies the mode on top of the direction', () => {
+    const open = door('main', { osmId: 1 });
+    const noCars = door('main', { osmId: 2, tags: { motor_vehicle: 'no' } });
+    expect(picker.routableEntrances([open, noCars], 'origin', 'driving')).toEqual([open]);
+    expect(picker.routableEntrances([open, noCars], 'origin', 'foot'))
+      .toEqual([open, noCars]);
+    // Omitted, nothing is filtered on access at all.
+    expect(picker.routableEntrances([open, noCars], 'origin')).toEqual([open, noCars]);
+  });
+});
+
+describe('marks', () => {
+  const tagged = (tags) => door('main', { tags });
+
+  test('a step-free door is marked on foot, and nowhere else', () => {
+    const wide = tagged({ wheelchair: 'yes' });
+    expect(picker.entranceMark(wide, 'foot').label).toBe('Wheelchair accessible');
+    expect(picker.entranceMark(wide, 'driving')).toBeNull();
+    expect(picker.entranceMark(wide, 'bike')).toBeNull();
+  });
+
+  test('designated counts as step-free, limited does not', () => {
+    expect(picker.entranceMark(tagged({ wheelchair: 'designated' }), 'foot')).toBeTruthy();
+    // "Limited" means passable only with help, or on terms the tag never spells
+    // out; promising step-free access there is worse than saying nothing.
+    expect(picker.entranceMark(tagged({ wheelchair: 'limited' }), 'foot')).toBeNull();
+    expect(picker.entranceMark(tagged({ wheelchair: 'no' }), 'foot')).toBeNull();
+  });
+
+  test('a parking entrance is marked when driving, and nowhere else', () => {
+    const gate = tagged({ amenity: 'parking_entrance' });
+    expect(picker.entranceMark(gate, 'driving').label).toBe('Parking entrance');
+    expect(picker.entranceMark(gate, 'car').label).toBe('Parking entrance');
+    expect(picker.entranceMark(gate, 'foot')).toBeNull();
+  });
+
+  test('cycling has no mark of its own, and neither has no mode at all', () => {
+    const both = tagged({ wheelchair: 'yes', amenity: 'parking_entrance' });
+    expect(picker.entranceMark(both, 'bike')).toBeNull();
+    expect(picker.entranceMark(both)).toBeNull();
+  });
+
+  test('an untagged door earns nothing', () => {
+    expect(picker.entranceMark(door('main'), 'foot')).toBeNull();
+    expect(picker.entranceMark(null, 'foot')).toBeNull();
+  });
+
+  // A mark never filters: an absent tag means nobody surveyed the door.
+  test('a mark says nothing about whether the door is offered', () => {
+    const plain = door('main', { osmId: 1 });
+    const marked = door('main', { osmId: 2, tags: { wheelchair: 'yes' } });
+    expect(picker.routableEntrances([plain, marked], 'origin', 'foot'))
+      .toEqual([plain, marked]);
+  });
+});

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -41,9 +41,13 @@ jest.mock('leaflet', () => ({
     handlers: {},
     getLatLng() { return this.latLng; },
     // Mimics enough of the label element for the layout pass to measure it.
+    // Boxes are keyed by the door's name, so the mark glyph is stripped with
+    // the markup.
     getElement() {
       const html = (this.options.icon && this.options.icon.options.html) || '';
-      const text = html.replace(/<[^>]*>/g, '');
+      const text = html
+        .replace(/<span class="osrm-entrance-mark[^>]*>[^<]*<\/span>/g, '')
+        .replace(/<[^>]*>/g, '');
       const boxes = require('./__label_boxes');
       const box = boxes.get(text);
       return {
@@ -110,8 +114,12 @@ function labels(map) {
   return g ? g._layers[1]._layers : [];
 }
 
+// The names a label shows, with any mark glyph stripped — the marks are
+// asserted on the markup itself.
 function labelTexts(map) {
-  return labels(map).map((m) => m.options.icon.options.html.replace(/<[^>]*>/g, ''));
+  return labels(map).map((m) => m.options.icon.options.html
+    .replace(/<span class="osrm-entrance-mark[^>]*>[^<]*<\/span>/g, '')
+    .replace(/<[^>]*>/g, ''));
 }
 
 function dots(map) {
@@ -555,5 +563,73 @@ describe('clicking a label', () => {
     labelBoxes.set({ Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16) });
     const { map } = openPicker({ entrances: NAMED });
     expect(labels(map).every((m) => m.options.keyboard === false)).toBe(true);
+  });
+});
+
+describe('marks on the map', () => {
+  const labelBoxes = require('./__label_boxes');
+  const box = (l, t, r, b) => ({ left: l, top: t, right: r, bottom: b });
+
+  const STEP_FREE = {
+    osmId: 1, type: 'main', center: { lat: 52.5209, lng: 13.3965 },
+    tags: { name: 'Nord', wheelchair: 'yes' }
+  };
+  const PLAIN = {
+    osmId: 2, type: 'yes', center: { lat: 52.5208, lng: 13.3970 }, tags: { name: 'Ost' }
+  };
+
+  afterEach(() => labelBoxes.clear());
+
+  function open(mode, boxes) {
+    labelBoxes.set(boxes || { Nord: box(0, 0, 40, 16), Ost: box(100, 0, 140, 16) });
+    return openPicker({ entrances: [STEP_FREE, PLAIN], mode: mode });
+  }
+
+  test('a marked door carries its glyph in the label; an unmarked one does not', () => {
+    const { map } = open('foot');
+    const html = labels(map).map((m) => m.options.icon.options.html);
+    expect(html[0]).toContain('osrm-entrance-mark-wheelchair');
+    expect(html[1]).not.toContain('osrm-entrance-mark');
+  });
+
+  test('the mark is hidden from assistive tech, which reads it off the dot instead', () => {
+    const { map } = open('foot');
+    expect(labels(map)[0].options.icon.options.html).toContain('aria-hidden="true"');
+    expect(dots(map)[0].options.alt).toBe('Nord (Wheelchair accessible)');
+    expect(dots(map)[1].options.alt).toBe('Ost');
+  });
+
+  test('a mode with no mark for that door marks nothing', () => {
+    const { map } = open('driving');
+    expect(labels(map)[0].options.icon.options.html).not.toContain('osrm-entrance-mark');
+    expect(dots(map)[0].options.alt).toBe('Nord');
+  });
+
+  test('a merged label marks only the doors that earned it', () => {
+    const { map } = open('foot', { Nord: box(0, 0, 40, 16), Ost: box(20, 0, 60, 16) });
+    expect(labelTexts(map)).toEqual(['NordOst']);
+    const html = labels(map)[0].options.icon.options.html;
+    expect(html.match(/osrm-entrance-mark-wheelchair/g)).toHaveLength(1);
+  });
+
+  test('the mark label goes through the translator', () => {
+    labelBoxes.set({ Nord: box(0, 0, 40, 16) });
+    const { map } = openPicker({ entrances: [STEP_FREE], mode: 'foot' },
+      { translate: (key) => ({ 'Wheelchair accessible': 'Barrierefrei' })[key] || key });
+    expect(dots(map)[0].options.alt).toBe('Nord (Barrierefrei)');
+  });
+});
+
+describe('re-showing without moving the view', () => {
+  test('frame: false redraws the offer where it is', () => {
+    const { map, picker } = openPicker();
+    settle();
+    expect(map.fitBounds).toHaveBeenCalledTimes(1);
+
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN], frame: false });
+    map.fire('moveend');
+    settle();
+    expect(map.fitBounds).toHaveBeenCalledTimes(1);
+    expect(dots(map)).toHaveLength(1);
   });
 });

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -296,6 +296,20 @@ describe('travel mode', () => {
     expect(wiring.claimView()).toBe(false);
   });
 
+  // The mirror of the case below: a mode switch can make a door usable that was
+  // not, and the place is still the one on screen.
+  test('a refresh reopens an offer the previous mode had emptied', () => {
+    let mode = 'driving';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+    expect(wiring.onGeocodeResult(geocodeEvent([NO_CARS]))).toBe(false);
+    expect(picker.open).toBe(false);
+
+    mode = 'foot';
+    expect(wiring.refresh()).toBe(true);
+    expect(picker.open).toBe(true);
+    expect(picker.shown[0].entrances).toEqual([NO_CARS]);
+  });
+
   test('a refresh that leaves no usable door closes the picker', () => {
     let mode = 'foot';
     const { wiring, picker } = build({ options: { mode: () => mode } });
@@ -312,6 +326,7 @@ describe('travel mode', () => {
     expect(picker.show).not.toHaveBeenCalled();
   });
 
+  // hide() is the deliberate dismissal, and it ends the offer for good.
   test('refresh forgets the place once the picker has been hidden', () => {
     const { wiring } = build({ options: { mode: () => 'foot' } });
     wiring.onGeocodeResult(geocodeEvent([MAIN]));

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -263,3 +263,66 @@ describe('hide', () => {
     expect(wiring.isOpen()).toBe(false);
   });
 });
+
+describe('travel mode', () => {
+  const NO_CARS = {
+    osmId: 5, type: 'main', center: DOOR, tags: { motor_vehicle: 'no' }
+  };
+
+  test('is read live, so switching profile changes what is offered', () => {
+    let mode = 'foot';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN, NO_CARS]));
+    expect(picker.shown[0].entrances).toEqual([MAIN, NO_CARS]);
+    expect(picker.shown[0].mode).toBe('foot');
+
+    mode = 'driving';
+    expect(wiring.refresh()).toBe(true);
+    expect(picker.shown[1].entrances).toEqual([MAIN]);
+    expect(picker.shown[1].mode).toBe('driving');
+  });
+
+  // The user did not ask to be taken back to the doors just by changing profile.
+  test('a refresh redraws the doors where they are and claims no view', () => {
+    let mode = 'foot';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN, NO_CARS]));
+    expect(picker.shown[0].frame).toBe(true);
+    wiring.claimView();
+
+    mode = 'driving';
+    wiring.refresh();
+    expect(picker.shown[1].frame).toBe(false);
+    expect(wiring.claimView()).toBe(false);
+  });
+
+  test('a refresh that leaves no usable door closes the picker', () => {
+    let mode = 'foot';
+    const { wiring, picker } = build({ options: { mode: () => mode } });
+    wiring.onGeocodeResult(geocodeEvent([NO_CARS]));
+
+    mode = 'driving';
+    expect(wiring.refresh()).toBe(false);
+    expect(picker.open).toBe(false);
+  });
+
+  test('refresh does nothing when no picker is open', () => {
+    const { wiring, picker } = build();
+    expect(wiring.refresh()).toBe(false);
+    expect(picker.show).not.toHaveBeenCalled();
+  });
+
+  test('refresh forgets the place once the picker has been hidden', () => {
+    const { wiring } = build({ options: { mode: () => 'foot' } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    wiring.hide();
+    expect(wiring.refresh()).toBe(false);
+  });
+
+  test('no mode supplied means no access filtering', () => {
+    const { wiring, picker } = build();
+    wiring.onGeocodeResult(geocodeEvent([MAIN, NO_CARS]));
+    expect(picker.shown[0].entrances).toEqual([MAIN, NO_CARS]);
+    expect(picker.shown[0].mode).toBeNull();
+  });
+});


### PR DESCRIPTION
Fourth of the series splitting #504. Stacked on #520 (labels), because a door's mark is drawn inside its label. **Review after #520 lands** — the diff below is against that branch.

## Access

Which doors are offered now follows the door's own OSM access tags as well as its direction. A door forbidden to cars may be perfectly fine on foot.

Keys are read in the order OSM's access documentation prescribes, most specific first, and the first one present settles it outright:

| mode | keys |
|---|---|
| foot | `foot`, `access` |
| bike | `bicycle`, `vehicle`, `access` |
| driving | `motor_vehicle`, `vehicle`, `access` |

Only `no` and `private` forbid. `permissive`, `customers`, `designated`, `destination` and `permit` are all usable — somebody routing to a shop's door is the customer it is tagged for — and an unrecognised value is not read as a prohibition. An untagged door is open to everyone: absence of a tag is not a prohibition.

The mode is read live rather than captured once, so switching profile re-applies the rules to the place already on screen. That redraw leaves the view where it is (`frame: false`): the user asked for a different profile, not to be taken back to the doors.

## Marks

A door can carry a mark, which **never filters**: ♿️ on foot, 🅿️ when driving. Roughly seven in eight entrance nodes carry no `wheelchair` tag at all, so an absent value means nobody surveyed the door rather than that the door lacks the property — filtering on it would hide most of the map.

Each mark belongs to one travel mode and appears in no other: step-free access matters to someone on foot and says nothing to a driver; which door swallows cars matters to a driver and is noise to everyone else. `wheelchair=designated` counts as step-free alongside `yes`; `limited` deliberately does not, since it means passable only with help or on terms the tag never spells out, and a mark promising step-free access there is worse than no mark.

There is deliberately no mark for cycling: `bicycle` on an entrance node does not reach even 0.05% of them globally — against `wheelchair` at 4.7% — so it would be an icon nobody ever sees.

Both glyphs carry an explicit U+FE0F emoji selector. The two characters default differently — U+267F is `Emoji_Presentation=Yes` and renders in colour on its own, U+1F17F is not and falls back to a black-and-white glyph without it — which is how one mark ends up coloured and the other not.

The mark is decoration inside the label and is `aria-hidden`; assistive technology reads it off the dot's `alt` in words instead, so it is announced once rather than twice.

## Tests

Access: untagged doors, no mode, only `no`/`private` forbidding, case, the specificity hierarchy in both directions, each mode reading its own keys, the profile aliases agreeing, and `routableEntrances` applying mode on top of direction. Marks: per-mode assignment, `designated` versus `limited`, cycling and no-mode having none, an untagged door earning nothing, and a mark not affecting what is offered. Live: the glyph in the label, `aria-hidden`, the dot's spoken alt, a merged label marking only the door that earned it, the translator, and `frame: false` redrawing without moving the view. Wiring: live mode, refresh re-filtering, a refresh that empties the offer closing it, and refresh claiming no view.

489 tests, 35 suites, lint clean. Verified against live Nominatim and OSRM: with Alexa Berlin's five doors on screen, switching Foot → Car re-filtered and re-laid out the offer with the map pane not moving a pixel.

🤖 Claude Code, Claude Opus 5
