### PR TITLE
feat: give every waypoint its own entrance offer

### DIFF
--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -326,7 +326,8 @@ function choicePoints(choices, placeCenter) {
  * change of travel mode re-filters the doors already on screen, and the user
  * did not ask to be taken to them.
  * @returns {{show: function, hide: function, focusView: function,
- *   isOpen: function, getWaypointIndex: function, getSelectedId: function}}
+ *   hideWaypoint: function, spliceOffers: function, isOpen: function,
+ *   isOpenFor: function, getWaypointIndex: function, getSelectedId: function}}
  */
 function createEntrancePicker(map, options) {
   options = options || {};
@@ -355,7 +356,13 @@ function createEntrancePicker(map, options) {
   var labelLayer = L.layerGroup();
   var markerLayer = L.layerGroup();
   var layer = L.layerGroup([linkLayer, labelLayer, markerLayer]);
-  var offer = null;
+  // One offer per waypoint. More than one waypoint can be showing its doors at
+  // once: naming a start must not withdraw the destination's, which is what a
+  // single shared offer did.
+  var offers = [];
+  // The offer the view frames: the one shown most recently, which is the one
+  // the user is looking at. Escape is not scoped to it — that clears them all.
+  var activeWaypointIndex = null;
   // What each dot currently drawn needs a label to say, in draw order: where it
   // is, what it is called, whether it is the chosen one, and what clicking it
   // does. Kept beside the markers rather than on them — Leaflet's marker is not
@@ -379,6 +386,17 @@ function createEntrancePicker(map, options) {
     return translate('Entrance');
   }
 
+  function offerAt(waypointIndex) {
+    for (var i = 0; i < offers.length; i++) {
+      if (offers[i].waypointIndex === waypointIndex) return offers[i];
+    }
+    return null;
+  }
+
+  function activeOffer() {
+    return activeWaypointIndex === null ? null : offerAt(activeWaypointIndex);
+  }
+
   function onKeyDown(e) {
     if (e && e.key === 'Escape') hide();
   }
@@ -390,51 +408,53 @@ function createEntrancePicker(map, options) {
     markerLayer.clearLayers();
     linkLayer.clearLayers();
     renderedDoors = [];
-    if (!offer) {
+    if (!offers.length) {
       labelLayer.clearLayers();
       return;
     }
 
-    offer.choices.forEach(function(choice) {
-      var chosen = choice.id === offer.selectedId;
-      var text = label(choice);
-      var mark = entranceMark(choice.entrance, offer.mode);
-      var className = 'osrm-entrance-marker osrm-entrance-marker-' + choice.kind +
+    offers.forEach(function(offer) {
+      offer.choices.forEach(function(choice) {
+        var chosen = choice.id === offer.selectedId;
+        var text = label(choice);
+        var mark = entranceMark(choice.entrance, offer.mode);
+        var className = 'osrm-entrance-marker osrm-entrance-marker-' + choice.kind +
         (chosen ? ' osrm-entrance-marker-selected' : '');
-      var marker = L.marker(choice.center, {
-        icon: L.divIcon({className: className, iconSize: [18, 18], iconAnchor: [9, 9], html: ''}),
-        // The label shows this as an icon; the alt spells it out, because the
-        // icon is marked aria-hidden and would otherwise be announced as
-        // nothing at all.
-        alt: mark ? text + ' (' + translate(mark.label) + ')' : text,
-        keyboard: true,
-        zIndexOffset: chosen ? 500 : 400
-      });
-      // The name travels beside the dot; layoutLabels turns it into a label the
-      // user can read without hovering, and click as a stand-in for the dot.
-      renderedDoors.push({
-        latLng: choice.center,
-        text: text,
-        mark: mark,
-        selected: chosen,
-        select: function() {
-          select(choice);
-        }
-      });
-      marker.on('click', function(e) {
+        var marker = L.marker(choice.center, {
+          icon: L.divIcon({className: className, iconSize: [18, 18], iconAnchor: [9, 9], html: ''}),
+          // The label shows this as an icon; the alt spells it out, because the
+          // icon is marked aria-hidden and would otherwise be announced as
+          // nothing at all.
+          alt: mark ? text + ' (' + translate(mark.label) + ')' : text,
+          keyboard: true,
+          zIndexOffset: chosen ? 500 : 400
+        });
+        // The name travels beside the dot; layoutLabels turns it into a label the
+        // user can read without hovering, and click as a stand-in for the dot.
+        renderedDoors.push({
+          latLng: choice.center,
+          text: text,
+          mark: mark,
+          selected: chosen,
+          select: function() {
+            select(offer, choice);
+          }
+        });
+        marker.on('click', function(e) {
         // Without this the click also lands on the map, which would drop a
         // new waypoint on top of the place being chosen for.
-        L.DomEvent.stopPropagation(e);
-        select(choice);
-      });
-      markerLayer.addLayer(marker);
+          L.DomEvent.stopPropagation(e);
+          select(offer, choice);
+        });
+        markerLayer.addLayer(marker);
 
-      // The pin stays on the place, so the chosen door is tied back to it with a
-      // dashed line: the route runs to the door, and this is the last bit on
-      // foot that no router can describe.
-      if (chosen && offer.placeCenter) {
-        linkLayer.addLayer(L.polyline([choice.center, offer.placeCenter], ENTRANCE_LINK_STYLE));
-      }
+        // The pin stays on the place, so the chosen door is tied back to it with a
+        // dashed line: the route runs to the door, and this is the last bit on
+        // foot that no router can describe.
+        if (chosen && offer.placeCenter) {
+          linkLayer.addLayer(L.polyline([choice.center, offer.placeCenter], ENTRANCE_LINK_STYLE));
+        }
+      });
     });
 
     layoutLabels();
@@ -536,7 +556,7 @@ function createEntrancePicker(map, options) {
   // colliding run is replaced by one label listing every door in it, anchored on
   // the first. Zooming in separates them and they come back individually.
   function layoutLabels() {
-    if (!offer) return null;
+    if (!offers.length) return null;
     var doors = renderedDoors;
 
     // One label per door first, because their boxes are what the grouping is
@@ -572,10 +592,11 @@ function createEntrancePicker(map, options) {
   // Clicking the chosen door again releases it, which is how the route goes back
   // to the place itself. There is no separate dot for that: the pin is already
   // sitting on it.
-  function select(choice) {
+  function select(offer, choice) {
     // A dot's handler closes over the offer it was drawn for, so a click
-    // arriving after that offer was withdrawn must do nothing.
-    if (!offer) return;
+    // arriving after that offer was withdrawn — hidden, or replaced by a newer
+    // one for the same waypoint — must do nothing.
+    if (!offer || offerAt(offer.waypointIndex) !== offer) return;
     var release = choice.id === offer.selectedId;
     offer.selectedId = release ? null : choice.id;
     render();
@@ -597,6 +618,9 @@ function createEntrancePicker(map, options) {
   // than merely centred, so the pane never sits over the thing being picked
   // from.
   function focusView() {
+    // The newest offer is framed: it is the one the user just asked for. The
+    // others stay on the map, they simply do not pull the view around.
+    var offer = activeOffer();
     if (!offer) return false;
     var points = choicePoints(offer.choices, offer.placeCenter);
     if (points.length < 2) return false;
@@ -614,7 +638,7 @@ function createEntrancePicker(map, options) {
   // map to settle before framing, with a timer as the backstop for the case
   // where nothing moved and no moveend ever arrives.
   function focusViewWhenSettled() {
-    if (!offer) return;
+    if (!activeOffer()) return;
     var timer = null;
     function run() {
       map.off('moveend', run);
@@ -631,10 +655,12 @@ function createEntrancePicker(map, options) {
     // A single door is still worth offering: the pin already marks the place,
     // so one dot is a real choice rather than a foregone one.
     if (choices.length < 1) {
-      hide();
+      // Only this waypoint's offer goes. A place with no doors of its own says
+      // nothing about the doors another waypoint is showing.
+      hideWaypoint(opts.waypointIndex);
       return false;
     }
-    offer = {
+    var offer = {
       waypointIndex: opts.waypointIndex,
       placeName: opts.placeName,
       placeCenter: opts.placeCenter || null,
@@ -644,6 +670,15 @@ function createEntrancePicker(map, options) {
       mode: opts.mode || null,
       selectedId: opts.selectedId || null
     };
+    var existing = offerAt(opts.waypointIndex);
+    if (existing) {
+      // Re-showing the same waypoint replaces its offer in place, so the order
+      // the dots were drawn in does not jump around on a mode change.
+      offers[offers.indexOf(existing)] = offer;
+    } else {
+      offers.push(offer);
+    }
+    activeWaypointIndex = offer.waypointIndex;
     attached = true;
     if (!map.hasLayer(layer)) layer.addTo(map);
     render();
@@ -661,10 +696,72 @@ function createEntrancePicker(map, options) {
     return true;
   }
 
+  /**
+   * Follows a splice of the waypoint list.
+   *
+   * Offers are keyed by waypoint index, so inserting or removing a waypoint
+   * renumbers the ones after it. Dropping every offer instead — which is what
+   * a single shared offer amounted to — meant that placing a destination by
+   * clicking the map took away the doors the start was already showing.
+   *
+   * @param {number} index — where the splice happened
+   * @param {number} nRemoved — waypoints deleted there
+   * @param {number} nAdded — waypoints inserted there
+   */
+  function spliceOffers(index, nRemoved, nAdded) {
+    var removed = nRemoved || 0;
+    var delta = (nAdded || 0) - removed;
+    var kept = [];
+    offers.forEach(function(offer) {
+      // Untouched: it sits before the splice.
+      if (offer.waypointIndex < index) {
+        kept.push(offer);
+        return;
+      }
+      // Its waypoint is gone, and so is the place it belonged to.
+      if (offer.waypointIndex < index + removed) {
+        if (activeWaypointIndex === offer.waypointIndex) activeWaypointIndex = null;
+        return;
+      }
+      if (activeWaypointIndex === offer.waypointIndex) activeWaypointIndex += delta;
+      offer.waypointIndex += delta;
+      kept.push(offer);
+    });
+    if (kept.length === offers.length && !delta) return;
+    offers = kept;
+    if (!offers.length) {
+      hide();
+      return;
+    }
+    if (activeWaypointIndex === null) {
+      activeWaypointIndex = offers[offers.length - 1].waypointIndex;
+    }
+    render();
+  }
+
+  // Withdraws one waypoint's offer, leaving every other one on the map.
+  function hideWaypoint(waypointIndex) {
+    var offer = offerAt(waypointIndex);
+    if (!offer) return;
+    offers.splice(offers.indexOf(offer), 1);
+    if (activeWaypointIndex === waypointIndex) {
+      // Frame whatever is left, newest first, so the view still follows
+      // something the user can see.
+      activeWaypointIndex = offers.length
+        ? offers[offers.length - 1].waypointIndex : null;
+    }
+    if (!offers.length) {
+      hide();
+      return;
+    }
+    render();
+  }
+
   function hide() {
     if (!attached) return;
     attached = false;
-    offer = null;
+    offers = [];
+    activeWaypointIndex = null;
     renderedDoors = [];
     map.off('zoomend', layoutLabels);
     linkLayer.clearLayers();
@@ -679,15 +776,22 @@ function createEntrancePicker(map, options) {
   return {
     show: show,
     hide: hide,
+    hideWaypoint: hideWaypoint,
+    spliceOffers: spliceOffers,
     focusView: focusViewWhenSettled,
     layoutLabels: layoutLabels,
     isOpen: function() {
-      return !!offer;
+      return offers.length > 0;
+    },
+    isOpenFor: function(waypointIndex) {
+      return !!offerAt(waypointIndex);
     },
     getWaypointIndex: function() {
+      var offer = activeOffer();
       return offer ? offer.waypointIndex : null;
     },
-    getSelectedId: function() {
+    getSelectedId: function(waypointIndex) {
+      var offer = arguments.length ? offerAt(waypointIndex) : activeOffer();
       return offer ? offer.selectedId : null;
     }
   };

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -152,7 +152,12 @@ function createEntranceWaypoints(options) {
     // access tags.
     var count = plan && plan._waypoints ? plan._waypoints.length : 0;
     var role = entrancePicker.waypointRole(e.waypointIndex, count);
-    lastEvents[e.waypointIndex] = {event: e, role: role};
+    // A copy of our own: `spliceWaypoints` renumbers the index it carries, and
+    // the event LRM fired belongs to LRM and its other listeners.
+    lastEvents[e.waypointIndex] = {
+      event: {waypointIndex: e.waypointIndex, waypoint: e.waypoint, value: e.value},
+      role: role
+    };
     // Read once: the mode is live, and filtering the doors by one value while
     // marking them for another would mark a door the filter had just judged on
     // different terms.
@@ -247,25 +252,34 @@ function createEntranceWaypoints(options) {
         // Its waypoint is gone, and so is the place it belonged to.
         if (reAdded === -1) return;
         to = index + reAdded;
+        // Its offer is inside the range spliceOffers is about to clear, and
+        // spliceOffers cannot tell a waypoint that moved from one that went.
+        // Whatever its role does, the offer has to be put back.
+        record.reoffer = true;
       } else {
         to = at + delta;
       }
       // The event carries the index the picker is keyed by, so it has to move
-      // with it.
+      // with it. The event is ours — a copy made when it was remembered.
       if (record.event) record.event.waypointIndex = to;
       moved[to] = record;
     });
     lastEvents = moved;
-    // Renumber the offers first. A waypoint that moved has had its offer
-    // dropped here — spliceOffers cannot tell it apart from a removal — and the
-    // re-filtering below puts it back at the index it now has.
+    // Renumber the offers first, so the re-offering below lands on the indexes
+    // the waypoints now have.
     picker.spliceOffers(index, removed, added);
 
     var count = plan && plan._waypoints ? plan._waypoints.length : 0;
     Object.keys(lastEvents).forEach(function(key) {
       var record = lastEvents[key];
       if (!record || !record.event) return;
-      if (entrancePicker.waypointRole(Number(key), count) === record.role) return;
+      var role = entrancePicker.waypointRole(Number(key), count);
+      var reoffer = record.reoffer;
+      delete record.reoffer;
+      // A role change alters which doors are on offer; a waypoint carried
+      // through the removed range has had its offer cleared and needs it back
+      // whether or not its role moved with it.
+      if (!reoffer && role === record.role) return;
       onGeocodeResult(record.event, false);
     });
   }

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -71,7 +71,8 @@ function entranceWaypointName(placeName, entrance, translate) {
  *   so switching between car, bike and foot re-applies the access rules
  * @param {function} [options.createPicker] — injection seam for tests
  * @returns {{onGeocodeResult: function, applySelection: function,
- *   refresh: function, hide: function, isOpen: function, claimView: function,
+ *   refresh: function, spliceWaypoints: function, hideWaypoint: function,
+ *   hide: function, isOpen: function, claimView: function,
  *   waypointName: function}}
  */
 function createEntranceWaypoints(options) {
@@ -85,9 +86,12 @@ function createEntranceWaypoints(options) {
   var mode = typeof options.mode === 'function' ? options.mode : function() {
     return null;
   };
-  // The last geocoding result seen, kept so a change of travel mode can
-  // re-apply the filters without a fresh geocode.
-  var lastEvent = null;
+  // The last geocoding result seen for each waypoint, kept so a change of
+  // travel mode or of the waypoint's role can re-apply the filters without a
+  // fresh geocode. Keyed by waypoint index, because several waypoints can be
+  // showing their doors at once; each entry holds the event and the role it was
+  // last filtered under, so a role change can be told from a mere renumbering.
+  var lastEvents = {};
   // Set when a geocode opens an offer and the picker frames its doors. The
   // route that follows would otherwise be fitted over that framing; index.js
   // asks for the claim once per route and stands down if it is set.
@@ -148,7 +152,7 @@ function createEntranceWaypoints(options) {
     // access tags.
     var count = plan && plan._waypoints ? plan._waypoints.length : 0;
     var role = entrancePicker.waypointRole(e.waypointIndex, count);
-    lastEvent = e;
+    lastEvents[e.waypointIndex] = {event: e, role: role};
     // Read once: the mode is live, and filtering the doors by one value while
     // marking them for another would mark a door the filter had just judged on
     // different terms.
@@ -157,7 +161,10 @@ function createEntranceWaypoints(options) {
       ? entrancePicker.routableEntrances(result.entrances, role, activeMode)
       : [];
     if (!entrances.length) {
-      picker.hide();
+      // Only this waypoint's dots go. Naming a start with no doors of its own
+      // must not withdraw the destination's — that is the whole reason offers
+      // are per-waypoint.
+      picker.hideWaypoint(e.waypointIndex);
       return false;
     }
 
@@ -175,26 +182,105 @@ function createEntranceWaypoints(options) {
     return shown;
   }
 
-  // Re-applies the filters to the place last geocoded. Switching from foot to
+  // Re-applies the filters to every place remembered. Switching from foot to
   // car can forbid the very door a waypoint sits on, and can equally make one
-  // usable that was not, so this runs whether or not the offer is currently on
+  // usable that was not, so this runs whether or not an offer is currently on
   // screen — a place whose doors are all shut to cars comes back when the
-  // traveller switches to walking. It is `hide()` that ends an offer for good,
-  // by forgetting the place along with it.
+  // traveller switches to walking. It is `hide()` and `hideWaypoint()` that end
+  // an offer for good, by forgetting the place along with it.
   //
   // The redraw stays where it is: the user asked for a different profile, not
   // to be taken back to the doors.
   function refresh() {
-    if (!lastEvent) return false;
-    return onGeocodeResult(lastEvent, false);
+    var any = false;
+    Object.keys(lastEvents).forEach(function(key) {
+      if (onGeocodeResult(lastEvents[key].event, false)) any = true;
+    });
+    return any;
+  }
+
+  // Where a waypoint that was spliced out has reappeared among the ones spliced
+  // in, or -1 if it is genuinely gone. LRM's reverse button replaces the whole
+  // list — spliceWaypoints(0, length, ...the same waypoint objects, reordered)
+  // — so "removed" and "added" overlap, and only object identity tells a real
+  // removal from a waypoint that merely changed places. LRM passes a waypoint
+  // through untouched when it already has a `latLng`, so the objects survive.
+  function addedIndexOf(added, waypoint) {
+    if (!waypoint || !added) return -1;
+    for (var i = 0; i < added.length; i++) {
+      if (added[i] === waypoint) return i;
+    }
+    return -1;
+  }
+
+  /**
+   * Follows a splice of the waypoint list, keeping the remembered results lined
+   * up with the waypoints they belong to. Without this a refresh after a splice
+   * would re-offer a place against the wrong waypoint.
+   *
+   * A splice can also change what a waypoint *is*: reversing start and
+   * destination, or adding one after it so it becomes a via. Which doors are on
+   * offer follows directly from that role — an entrance=exit can be left
+   * through but not entered — so every waypoint whose role changed is
+   * re-filtered against the result already remembered for it. Without this,
+   * reversing a route left a door that is only valid at the new end unoffered
+   * until the address was typed again.
+   */
+  function spliceWaypoints(e) {
+    var index = e && typeof e.index === 'number' ? e.index : 0;
+    var removed = e && typeof e.nRemoved === 'number' ? e.nRemoved : 0;
+    var addedList = e && e.added ? e.added : [];
+    var added = addedList.length;
+    var delta = added - removed;
+    var moved = {};
+    Object.keys(lastEvents).forEach(function(key) {
+      var at = Number(key);
+      var record = lastEvents[key];
+      var to;
+      if (at < index) {
+        // Untouched: it sits before the splice.
+        moved[at] = record;
+        return;
+      }
+      if (at < index + removed) {
+        var reAdded = addedIndexOf(addedList, record.event && record.event.waypoint);
+        // Its waypoint is gone, and so is the place it belonged to.
+        if (reAdded === -1) return;
+        to = index + reAdded;
+      } else {
+        to = at + delta;
+      }
+      // The event carries the index the picker is keyed by, so it has to move
+      // with it.
+      if (record.event) record.event.waypointIndex = to;
+      moved[to] = record;
+    });
+    lastEvents = moved;
+    // Renumber the offers first. A waypoint that moved has had its offer
+    // dropped here — spliceOffers cannot tell it apart from a removal — and the
+    // re-filtering below puts it back at the index it now has.
+    picker.spliceOffers(index, removed, added);
+
+    var count = plan && plan._waypoints ? plan._waypoints.length : 0;
+    Object.keys(lastEvents).forEach(function(key) {
+      var record = lastEvents[key];
+      if (!record || !record.event) return;
+      if (entrancePicker.waypointRole(Number(key), count) === record.role) return;
+      onGeocodeResult(record.event, false);
+    });
   }
 
   return {
     onGeocodeResult: onGeocodeResult,
     applySelection: applySelection,
     refresh: refresh,
+    spliceWaypoints: spliceWaypoints,
+    hideWaypoint: function(waypointIndex) {
+      delete lastEvents[waypointIndex];
+      picker.hideWaypoint(waypointIndex);
+    },
     hide: function() {
-      lastEvent = null;
+      lastEvents = {};
       picker.hide();
     },
     isOpen: function() {

--- a/src/index.js
+++ b/src/index.js
@@ -743,10 +743,16 @@ if (modeSelector && modeSelector.select) {
   });
 }
 
-// Adding, removing or reordering waypoints invalidates the index the offer is
-// pinned to; dragging the pin means the user has already chosen a spot.
-plan.on('waypointsspliced', entranceWaypoints.hide);
-plan.on('waypointdragstart', entranceWaypoints.hide);
+// Adding, removing or reordering waypoints renumbers the ones after the splice,
+// and each waypoint keeps its own offer — so the offers are renumbered too
+// rather than thrown away. Dropping them all meant that placing a destination
+// by clicking the map took the start's doors off the screen with it.
+plan.on('waypointsspliced', entranceWaypoints.spliceWaypoints);
+// Only the dragged waypoint's doors go: it is being moved off the place they
+// belong to, and no other waypoint is affected.
+plan.on('waypointdragstart', function(e) {
+  entranceWaypoints.hideWaypoint(e && e.index);
+});
 
 // The route the picker was waiting on never came; its claim on the view must
 // not carry over to whatever route comes next.

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -633,3 +633,146 @@ describe('re-showing without moving the view', () => {
     expect(dots(map)).toHaveLength(1);
   });
 });
+
+describe('one offer per waypoint', () => {
+  const OTHER = { osmId: 7, type: 'main', center: { lat: 52.4, lng: 13.5 } };
+
+  // Two waypoints showing their doors at once. openPicker builds the first.
+  function openTwo() {
+    const opened = openPicker();
+    opened.picker.show({
+      waypointIndex: 3, placeName: 'BER', placeCenter: { lat: 52.36, lng: 13.5 },
+      entrances: [OTHER]
+    });
+    return opened;
+  }
+
+  test('naming a second place does not withdraw the first place\'s doors', () => {
+    const { map, picker } = openTwo();
+    expect(dots(map)).toHaveLength(3);
+    expect(picker.isOpenFor(1)).toBe(true);
+    expect(picker.isOpenFor(3)).toBe(true);
+  });
+
+  test('the view follows the newest offer', () => {
+    const { map, picker } = openTwo();
+    expect(picker.getWaypointIndex()).toBe(3);
+    settle();
+    expect(map.fitBounds.mock.calls.pop()[0]._points).toContain(OTHER.center);
+  });
+
+  test('each offer keeps its own selection', () => {
+    const { map, picker, onSelect } = openTwo();
+    dots(map)[0].fire('click');
+    dots(map)[2].fire('click');
+    expect(picker.getSelectedId(1)).toBe('osm:1');
+    expect(picker.getSelectedId(3)).toBe('osm:7');
+    expect(onSelect.mock.calls.map((c) => c[0].waypointIndex)).toEqual([1, 3]);
+  });
+
+  test('re-showing a waypoint replaces its offer in place, leaving the other alone', () => {
+    const { map, picker } = openTwo();
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN], frame: false });
+    expect(dots(map)).toHaveLength(2);
+    expect(picker.isOpenFor(3)).toBe(true);
+  });
+
+  test('withdrawing one offer leaves the others on the map', () => {
+    const { map, picker } = openTwo();
+    picker.hideWaypoint(1);
+    expect(picker.isOpenFor(1)).toBe(false);
+    expect(picker.isOpenFor(3)).toBe(true);
+    expect(dots(map)).toHaveLength(1);
+    expect(picker.isOpen()).toBe(true);
+  });
+
+  test('withdrawing the framed offer hands the view to a surviving one', () => {
+    const { picker } = openTwo();
+    expect(picker.getWaypointIndex()).toBe(3);
+    picker.hideWaypoint(3);
+    expect(picker.getWaypointIndex()).toBe(1);
+  });
+
+  test('withdrawing the last offer closes the picker altogether', () => {
+    const { map, picker } = openTwo();
+    picker.hideWaypoint(1);
+    picker.hideWaypoint(3);
+    expect(picker.isOpen()).toBe(false);
+    expect(map.hasLayer(pickerGroup(map))).toBe(false);
+  });
+
+  test('withdrawing a waypoint with no offer is harmless', () => {
+    const { picker } = openTwo();
+    picker.hideWaypoint(9);
+    expect(picker.isOpen()).toBe(true);
+  });
+
+  test('a click on a door whose offer was replaced does nothing', () => {
+    const { map, picker, onSelect } = openPicker();
+    const stale = dots(map)[0];
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [SIDE], frame: false });
+    stale.fire('click');
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('offers follow a splice of the waypoint list', () => {
+  const OTHER = { osmId: 7, type: 'main', center: { lat: 52.4, lng: 13.5 } };
+
+  function openAt(indexes) {
+    const map = makeMap();
+    const picker = entrancePicker.createEntrancePicker(map, {});
+    indexes.forEach((i) => picker.show({
+      waypointIndex: i, placeCenter: CENTRE, entrances: [MAIN, OTHER], frame: false
+    }));
+    return { map, picker };
+  }
+
+  test('an insert before an offer renumbers it', () => {
+    const { picker } = openAt([2]);
+    picker.spliceOffers(0, 0, 1);
+    expect(picker.isOpenFor(3)).toBe(true);
+    expect(picker.isOpenFor(2)).toBe(false);
+  });
+
+  test('an offer before the splice is left where it is', () => {
+    const { picker } = openAt([0, 3]);
+    picker.spliceOffers(2, 0, 1);
+    expect(picker.isOpenFor(0)).toBe(true);
+    expect(picker.isOpenFor(4)).toBe(true);
+  });
+
+  test('removing a waypoint takes its offer and pulls the later ones back', () => {
+    const { picker } = openAt([1, 3]);
+    picker.spliceOffers(1, 1, 0);
+    expect(picker.isOpenFor(1)).toBe(false);
+    expect(picker.isOpenFor(2)).toBe(true);
+  });
+
+  test('the framed offer moves with its waypoint', () => {
+    const { picker } = openAt([2]);
+    picker.spliceOffers(0, 0, 2);
+    expect(picker.getWaypointIndex()).toBe(4);
+  });
+
+  test('removing the framed offer hands the view to a survivor', () => {
+    const { picker } = openAt([0, 2]);
+    expect(picker.getWaypointIndex()).toBe(2);
+    picker.spliceOffers(2, 1, 0);
+    expect(picker.getWaypointIndex()).toBe(0);
+  });
+
+  test('removing every offer closes the picker', () => {
+    const { map, picker } = openAt([0, 1]);
+    picker.spliceOffers(0, 2, 0);
+    expect(picker.isOpen()).toBe(false);
+    expect(map.hasLayer(pickerGroup(map))).toBe(false);
+  });
+
+  test('a splice that changes nothing leaves the offers untouched', () => {
+    const { picker } = openAt([0, 1]);
+    picker.spliceOffers(5, 0, 0);
+    expect(picker.isOpenFor(0)).toBe(true);
+    expect(picker.isOpenFor(1)).toBe(true);
+  });
+});

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -425,6 +425,22 @@ describe('following a splice of the waypoint list', () => {
     expect(offer.frame).toBe(false);
   });
 
+  // A three-waypoint reverse: the ends swap roles, the middle stays a via. Its
+  // offer is inside the removed range like every other, so it has to be put
+  // back even though nothing about its role changed.
+  test('reversing a longer route keeps the middle waypoint\'s offer', () => {
+    const plan = makePlan(3);
+    const [first, middle, last] = plan._waypoints;
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1, waypoint: middle }));
+    expect(picker.isOpenFor(1)).toBe(true);
+
+    plan._waypoints.reverse();
+    wiring.spliceWaypoints({ index: 0, nRemoved: 3, added: [last, middle, first] });
+
+    expect(picker.isOpenFor(1)).toBe(true);
+  });
+
   test('a splice that leaves the roles alone re-offers nothing', () => {
     const plan = makePlan(3);
     const { wiring, picker } = build({ plan });
@@ -450,6 +466,20 @@ describe('following a splice of the waypoint list', () => {
     wiring.spliceWaypoints({ index: 2, nRemoved: 0, added: [plan._waypoints[2]] });
 
     expect(picker.hiddenWaypoints).toContain(1);
+  });
+
+  // The event belongs to LRM and its other listeners; renumbering happens on a
+  // copy of our own.
+  test('a splice does not rewrite the event the plan fired', () => {
+    const plan = makePlan(3);
+    const { wiring } = build({ plan });
+    const event = geocodeEvent([MAIN], { waypointIndex: 1, waypoint: plan._waypoints[1] });
+    wiring.onGeocodeResult(event);
+
+    plan._waypoints.unshift({ latLng: null, name: '' });
+    wiring.spliceWaypoints({ index: 0, nRemoved: 0, added: [plan._waypoints[0]] });
+
+    expect(event.waypointIndex).toBe(1);
   });
 
   test('hideWaypoint forgets the place as well as withdrawing the dots', () => {

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -29,6 +29,8 @@ const CENTRE = { lat: 52.5209336, lng: 13.3956302 };
 const DOOR = { lat: 52.5209566, lng: 13.3965227 };
 const MAIN = { osmId: 1, type: 'main', center: DOOR };
 const EXIT = { osmId: 2, type: 'exit', center: DOOR };
+// entrance=entrance is a one-way in, so it is no use at an origin.
+const IN_ONLY = { osmId: 3, type: 'entrance', center: DOOR };
 
 function makePlan(count) {
   const waypoints = [];
@@ -52,18 +54,42 @@ function makeFakePicker() {
   const picker = {
     shown: [],
     hidden: 0,
+    // Waypoint indices withdrawn one at a time, in order.
+    hiddenWaypoints: [],
+    // Which waypoints currently have an offer, as the real picker tracks.
+    openFor: new Set(),
     open: false,
     onSelect: null,
     show: jest.fn(function(opts) {
       picker.shown.push(opts);
+      picker.openFor.add(opts.waypointIndex);
       picker.open = true;
       return true;
     }),
     hide: jest.fn(function() {
       picker.hidden++;
+      picker.openFor.clear();
       picker.open = false;
     }),
-    isOpen: jest.fn(() => picker.open)
+    hideWaypoint: jest.fn(function(waypointIndex) {
+      picker.hiddenWaypoints.push(waypointIndex);
+      picker.openFor.delete(waypointIndex);
+      picker.open = picker.openFor.size > 0;
+    }),
+    // Mirrors the real picker: offers are renumbered by a splice, not dropped.
+    spliceOffers: jest.fn(function(index, nRemoved, nAdded) {
+      const delta = (nAdded || 0) - (nRemoved || 0);
+      const next = new Set();
+      picker.openFor.forEach((at) => {
+        if (at < index) { next.add(at); return; }
+        if (at < index + (nRemoved || 0)) return;
+        next.add(at + delta);
+      });
+      picker.openFor = next;
+      picker.open = picker.openFor.size > 0;
+    }),
+    isOpen: jest.fn(() => picker.open),
+    isOpenFor: jest.fn((waypointIndex) => picker.openFor.has(waypointIndex))
   };
   return picker;
 }
@@ -153,17 +179,22 @@ describe('building the offer', () => {
     expect(picker.shown[1].entrances).toEqual([MAIN, EXIT]);
   });
 
-  test('a place with no usable door withdraws the offer instead of showing one', () => {
-    const { wiring, picker } = build();
-    expect(wiring.onGeocodeResult(geocodeEvent([EXIT]))).toBe(false);
-    expect(picker.show).not.toHaveBeenCalled();
-    expect(picker.hidden).toBe(1);
+  test('a place with no usable door withdraws its own offer, and only its own', () => {
+    const plan = makePlan(3);
+    const { wiring, picker } = build({ plan });
+    // A via with doors, then a start with none: the via keeps its dots.
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1 }));
+    expect(wiring.onGeocodeResult(geocodeEvent([IN_ONLY], { waypointIndex: 0 }))).toBe(false);
+    expect(picker.hiddenWaypoints).toEqual([0]);
+    expect(picker.hidden).toBe(0);
+    expect(picker.isOpenFor(1)).toBe(true);
   });
 
   test('a geocode with no result at all is not an error', () => {
     const { wiring, picker } = build();
     expect(wiring.onGeocodeResult({ waypointIndex: 1, value: null })).toBe(false);
     expect(picker.show).not.toHaveBeenCalled();
+    expect(picker.hiddenWaypoints).toEqual([1]);
   });
 });
 
@@ -243,6 +274,7 @@ describe('claimView', () => {
   test('a later geocode with no usable door withdraws the earlier claim', () => {
     const { wiring } = build();
     wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    // The same waypoint, so its offer — and the claim with it — is withdrawn.
     wiring.onGeocodeResult(geocodeEvent([EXIT]));
     expect(wiring.claimView()).toBe(false);
   });
@@ -310,13 +342,14 @@ describe('travel mode', () => {
     expect(picker.shown[0].entrances).toEqual([NO_CARS]);
   });
 
-  test('a refresh that leaves no usable door closes the picker', () => {
+  test('a refresh that leaves no usable door withdraws that offer', () => {
     let mode = 'foot';
     const { wiring, picker } = build({ options: { mode: () => mode } });
     wiring.onGeocodeResult(geocodeEvent([NO_CARS]));
 
     mode = 'driving';
     expect(wiring.refresh()).toBe(false);
+    expect(picker.hiddenWaypoints).toEqual([1]);
     expect(picker.open).toBe(false);
   });
 
@@ -339,5 +372,106 @@ describe('travel mode', () => {
     wiring.onGeocodeResult(geocodeEvent([MAIN, NO_CARS]));
     expect(picker.shown[0].entrances).toEqual([MAIN, NO_CARS]);
     expect(picker.shown[0].mode).toBeNull();
+  });
+});
+
+describe('following a splice of the waypoint list', () => {
+  test('a remembered result moves with its waypoint, so a refresh stays correct', () => {
+    const plan = makePlan(3);
+    const { wiring, picker } = build({ plan, options: { mode: () => 'foot' } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1, waypoint: plan._waypoints[1] }));
+
+    // A waypoint inserted at the front pushes it to index 2.
+    plan._waypoints.unshift({ latLng: null, name: '' });
+    wiring.spliceWaypoints({ index: 0, nRemoved: 0, added: [plan._waypoints[0]] });
+
+    wiring.refresh();
+    expect(picker.shown[picker.shown.length - 1].waypointIndex).toBe(2);
+  });
+
+  test('a removed waypoint takes its remembered place with it', () => {
+    const plan = makePlan(3);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1, waypoint: plan._waypoints[1] }));
+
+    plan._waypoints.splice(1, 1);
+    wiring.spliceWaypoints({ index: 1, nRemoved: 1, added: [] });
+
+    expect(wiring.refresh()).toBe(false);
+    expect(picker.shown).toHaveLength(1);
+  });
+
+  // The reported bug behind this slice. An entrance=exit can be left through
+  // but not entered, so it is right to offer nothing while the place is the
+  // destination — and wrong to keep offering nothing once it becomes the start.
+  // LRM's reverse button replaces the whole list, so this arrives as a splice
+  // of everything, with the same waypoint objects in a new order.
+  test('reversing the route re-offers the doors the new roles allow', () => {
+    const plan = makePlan(2);
+    const [first, second] = plan._waypoints;
+    const { wiring, picker } = build({ plan });
+
+    wiring.onGeocodeResult(geocodeEvent([EXIT], { waypointIndex: 1, waypoint: second }));
+    expect(picker.isOpenFor(1)).toBe(false);
+
+    plan._waypoints.reverse();
+    wiring.spliceWaypoints({ index: 0, nRemoved: 2, added: [second, first] });
+
+    expect(picker.isOpenFor(0)).toBe(true);
+    const offer = picker.shown[picker.shown.length - 1];
+    expect(offer.waypointIndex).toBe(0);
+    expect(offer.entrances).toEqual([EXIT]);
+    // Redrawn where it is: a reorder is not a request to be taken to the doors.
+    expect(offer.frame).toBe(false);
+  });
+
+  test('a splice that leaves the roles alone re-offers nothing', () => {
+    const plan = makePlan(3);
+    const { wiring, picker } = build({ plan });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 1, waypoint: plan._waypoints[1] }));
+    const shownBefore = picker.shown.length;
+
+    // A via stays a via when another waypoint is added after it.
+    plan._waypoints.splice(2, 0, { latLng: null, name: '' });
+    wiring.spliceWaypoints({ index: 2, nRemoved: 0, added: [plan._waypoints[2]] });
+
+    expect(picker.shown).toHaveLength(shownBefore);
+  });
+
+  test('a waypoint that becomes a via loses the one-way doors', () => {
+    const plan = makePlan(2);
+    const { wiring, picker } = build({ plan });
+    // The destination, where a one-way in is exactly right.
+    wiring.onGeocodeResult(geocodeEvent([IN_ONLY], { waypointIndex: 1, waypoint: plan._waypoints[1] }));
+    expect(picker.isOpenFor(1)).toBe(true);
+
+    // A waypoint appended after it makes it a via, which needs both directions.
+    plan._waypoints.push({ latLng: null, name: '' });
+    wiring.spliceWaypoints({ index: 2, nRemoved: 0, added: [plan._waypoints[2]] });
+
+    expect(picker.hiddenWaypoints).toContain(1);
+  });
+
+  test('hideWaypoint forgets the place as well as withdrawing the dots', () => {
+    const { wiring, picker } = build();
+    wiring.onGeocodeResult(geocodeEvent([MAIN]));
+    wiring.hideWaypoint(1);
+    expect(picker.hiddenWaypoints).toEqual([1]);
+    expect(wiring.refresh()).toBe(false);
+  });
+
+  test('a refresh re-applies to every place remembered, not just the newest', () => {
+    const plan = makePlan(3);
+    let mode = 'foot';
+    const { wiring, picker } = build({ plan, options: { mode: () => mode } });
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 0, waypoint: plan._waypoints[0] }));
+    wiring.onGeocodeResult(geocodeEvent([MAIN], { waypointIndex: 2, waypoint: plan._waypoints[2] }));
+    const shownBefore = picker.shown.length;
+
+    mode = 'driving';
+    expect(wiring.refresh()).toBe(true);
+    const redrawn = picker.shown.slice(shownBefore);
+    expect(redrawn.map((o) => o.waypointIndex).sort()).toEqual([0, 2]);
+    expect(redrawn.every((o) => o.mode === 'driving' && o.frame === false)).toBe(true);
   });
 });


### PR DESCRIPTION
Fifth of the series splitting #504, on top of #517, #519, #520 and #521.

The picker held a single offer, so every geocode replaced whatever was on the map: naming a start withdrew the destination's doors, and vice versa. Each waypoint now keeps its own — its own doors, its own choice, its own travel mode — and they coexist.

## What changes

Several places can show their doors at once. The view frames the newest offer, which is the one the user just asked for; the others stay where they are. Escape still clears them all.

Withdrawal is per waypoint too. A place with no usable doors withdraws only its own dots — naming a start with nothing offerable must not take the destination's dots away. Dragging a pin withdraws only that waypoint's, since it is being moved off the place they belong to.

## Splices

Offers are keyed by waypoint index, so inserting or removing a waypoint renumbers them rather than dropping them. Dropping them all is what the single offer effectively did: placing a destination by clicking the map took the start's doors off the screen with it.

A splice can also change what a waypoint *is* — reversing start and destination, or appending one so a destination becomes a via. Which doors are on offer follows directly from that role: an `entrance=exit` can be left through but not entered. So every waypoint whose role changed is re-filtered against the result already remembered for it, redrawn in place. Reversing a route used to leave a door that is only valid at the new end unoffered until the address was typed again.

Telling a real removal from a waypoint that merely moved needs object identity. LRM's reverse button replaces the whole list — `spliceWaypoints(0, length, ...the same waypoint objects, reordered)` — so "removed" and "added" overlap, and only identity separates the two cases. LRM passes a waypoint through untouched when it already has a `latLng`, so the objects survive the round trip.

## Tests

Picker: two offers coexisting, the newest framed, per-offer selection, re-showing one in place, withdrawing one and then the last, a stale click after an offer was replaced, and seven splice cases (insert before, before the splice, removal, the framed offer moving, the framed offer removed, everything removed, a no-op splice). Wiring: a remembered result moving with its waypoint, a removed waypoint taking its place with it, reversing re-offering by role, a splice that changes no roles re-offering nothing, a destination that becomes a via losing its one-way doors, `hideWaypoint` forgetting the place, and a refresh applying to every place remembered rather than the newest.

515 tests, 35 suites, lint clean. Verified against live Nominatim: Alexa Berlin as the start and the Pergamonmuseum as the destination show 7 dots and two labels at once, the view frames the newest, and adding a third waypoint leaves both offers intact.

## Follows

The site outline, and the bbox-versus-doors framing decision. The reverse-geocode notifier — which lets a waypoint restored from a URL, dropped by a map click or dragged reach the picker at all — is worth its own change and is not here.

🤖 Claude Code, Claude Opus 5
