### PR TITLE
feat: frame the site a door belongs to, not just the doors

### DIFF
--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -29,6 +29,16 @@ var ENTRANCE_USE = {
 
 var MAX_PICKER_ZOOM = 18;
 
+// The area has to fill at least this share of the free viewport to count as
+// framed. Below it the site reads as a blob somewhere on the map rather than as
+// the place the user is choosing a door into.
+var MIN_EXTENT_FILL = 0.35;
+
+// Two entrance dots closer together than this on screen cannot be aimed at
+// separately. The dots are 18 px across, so this leaves a clear gap between
+// them.
+var MIN_DOT_SEPARATION_PX = 32;
+
 // Breathing room between the framed doors and the edges of the viewport.
 var FIT_PADDING = 24;
 
@@ -298,6 +308,48 @@ function choicePoints(choices, placeCenter) {
   });
   if (placeCenter) points.push(placeCenter);
   return points;
+}
+
+// Zooming is worth the disruption unless the area already sits clear of the
+// pane and fills enough of the free viewport to be legible. Both are measured
+// in container pixels.
+function shouldZoomToExtent(extent, viewport, clear) {
+  if (!clear) return true;
+  if (!viewport || viewport.width <= 0 || viewport.height <= 0) return true;
+  var fill = Math.max(extent.width / viewport.width, extent.height / viewport.height);
+  return fill < MIN_EXTENT_FILL;
+}
+
+// Whether an extent, already projected to container pixels, sits inside the
+// part of the map the directions pane does not cover. Anything under the pane
+// is as good as off screen.
+function isExtentClear(sw, ne, mapSize, paneWidth) {
+  var usableWidth = mapSize.x - (paneWidth || 0);
+  return Math.min(sw.x, ne.x) >= 0 && Math.max(sw.x, ne.x) <= usableWidth &&
+    Math.min(sw.y, ne.y) >= 0 && Math.max(sw.y, ne.y) <= mapSize.y;
+}
+
+// The door positions: every choice is a door.
+function entranceCenters(choices) {
+  return choices.map(function(choice) {
+    return choice.center;
+  });
+}
+
+// Smallest gap between any two of the projected dots, in pixels. This is what
+// decides whether a framing leaves the entrances separately clickable.
+function minPairSeparation(points) {
+  if (!points || points.length < 2) return Infinity;
+  var min = Infinity;
+  for (var i = 0; i < points.length - 1; i++) {
+    for (var j = i + 1; j < points.length; j++) {
+      var dx = points[i].x - points[j].x;
+      var dy = points[i].y - points[j].y;
+      var d = Math.sqrt(dx * dx + dy * dy);
+      if (d < min) min = d;
+    }
+  }
+  return min;
 }
 
 /**
@@ -617,17 +669,63 @@ function createEntrancePicker(map, options) {
   // Framed into the part of the map the directions pane does not cover, rather
   // than merely centred, so the pane never sits over the thing being picked
   // from.
+  // What to frame. The place's own bounding box is preferred — it shows the
+  // site the doors belong to — but only while that framing leaves the doors far
+  // enough apart to aim at. BER's five entrances sit ~36 m apart on a 5 km site,
+  // which is about 3 px at the zoom its bbox implies, so there the entrances win
+  // and the site simply runs off the edges.
+  function framingBounds(padRight, offer) {
+    var area = offer.placeBounds;
+    var doors = entranceCenters(offer.choices);
+
+    if (!area || !area.isValid()) {
+      // The pin stays on the centre, so it belongs in the frame alongside the
+      // doors unless the doors alone already span enough to aim at.
+      var points = doors.length > 1 ? doors : choicePoints(offer.choices, offer.placeCenter);
+      return points.length > 1 ? L.latLngBounds(points) : null;
+    }
+    if (doors.length < 2) return area;
+
+    // The zoom fitting the area would settle on, and the dots as they would
+    // land at it.
+    var areaZoom = map.getBoundsZoom(area, false,
+      L.point(padRight + 2 * FIT_PADDING, 2 * FIT_PADDING));
+    var projected = doors.map(function(latLng) {
+      return map.project(latLng, areaZoom);
+    });
+    if (minPairSeparation(projected) >= MIN_DOT_SEPARATION_PX) return area;
+    return L.latLngBounds(doors);
+  }
+
+  // Frames whatever framingBounds picked into the part of the map the
+  // directions pane does not cover, rather than merely centring it, so the pane
+  // never sits over the thing being picked from.
   function focusView() {
     // The newest offer is framed: it is the one the user just asked for. The
     // others stay on the map, they simply do not pull the view around.
     var offer = activeOffer();
     if (!offer) return false;
-    var points = choicePoints(offer.choices, offer.placeCenter);
-    if (points.length < 2) return false;
-    map.fitBounds(L.latLngBounds(points), {
+    var padRight = paneWidth();
+    var bounds = framingBounds(padRight, offer);
+    if (!bounds || !bounds.isValid()) return false;
+
+    var sw = map.latLngToContainerPoint(bounds.getSouthWest());
+    var ne = map.latLngToContainerPoint(bounds.getNorthEast());
+    var mapSize = map.getSize();
+    var extent = {width: Math.abs(ne.x - sw.x), height: Math.abs(sw.y - ne.y)};
+    var viewport = {
+      width: mapSize.x - padRight - 2 * FIT_PADDING,
+      height: mapSize.y - 2 * FIT_PADDING
+    };
+    // Already framed and legible: moving the map would be disruption for its
+    // own sake.
+    var clear = isExtentClear(sw, ne, mapSize, padRight);
+    if (!shouldZoomToExtent(extent, viewport, clear)) return false;
+
+    map.fitBounds(bounds, {
       maxZoom: MAX_PICKER_ZOOM,
       paddingTopLeft: L.point(FIT_PADDING, FIT_PADDING),
-      paddingBottomRight: L.point(paneWidth() + FIT_PADDING, FIT_PADDING)
+      paddingBottomRight: L.point(padRight + FIT_PADDING, FIT_PADDING)
     });
     return true;
   }
@@ -664,6 +762,9 @@ function createEntrancePicker(map, options) {
       waypointIndex: opts.waypointIndex,
       placeName: opts.placeName,
       placeCenter: opts.placeCenter || null,
+      // The site the doors belong to, when the geocoder gave one. Framed in
+      // preference to the doors alone, while it leaves them far enough apart.
+      placeBounds: opts.placeBounds || null,
       choices: choices,
       // Which mark a door earns depends on it, and refresh() re-shows the
       // picker with a new one whenever the travel mode changes.
@@ -799,6 +900,12 @@ function createEntrancePicker(map, options) {
 
 module.exports = {
   routableEntrances: routableEntrances,
+  shouldZoomToExtent: shouldZoomToExtent,
+  isExtentClear: isExtentClear,
+  entranceCenters: entranceCenters,
+  minPairSeparation: minPairSeparation,
+  MIN_EXTENT_FILL: MIN_EXTENT_FILL,
+  MIN_DOT_SEPARATION_PX: MIN_DOT_SEPARATION_PX,
   allowsMode: allowsMode,
   entranceMark: entranceMark,
   boxesOverlap: boxesOverlap,

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -177,6 +177,7 @@ function createEntranceWaypoints(options) {
       waypointIndex: e.waypointIndex,
       placeName: result.name,
       placeCenter: result.center,
+      placeBounds: result.bbox,
       entrances: entrances,
       // The picker marks doors differently per mode, so it gets the same value
       // the filtering above used.

--- a/test/entrance_picker.test.js
+++ b/test/entrance_picker.test.js
@@ -325,3 +325,72 @@ describe('marks', () => {
       .toEqual([plain, marked]);
   });
 });
+
+describe('when a framing is worth the disruption', () => {
+  const viewport = { width: 1000, height: 800 };
+
+  test('anything not already in the clear is framed', () => {
+    expect(picker.shouldZoomToExtent({ width: 900, height: 700 }, viewport, false)).toBe(true);
+  });
+
+  test('a place already filling enough of the view is left alone', () => {
+    expect(picker.shouldZoomToExtent({ width: 900, height: 100 }, viewport, true)).toBe(false);
+  });
+
+  test('a place clear but too small to read is framed', () => {
+    expect(picker.shouldZoomToExtent({ width: 10, height: 10 }, viewport, true)).toBe(true);
+  });
+
+  test('either dimension filling the view is enough', () => {
+    const tall = { width: 10, height: viewport.height * (picker.MIN_EXTENT_FILL + 0.05) };
+    expect(picker.shouldZoomToExtent(tall, viewport, true)).toBe(false);
+  });
+
+  test('a viewport with no room at all is framed rather than divided by zero', () => {
+    expect(picker.shouldZoomToExtent({ width: 10, height: 10 }, { width: 0, height: 0 }, true))
+      .toBe(true);
+    expect(picker.shouldZoomToExtent({ width: 10, height: 10 }, null, true)).toBe(true);
+  });
+});
+
+describe('isExtentClear', () => {
+  const size = { x: 1000, y: 800 };
+
+  test('an extent inside the uncovered part of the map is clear', () => {
+    expect(picker.isExtentClear({ x: 50, y: 50 }, { x: 500, y: 400 }, size, 200)).toBe(true);
+  });
+
+  // Anything under the directions pane is as good as off screen.
+  test('an extent reaching under the pane is not', () => {
+    expect(picker.isExtentClear({ x: 50, y: 50 }, { x: 900, y: 400 }, size, 200)).toBe(false);
+  });
+
+  test('an extent off any edge is not', () => {
+    expect(picker.isExtentClear({ x: -10, y: 50 }, { x: 500, y: 400 }, size, 0)).toBe(false);
+    expect(picker.isExtentClear({ x: 50, y: 50 }, { x: 500, y: 900 }, size, 0)).toBe(false);
+  });
+
+  test('corners in either order read the same', () => {
+    expect(picker.isExtentClear({ x: 500, y: 400 }, { x: 50, y: 50 }, size, 200)).toBe(true);
+  });
+});
+
+describe('minPairSeparation', () => {
+  test('finds the closest pair, not the first', () => {
+    expect(picker.minPairSeparation([{ x: 0, y: 0 }, { x: 100, y: 0 }, { x: 103, y: 4 }]))
+      .toBe(5);
+  });
+
+  test('fewer than two points can never be too close', () => {
+    expect(picker.minPairSeparation([{ x: 0, y: 0 }])).toBe(Infinity);
+    expect(picker.minPairSeparation([])).toBe(Infinity);
+    expect(picker.minPairSeparation(null)).toBe(Infinity);
+  });
+});
+
+describe('entranceCenters', () => {
+  test('is the doors alone, without the place centre', () => {
+    const choices = picker.buildChoices(at(52.5, 13.4), [door('main'), door('yes', { osmId: 2 })]);
+    expect(picker.entranceCenters(choices)).toHaveLength(2);
+  });
+});

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -24,7 +24,15 @@ function mockMakeLayerGroup(children) {
 }
 
 function mockMakeBounds(points) {
-  return { _kind: 'bounds', _points: points, isValid: () => points.length > 0 };
+  const lats = points.map((p) => p.lat);
+  const lngs = points.map((p) => p.lng);
+  return {
+    _kind: 'bounds',
+    _points: points,
+    isValid: () => points.length > 0,
+    getSouthWest: () => ({ lat: Math.min(...lats), lng: Math.min(...lngs) }),
+    getNorthEast: () => ({ lat: Math.max(...lats), lng: Math.max(...lngs) })
+  };
 }
 
 jest.mock('leaflet', () => ({
@@ -63,11 +71,30 @@ jest.mock('leaflet', () => ({
 
 const entrancePicker = require('../src/entrance_picker');
 
-function makeMap() {
+const makeBounds = mockMakeBounds;
+
+// The projection is a plain scaling of lat/lng, which is all the framing
+// arithmetic needs: what matters is relative distances, not the real Mercator.
+function makeMap(overrides) {
+  const o = Object.assign({
+    size: { x: 1200, y: 800 },
+    pixelsPerDegree: 10000,
+    center: { lat: 52.5209336, lng: 13.3956302 }
+  }, overrides);
   return {
     _layers: [],
     _handlers: {},
     _panes: {},
+    getSize: () => o.size,
+    latLngToContainerPoint: (ll) => ({
+      x: o.size.x / 2 + (ll.lng - o.center.lng) * o.pixelsPerDegree,
+      y: o.size.y / 2 - (ll.lat - o.center.lat) * o.pixelsPerDegree
+    }),
+    project: (ll, zoom) => ({
+      x: ll.lng * o.pixelsPerDegree * (zoom || 1),
+      y: -ll.lat * o.pixelsPerDegree * (zoom || 1)
+    }),
+    getBoundsZoom: jest.fn(() => (o.boundsZoom !== undefined ? o.boundsZoom : 1)),
     getPane(name) { return this._panes[name]; },
     createPane(name) { this._panes[name] = { style: {} }; return this._panes[name]; },
     fitBounds: jest.fn(),
@@ -85,8 +112,8 @@ const CENTRE = { lat: 52.5209336, lng: 13.3956302 };
 const MAIN = { osmId: 1, type: 'main', center: { lat: 52.5209566, lng: 13.3965227 } };
 const SIDE = { osmId: 2, type: 'yes', center: { lat: 52.5207240, lng: 13.3974377 } };
 
-function openPicker(showOpts, options) {
-  const map = makeMap();
+function openPicker(showOpts, options, mapOverrides) {
+  const map = makeMap(mapOverrides);
   const onSelect = jest.fn();
   const picker = entrancePicker.createEntrancePicker(
     map, Object.assign({ onSelect }, options));
@@ -191,12 +218,20 @@ describe('show', () => {
 
   // The doors are metres apart on a site the map is showing from kilometres
   // away; without this the offer is a cluster nobody can aim at.
-  test('brings the doors into view, and the pin with them', () => {
+  test('brings the doors into view', () => {
     const { map } = openPicker();
     settle();
     expect(map.fitBounds).toHaveBeenCalledTimes(1);
     expect(map.fitBounds.mock.calls[0][0]._points)
-      .toEqual([MAIN.center, SIDE.center, CENTRE]);
+      .toEqual([MAIN.center, SIDE.center]);
+  });
+
+  // One door spans nothing, so the pin has to be in the frame or there is
+  // nothing to frame against.
+  test('a lone door is framed together with the pin', () => {
+    const { map } = openPicker({ entrances: [MAIN] });
+    settle();
+    expect(map.fitBounds.mock.calls[0][0]._points).toEqual([MAIN.center, CENTRE]);
   });
 
   // The route to the place arrives just after the geocode that opened the
@@ -774,5 +809,74 @@ describe('offers follow a splice of the waypoint list', () => {
     picker.spliceOffers(5, 0, 0);
     expect(picker.isOpenFor(0)).toBe(true);
     expect(picker.isOpenFor(1)).toBe(true);
+  });
+});
+
+describe('choosing what to frame', () => {
+  // A bbox big enough that the doors stay far apart inside it.
+  const ROOMY = makeBounds([{ lat: 52.5205, lng: 13.3960 }, { lat: 52.5212, lng: 13.3980 }]);
+  // The BER case: a 5 km site whose five doors sit metres apart.
+  const HUGE = makeBounds([{ lat: 52.30, lng: 13.45 }, { lat: 52.40, lng: 13.55 }]);
+
+  test('the place bbox is framed when it leaves the doors far enough apart', () => {
+    // At this zoom the two doors project ~45 px apart: aimable, so the site
+    // itself is what gets framed.
+    const { map } = openPicker({ placeBounds: ROOMY }, null, { boundsZoom: 5 });
+    settle();
+    expect(map.fitBounds.mock.calls[0][0]).toBe(ROOMY);
+  });
+
+  // Framing a 5 km airport puts its doors about 3 px apart: a cluster nobody
+  // can aim at. The doors win and the site runs off the edges.
+  test('the doors are framed instead when the bbox would bunch them up', () => {
+    const { map } = openPicker({ placeBounds: HUGE }, null, { boundsZoom: 0.0001 });
+    settle();
+    const framed = map.fitBounds.mock.calls[0][0];
+    expect(framed).not.toBe(HUGE);
+    expect(framed._points).toEqual([MAIN.center, SIDE.center]);
+  });
+
+  test('a single door leaves nothing to bunch up, so the bbox is kept', () => {
+    const { map } = openPicker({ placeBounds: HUGE, entrances: [MAIN] }, null,
+      { boundsZoom: 0.0001 });
+    settle();
+    expect(map.fitBounds.mock.calls[0][0]).toBe(HUGE);
+  });
+
+  test('a bbox the geocoder did not give falls back to the doors', () => {
+    const { map } = openPicker({ placeBounds: makeBounds([]) });
+    settle();
+    expect(map.fitBounds.mock.calls[0][0]._points).toEqual([MAIN.center, SIDE.center]);
+  });
+
+  // Already framed and legible: moving the map would be disruption for its own
+  // sake.
+  // Centred between the two doors, so what is left to decide is size alone.
+  const BETWEEN_DOORS = { lat: 52.5208403, lng: 13.3969802 };
+
+  test('a place already filling the view is left alone', () => {
+    // The doors span ~576 px here, half the free viewport, and sit clear of
+    // both the edges and the pane: moving the map would be disruption for its
+    // own sake.
+    const { map } = openPicker(null, null,
+      { center: BETWEEN_DOORS, pixelsPerDegree: 630000 });
+    settle();
+    expect(map.fitBounds).not.toHaveBeenCalled();
+  });
+
+  test('a place too small to read is framed even when it is in the clear', () => {
+    // The same doors, now ~9 px apart.
+    const { map } = openPicker(null, null,
+      { center: BETWEEN_DOORS, pixelsPerDegree: 10000 });
+    settle();
+    expect(map.fitBounds).toHaveBeenCalled();
+  });
+
+  test('a place hidden behind the directions pane is always re-framed', () => {
+    // Big enough to be legible, but the pane covers where it sits.
+    const { map } = openPicker(null, { paneWidth: () => 1100 },
+      { center: BETWEEN_DOORS, pixelsPerDegree: 630000 });
+    settle();
+    expect(map.fitBounds).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Sixth of the series splitting #504, on top of #517, #519, #520, #521 and #522.

Opening an offer framed the doors alone. For a small building that zooms past the place itself: you see two dots and nothing of what you are choosing a way into. The place's own bounding box is framed instead, where the geocoder gave one.

## Except when the doors would bunch up

BER decides this one. Five entrances about 36 m apart on a 5 km site: at the zoom its bounding box implies they land some 3 px from each other, which is a cluster nobody can aim at. So the choice is made by measuring, not by guessing at a size threshold — the smallest gap between any two dots, projected at the zoom `getBoundsZoom` says the area would settle on, against the 32 px that leaves clear air between two 18 px dots. Below that the doors win and the site runs off the edges.

A place with a single door has nothing to bunch up, so its bbox is always kept. A place with no bbox falls back to the doors, and to the doors plus the pin when there is only one — one door spans nothing to frame against.

## And when the view is already fine

If the area sits clear of the directions pane and already fills at least a third of the free viewport, nothing moves: re-framing a place you can already see is disruption for its own sake. Anything under the pane counts as off screen, so that is always re-framed.

## Tests

Pure: `shouldZoomToExtent` (not clear, clear and large, clear and small, either dimension counting, a zero viewport), `isExtentClear` (inside, reaching under the pane, off each edge, corners in either order), `minPairSeparation` (the closest pair rather than the first, fewer than two points) and `entranceCenters`. Live, against a fake map with a real projection: the bbox framed when it leaves the doors apart, the doors framed when it would not, a single door keeping the bbox, no bbox falling back, a place already filling the view left alone, one too small re-framed, and one behind the pane re-framed.

537 tests, 35 suites, lint clean.

One caveat on verification: I could not drive the geocoder input in the browser this session — a synthetic click lands on the input but focus stays on `body` — so this slice was not spot-checked live the way the earlier ones were. The framing path itself is the one observed working in #519 and #522; what is new here is which bounds it is handed.

## Follows

The site outline, and the reverse-geocode notifier that lets URL-restored, map-clicked and dragged waypoints reach the picker at all.

🤖 Claude Code, Claude Opus 5
