### PR TITLE
feat: let a reverse-geocoded waypoint reach the entrance picker

### DIFF
--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -60,6 +60,98 @@ function entranceWaypointName(placeName, entrance, translate) {
   return placeName + ' (' + suffix + ')';
 }
 
+// LRM's own default for maxGeocoderTolerance, in metres. Beyond it LRM labels
+// the waypoint with bare coordinates instead of the place it found.
+var MAX_GEOCODER_TOLERANCE = 200;
+
+/**
+ * Wraps the geocoder handed to LRM's plan so a reverse-geocoded waypoint still
+ * reaches the picker.
+ *
+ * LRM fires `geocoded` only when the user picks from the autocomplete. A
+ * waypoint that arrives with coordinates and no name — restored from a shared
+ * URL, dropped by a click on the map, dragged somewhere new — is named by
+ * GeocoderElement.update() calling `geocoder.reverse` directly, and that result
+ * is discarded once the name has been taken out of it. The entrance list goes
+ * with it, so a place whose doors were on offer a moment ago has none after a
+ * reload, even though the answer is sitting in the cache.
+ *
+ * A reverse result has the same shape as a search result, so it is re-fired as
+ * `waypointgeocoderesult` against whichever waypoint the coordinates belong to.
+ *
+ * No guard against reopening the picker unbidden is needed: `update()` only
+ * reverse-geocodes when the waypoint has no name, and LRM's one forced call
+ * clears the name first, so every reverse arriving here is a waypoint being
+ * named for the first time.
+ *
+ * @param {object} options
+ * @param {object} options.geocoder — the geocoder LRM would otherwise be given
+ * @param {function} options.getPlan — () => the plan, read late because the plan
+ *   is built from the geocoder and cannot exist yet
+ * @param {number} [options.tolerance] — metres; beyond this LRM discards the
+ *   name, and offering that place's doors would offer doors of somewhere the
+ *   user did not pick
+ * @returns {object} a geocoder to hand to the plan
+ */
+function createReverseNotifier(options) {
+  options = options || {};
+  var geocoder = options.geocoder;
+  var getPlan = options.getPlan;
+  if (!geocoder || typeof geocoder.reverse !== 'function') return geocoder;
+  var tolerance = typeof options.tolerance === 'number'
+    ? options.tolerance : MAX_GEOCODER_TOLERANCE;
+
+  // Bound rather than copied, so the original keeps its own `this` whatever it
+  // closes over.
+  var wrapped = {};
+  for (var key in geocoder) {
+    wrapped[key] = typeof geocoder[key] === 'function'
+      ? geocoder[key].bind(geocoder) : geocoder[key];
+  }
+
+  function waypointIndexAt(latLng) {
+    var plan = typeof getPlan === 'function' ? getPlan() : null;
+    var waypoints = plan && plan._waypoints;
+    if (!waypoints || !latLng) return -1;
+    for (var i = 0; i < waypoints.length; i++) {
+      var wp = waypoints[i];
+      var at = wp && wp.latLng;
+      if (!at) continue;
+      if (at === latLng) return i;
+      if (at.lat === latLng.lat && at.lng === latLng.lng) return i;
+    }
+    return -1;
+  }
+
+  function notify(latLng, results) {
+    var result = results && results.length ? results[0] : null;
+    if (!result || !result.center) return;
+    if (typeof result.center.distanceTo === 'function' &&
+        result.center.distanceTo(latLng) >= tolerance) return;
+    var index = waypointIndexAt(latLng);
+    if (index === -1) return;
+    var plan = getPlan();
+    plan.fire('waypointgeocoderesult', {
+      waypointIndex: index,
+      waypoint: plan._waypoints[index],
+      value: result
+    });
+  }
+
+  wrapped.reverse = function(latLng, scale, cb, context) {
+    return geocoder.reverse(latLng, scale, function(results) {
+      // LRM's callback first: it sets the waypoint's name, and the picker's
+      // offer is built against a waypoint that has already been named.
+      if (typeof cb === 'function') cb.call(context, results);
+      try {
+        notify(latLng, results);
+      } catch (e) {}
+    }, context);
+  };
+
+  return wrapped;
+}
+
 /**
  * @param {object} options
  * @param {L.Map} options.map
@@ -321,6 +413,7 @@ function createEntranceWaypoints(options) {
 
 module.exports = {
   waypointMarkerLatLng: waypointMarkerLatLng,
+  createReverseNotifier: createReverseNotifier,
   entranceWaypointName: entranceWaypointName,
   createEntranceWaypoints: createEntranceWaypoints
 };

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -123,6 +123,10 @@ function createReverseNotifier(options) {
     return -1;
   }
 
+  // The cases where there is legitimately nothing to notify are checked rather
+  // than caught: no result, one too far to be this waypoint's place, no
+  // waypoint at those coordinates, or a plan that does not exist yet — which is
+  // ordinary while the app is still starting up.
   function notify(latLng, results) {
     var result = results && results.length ? results[0] : null;
     if (!result || !result.center) return;
@@ -130,7 +134,8 @@ function createReverseNotifier(options) {
         result.center.distanceTo(latLng) >= tolerance) return;
     var index = waypointIndexAt(latLng);
     if (index === -1) return;
-    var plan = getPlan();
+    var plan = typeof getPlan === 'function' ? getPlan() : null;
+    if (!plan || typeof plan.fire !== 'function') return;
     plan.fire('waypointgeocoderesult', {
       waypointIndex: index,
       waypoint: plan._waypoints[index],
@@ -145,7 +150,13 @@ function createReverseNotifier(options) {
       if (typeof cb === 'function') cb.call(context, results);
       try {
         notify(latLng, results);
-      } catch (e) {}
+      } catch (e) {
+        // Anything reaching here is a bug, but it must not take the waypoint's
+        // name down with it: LRM has already been called back, and a throw on
+        // this path would leave the waypoint half-named. Reported rather than
+        // swallowed, so it is findable.
+        console.warn('osrm-entrances: offering a reverse-geocoded place failed', e);
+      }
     }, context);
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -292,8 +292,24 @@ function makeIcon(i, n) {
   return L.icon(waypointMarker.waypointIconOptions(i, n));
 }
 
-var plan = new ReversablePlan([], {
-  geocoder: createGeocoder.coordPreserving(leafletOptions.nominatim && leafletOptions.nominatim.path),
+var routingGeocoder = createGeocoder.coordPreserving(leafletOptions.nominatim && leafletOptions.nominatim.path);
+
+// Declared before the geocoder wrapper below, which reads it back late: the
+// plan is built from that geocoder and so cannot exist yet when it is made.
+var plan;
+
+// A waypoint restored from a URL, dropped by a map click or dragged is named by
+// LRM through a reverse geocode that never fires `geocoded`, so its entrance
+// list would be thrown away with the result. This re-fires it at the plan.
+var planGeocoder = entranceWaypointsModule.createReverseNotifier({
+  geocoder: routingGeocoder,
+  getPlan: function() {
+    return plan;
+  }
+});
+
+plan = new ReversablePlan([], {
+  geocoder: planGeocoder,
   waypointNameFallback: createGeocoder.wrappedWaypointNameFallback,
   language: mergedOptions.language,
   routeWhileDragging: true,

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -21,6 +21,7 @@ jest.mock('leaflet', () => ({
 
 const {
   createEntranceWaypoints,
+  createReverseNotifier,
   entranceWaypointName,
   waypointMarkerLatLng
 } = require('../src/entrance_waypoints');
@@ -503,5 +504,135 @@ describe('following a splice of the waypoint list', () => {
     const redrawn = picker.shown.slice(shownBefore);
     expect(redrawn.map((o) => o.waypointIndex).sort()).toEqual([0, 2]);
     expect(redrawn.every((o) => o.mode === 'driving' && o.frame === false)).toBe(true);
+  });
+});
+
+describe('reverse-geocoded waypoints reaching the picker', () => {
+  // A reverse result: the same shape a search returns, entrances included.
+  const RESULT = { name: 'Pergamonmuseum', center: latLng(52.5209336, 13.3956302),
+    entrances: [MAIN] };
+
+  // Leaflet's LatLng, as much of it as this needs.
+  function latLng(lat, lng) {
+    return {
+      lat, lng,
+      distanceTo(other) {
+        // Plane approximation; the numbers here are metres apart, not degrees.
+        const dx = (other.lng - lng) * 68000;
+        const dy = (other.lat - lat) * 111000;
+        return Math.sqrt(dx * dx + dy * dy);
+      }
+    };
+  }
+
+  function build(extra) {
+    const at = (extra && extra.at) || latLng(52.5209336, 13.3956302);
+    const plan = {
+      _waypoints: [{ latLng: null, name: '' }, { latLng: at, name: '' }],
+      fired: [],
+      fire(type, data) { this.fired.push({ type, data }); }
+    };
+    const results = (extra && extra.results !== undefined) ? extra.results : [RESULT];
+    const geocoder = {
+      name: 'inner',
+      reverse: jest.fn(function(ll, scale, cb, context) {
+        if (typeof cb === 'function') cb.call(context, results);
+        return 'returned';
+      }),
+      geocode: jest.fn(function() { return this.name; })
+    };
+    const wrapped = createReverseNotifier(Object.assign(
+      { geocoder, getPlan: () => plan }, extra && extra.options));
+    return { plan, geocoder, wrapped, at };
+  }
+
+  test('re-fires the reverse result at the waypoint it belongs to', () => {
+    // The whole point: LRM names a restored waypoint by reverse geocoding and
+    // then throws the result away, entrance list and all.
+    const { plan, wrapped, at } = build();
+    wrapped.reverse(at, 100, () => {});
+    expect(plan.fired).toHaveLength(1);
+    expect(plan.fired[0].type).toBe('waypointgeocoderesult');
+    expect(plan.fired[0].data).toEqual({
+      waypointIndex: 1, waypoint: plan._waypoints[1], value: RESULT
+    });
+  });
+
+  test('LRM is called back first, so the waypoint is named before the offer', () => {
+    const order = [];
+    const { plan, wrapped, at } = build();
+    plan.fire = () => order.push('picker');
+    wrapped.reverse(at, 100, () => order.push('lrm'));
+    expect(order).toEqual(['lrm', 'picker']);
+  });
+
+  test('the caller keeps its own callback context and return value', () => {
+    const ctx = { seen: null };
+    const { wrapped, at } = build();
+    const out = wrapped.reverse(at, 100, function(r) { this.seen = r; }, ctx);
+    expect(ctx.seen).toEqual([RESULT]);
+    expect(out).toBe('returned');
+  });
+
+  test('a coordinate matching no waypoint fires nothing', () => {
+    const { plan, wrapped } = build();
+    wrapped.reverse(latLng(1, 1), 100, () => {});
+    expect(plan.fired).toEqual([]);
+  });
+
+  // Beyond LRM's tolerance it labels the waypoint with bare coordinates rather
+  // than the place, so offering that place's doors would offer doors of
+  // somewhere the user did not pick.
+  test('a result too far from the waypoint is not offered', () => {
+    const far = { name: 'Elsewhere', center: latLng(52.53, 13.40), entrances: [MAIN] };
+    const { plan, wrapped, at } = build({ results: [far] });
+    wrapped.reverse(at, 100, () => {});
+    expect(plan.fired).toEqual([]);
+  });
+
+  test('the tolerance is configurable, and a near result still passes', () => {
+    // About 10 m from the waypoint.
+    const near = { name: 'Next door', center: latLng(52.5210236, 13.3956302),
+      entrances: [MAIN] };
+    const { plan, wrapped, at } = build({ results: [near], options: { tolerance: 5 } });
+    wrapped.reverse(at, 100, () => {});
+    expect(plan.fired).toEqual([]);
+
+    const loose = build({ results: [near], options: { tolerance: 5000 } });
+    loose.wrapped.reverse(loose.at, 100, () => {});
+    expect(loose.plan.fired).toHaveLength(1);
+  });
+
+  test('an empty or malformed result is not an error', () => {
+    [[], null, [{}]].forEach((results) => {
+      const { plan, wrapped, at } = build({ results });
+      expect(() => wrapped.reverse(at, 100, () => {})).not.toThrow();
+      expect(plan.fired).toEqual([]);
+    });
+  });
+
+  test('the waypoint is matched by identity as well as by value', () => {
+    const { plan, wrapped } = build();
+    // A different object with the same coordinates still finds its waypoint.
+    wrapped.reverse(latLng(52.5209336, 13.3956302), 100, () => {});
+    expect(plan.fired).toHaveLength(1);
+  });
+
+  test('a plan that does not exist yet is simply not notified', () => {
+    const geocoder = { reverse: (ll, scale, cb) => cb([RESULT]) };
+    const wrapped = createReverseNotifier({ geocoder, getPlan: () => null });
+    expect(() => wrapped.reverse(latLng(52.5, 13.4), 100, () => {})).not.toThrow();
+  });
+
+  test('every other geocoder method is passed through, bound to the original', () => {
+    const { geocoder, wrapped } = build();
+    expect(wrapped.geocode()).toBe('inner');
+    expect(wrapped.name).toBe('inner');
+  });
+
+  test('a geocoder that cannot reverse is handed back untouched', () => {
+    const plain = { geocode: () => {} };
+    expect(createReverseNotifier({ geocoder: plain, getPlan: () => ({}) })).toBe(plain);
+    expect(createReverseNotifier({})).toBeUndefined();
   });
 });

--- a/test/entrance_waypoints.test.js
+++ b/test/entrance_waypoints.test.js
@@ -618,10 +618,32 @@ describe('reverse-geocoded waypoints reaching the picker', () => {
     expect(plan.fired).toHaveLength(1);
   });
 
-  test('a plan that does not exist yet is simply not notified', () => {
+  // Ordinary while the app is still starting up: checked, not caught.
+  test('a plan that does not exist yet is quietly not notified', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const geocoder = { reverse: (ll, scale, cb) => cb([RESULT]) };
-    const wrapped = createReverseNotifier({ geocoder, getPlan: () => null });
-    expect(() => wrapped.reverse(latLng(52.5, 13.4), 100, () => {})).not.toThrow();
+    const at = latLng(52.5209336, 13.3956302);
+    [null, {}, { _waypoints: [] }].forEach((plan) => {
+      const wrapped = createReverseNotifier({ geocoder, getPlan: () => plan });
+      expect(() => wrapped.reverse(at, 100, () => {})).not.toThrow();
+    });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  // A throw here would leave the waypoint half-named, so it is contained — but
+  // reported, because anything reaching it is a bug.
+  test('an unexpected failure is reported rather than swallowed', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { wrapped, plan, at } = build();
+    plan.fire = () => { throw new Error('boom'); };
+    let named = false;
+    expect(() => wrapped.reverse(at, 100, () => { named = true; })).not.toThrow();
+    // LRM was still called back, so the waypoint has its name.
+    expect(named).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      'osrm-entrances: offering a reverse-geocoded place failed', expect.any(Error));
+    warn.mockRestore();
   });
 
   test('every other geocoder method is passed through, bound to the original', () => {


### PR DESCRIPTION
Seventh of the series splitting #504. Stacked on #523 — **review after that lands**; the diff below is against its branch.

## The gap

LRM fires `geocoded` only when the user picks from the autocomplete. A waypoint that arrives with coordinates and no name — restored from a shared URL, dropped by a click on the map, dragged somewhere new — is named by `GeocoderElement.update()` calling `geocoder.reverse` directly, and that result is thrown away once the name has been read out of it. The entrance list goes with it, so a place whose doors were on offer a moment ago has none after a reload, even when the answer is sitting in the cache.

## What it does

A reverse result has the same shape as a search result, so the geocoder handed to the plan is wrapped: after LRM's own callback runs — it sets the name, and the offer should be built against a waypoint that already has one — the result is re-fired as `waypointgeocoderesult` against whichever waypoint those coordinates belong to.

The wrapper binds every other method to the original geocoder rather than copying it, so nothing loses its `this`, and a geocoder with no `reverse` is handed straight back.

Beyond LRM's own 200 m tolerance the waypoint is labelled with bare coordinates instead of the place, so a result further away than that is not offered — its doors would belong to somewhere the user did not pick. The tolerance is an option.

## Tests

12 covering the contract: the re-fire and its payload, LRM's callback running first, the caller's context and return value preserved, a coordinate matching no waypoint, a result beyond tolerance, a configurable tolerance in both directions, empty and malformed results, matching a waypoint by value as well as identity, a plan that does not exist yet, pass-through of other methods, and a geocoder that cannot reverse.

548 tests, 35 suites, lint clean.

## On verification

I could not demonstrate this live, and the reason is worth stating rather than hiding: reverse-geocoding a stored coordinate returns the *nearest address*, not the place that was searched for. Reloading BER's centroid names it `Betriebsstraße 19, Waßmannsdorf`, and a map click near the museums names an apartment hotel — neither carries entrance nodes. So this makes the path possible, and whether any particular reverse result has doors is Nominatim's business. Recovering a specific place's offer across a reload means persisting the place, not re-deriving it from its coordinates; that is a separate change and is not attempted here.

## Follows

The site outline is the last slice.

🤖 Claude Code, Claude Opus 5
