### PR TITLE
feat: draw the site an entrance belongs to behind its doors

### DIFF
--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -45,6 +45,14 @@ var FIT_PADDING = 24;
 // Long enough to outlast Leaflet's default 250 ms pan/zoom animation.
 var SETTLE_TIMEOUT_MS = 450;
 
+// The outline sits in its own pane between Leaflet's tiles (200) and its
+// overlay pane (400), where the route line is drawn. Sharing the overlay pane
+// would leave the two ordered by whichever was added last, and the outline
+// arrives when its request resolves — usually after the route — so it would
+// land on top of the very thing it must not obscure.
+var OUTLINE_PANE = 'osrmEntranceOutline';
+var OUTLINE_PANE_Z_INDEX = 350;
+
 // The site the entrances belong to. Muted and non-interactive: it is context
 // for the dots, not a thing to click, and it must never obscure the route line.
 var OUTLINE_STYLE = {
@@ -486,7 +494,10 @@ function createEntrancePicker(map, options) {
       // Redrawn from the geometry each time rather than left in place, so one
       // waypoint's outline can be removed without disturbing another's.
       if (offer.outline) {
-        outlineLayer.addLayer(L.geoJSON(offer.outline, {style: OUTLINE_STYLE}));
+        var outlineOptions = {style: OUTLINE_STYLE};
+        var outlinePane = ensurePane(OUTLINE_PANE, OUTLINE_PANE_Z_INDEX);
+        if (outlinePane) outlineOptions.pane = outlinePane;
+        outlineLayer.addLayer(L.geoJSON(offer.outline, outlineOptions));
       }
       offer.choices.forEach(function(choice) {
         var chosen = choice.id === offer.selectedId;
@@ -536,15 +547,15 @@ function createEntrancePicker(map, options) {
 
   // Created lazily, because the picker may be built before the map has panes.
   // Answers with the pane's name only once there really is a pane: naming one
-  // that does not exist would leave the label unplaced.
-  function ensureLabelPane() {
+  // that does not exist would leave the layer unplaced.
+  function ensurePane(name, zIndex) {
     if (typeof map.createPane !== 'function' || typeof map.getPane !== 'function') return null;
-    var pane = map.getPane(LABEL_PANE);
+    var pane = map.getPane(name);
     if (!pane) {
-      pane = map.createPane(LABEL_PANE);
-      if (pane && pane.style) pane.style.zIndex = LABEL_PANE_Z_INDEX;
+      pane = map.createPane(name);
+      if (pane && pane.style) pane.style.zIndex = zIndex;
     }
-    return pane ? LABEL_PANE : null;
+    return pane ? name : null;
   }
 
   // Which line of a label a click landed on, from the element under the
@@ -602,7 +613,7 @@ function createEntrancePicker(map, options) {
       keyboard: false,
       zIndexOffset: 100
     };
-    var pane = ensureLabelPane();
+    var pane = ensurePane(LABEL_PANE, LABEL_PANE_Z_INDEX);
     if (pane) options.pane = pane;
     var marker = L.marker(latLng, options);
     marker.on('click', function(e) {

--- a/src/entrance_picker.js
+++ b/src/entrance_picker.js
@@ -45,6 +45,19 @@ var FIT_PADDING = 24;
 // Long enough to outlast Leaflet's default 250 ms pan/zoom animation.
 var SETTLE_TIMEOUT_MS = 450;
 
+// The site the entrances belong to. Muted and non-interactive: it is context
+// for the dots, not a thing to click, and it must never obscure the route line.
+var OUTLINE_STYLE = {
+  color: '#2b7ac9',
+  weight: 2,
+  opacity: 0.7,
+  dashArray: '6 4',
+  fill: true,
+  fillColor: '#2b7ac9',
+  fillOpacity: 0.07,
+  interactive: false
+};
+
 // Labels live in their own pane, kept just below Leaflet's marker pane (600).
 // A zIndexOffset cannot do this job: Leaflet derives a marker's z-index from its
 // latitude, so a label on a northerly door still outranks a dot on a southerly
@@ -371,6 +384,7 @@ function minPairSeparation(points) {
  * @param {object} options
  * @param {function} options.onSelect — called with {waypointIndex, placeName,
  *   latLng, markerLatLng, entrance}
+ * @param {function} [options.fetchOutline] — (place) => Promise<GeoJSON|null>
  * @param {function} [options.paneWidth] — () => width in px of the directions
  *   pane, so the doors are framed into the part of the map it does not cover
  *
@@ -384,6 +398,7 @@ function minPairSeparation(points) {
 function createEntrancePicker(map, options) {
   options = options || {};
   var onSelect = typeof options.onSelect === 'function' ? options.onSelect : function() {};
+  var fetchOutline = typeof options.fetchOutline === 'function' ? options.fetchOutline : null;
   var translate = typeof options.translate === 'function' ? options.translate : function(key) {
     return key;
   };
@@ -392,12 +407,13 @@ function createEntrancePicker(map, options) {
   var paneWidth = typeof options.paneWidth === 'function' ? options.paneWidth : function() {
     return 0;
   };
-  // Three groups, so each can be cleared without disturbing the others. Markers
+  // Four groups, so each can be cleared without disturbing the others. Markers
   // sit in Leaflet's marker pane and paths in the overlay pane, so the dots stay
   // above the dashed link whatever the draw order.
   //
   // The dashed link runs from the chosen door back to the pin, which never
   // moves.
+  var outlineLayer = L.layerGroup();
   var linkLayer = L.layerGroup();
   // Labels are markers of our own rather than Leaflet tooltips, for two
   // reasons. The tooltip pane sits above the marker pane, so a label would be
@@ -407,7 +423,7 @@ function createEntrancePicker(map, options) {
   // pane, whereas clearing a layer group really does remove what is in it.
   var labelLayer = L.layerGroup();
   var markerLayer = L.layerGroup();
-  var layer = L.layerGroup([linkLayer, labelLayer, markerLayer]);
+  var layer = L.layerGroup([outlineLayer, linkLayer, labelLayer, markerLayer]);
   // One offer per waypoint. More than one waypoint can be showing its doors at
   // once: naming a start must not withdraw the destination's, which is what a
   // single shared offer did.
@@ -459,6 +475,7 @@ function createEntrancePicker(map, options) {
   function render() {
     markerLayer.clearLayers();
     linkLayer.clearLayers();
+    outlineLayer.clearLayers();
     renderedDoors = [];
     if (!offers.length) {
       labelLayer.clearLayers();
@@ -466,6 +483,11 @@ function createEntrancePicker(map, options) {
     }
 
     offers.forEach(function(offer) {
+      // Redrawn from the geometry each time rather than left in place, so one
+      // waypoint's outline can be removed without disturbing another's.
+      if (offer.outline) {
+        outlineLayer.addLayer(L.geoJSON(offer.outline, {style: OUTLINE_STYLE}));
+      }
       offer.choices.forEach(function(choice) {
         var chosen = choice.id === offer.selectedId;
         var text = label(choice);
@@ -748,6 +770,22 @@ function createEntrancePicker(map, options) {
     map.on('moveend', run);
   }
 
+  // The outline is best-effort context: a failed or absent one simply means the
+  // picker shows dots without a site boundary.
+  function loadOutline(offer, place) {
+    offer.outline = null;
+    if (!fetchOutline || !place) return;
+    fetchOutline(place).then(function(geometry) {
+      // Guarded by the offer's own identity rather than a shared counter: the
+      // offer may have been withdrawn, or replaced by a later one for the same
+      // waypoint, while the request was in flight — but another waypoint being
+      // shown meanwhile must not cancel this one.
+      if (!geometry || offerAt(offer.waypointIndex) !== offer) return;
+      offer.outline = geometry;
+      render();
+    });
+  }
+
   function show(opts) {
     var choices = buildChoices(opts.placeCenter, opts.entrances);
     // A single door is still worth offering: the pin already marks the place,
@@ -769,7 +807,8 @@ function createEntrancePicker(map, options) {
       // Which mark a door earns depends on it, and refresh() re-shows the
       // picker with a new one whenever the travel mode changes.
       mode: opts.mode || null,
-      selectedId: opts.selectedId || null
+      selectedId: opts.selectedId || null,
+      outline: null
     };
     var existing = offerAt(opts.waypointIndex);
     if (existing) {
@@ -782,6 +821,7 @@ function createEntrancePicker(map, options) {
     activeWaypointIndex = offer.waypointIndex;
     attached = true;
     if (!map.hasLayer(layer)) layer.addTo(map);
+    loadOutline(offer, opts.place);
     render();
     if (opts.frame !== false) focusViewWhenSettled();
     // Which labels fit is a question of zoom, so the layout is redone after
@@ -865,6 +905,7 @@ function createEntrancePicker(map, options) {
     activeWaypointIndex = null;
     renderedDoors = [];
     map.off('zoomend', layoutLabels);
+    outlineLayer.clearLayers();
     linkLayer.clearLayers();
     labelLayer.clearLayers();
     markerLayer.clearLayers();

--- a/src/entrance_waypoints.js
+++ b/src/entrance_waypoints.js
@@ -169,6 +169,7 @@ function createReverseNotifier(options) {
  * @param {L.Routing.Plan} options.plan
  * @param {object} options.routeFitTracker — from route_zoom
  * @param {function} [options.translate] — (key) => localized string
+ * @param {function} [options.fetchOutline] — (place) => Promise<GeoJSON|null>
  * @param {function} [options.paneWidth] — () => width of the directions pane
  * @param {function} [options.mode] — () => the active routing profile, read live
  *   so switching between car, bike and foot re-applies the access rules
@@ -239,6 +240,7 @@ function createEntranceWaypoints(options) {
 
   var picker = createPicker(options.map, {
     translate: translate,
+    fetchOutline: options.fetchOutline,
     paneWidth: options.paneWidth,
     onSelect: applySelection
   });
@@ -282,6 +284,7 @@ function createEntranceWaypoints(options) {
       placeCenter: result.center,
       placeBounds: result.bbox,
       entrances: entrances,
+      place: result,
       // The picker marks doors differently per mode, so it gets the same value
       // the filtering above used.
       mode: activeMode,

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var L = require('leaflet');
+var simplify = require('./simplify');
 
 var geocoder = function(i, num) {
   var container = L.DomUtil.create('div',
@@ -335,6 +336,70 @@ geocoder.coordPreserving = function(nominatimUrl) {
   var supportsFetch = typeof fetch === 'function';
   var serviceBase = (normalizedNominatimUrl && normalizedNominatimUrl.length > 0) ? normalizedNominatimUrl.replace(/\/+$/, '') + '/' : 'https://nominatim.openstreetmap.org/';
 
+  // Place outlines are fetched one at a time, only when something is actually
+  // about to draw one. They deliberately do not ride along on search: `suggest`
+  // runs on every keystroke, and a polygon per result would multiply a payload
+  // that is almost always discarded. Kept in memory only — the persisted result
+  // cache has a fixed shape that geometry has no place in.
+  var outlineCache = {};
+
+  var OSM_TYPE_PREFIX = {node: 'N', way: 'W', relation: 'R'};
+
+  // Backstop against a pathological relation. Ordinary places are governed by
+  // visual negligibility instead and never come near this.
+  var MAX_OUTLINE_POINTS_PER_RING = 2000;
+
+  function buildLookupUrl(osmType, osmId) {
+    var prefix = OSM_TYPE_PREFIX[String(osmType).toLowerCase()];
+    if (!prefix) return null;
+    // The full outline is requested and thinned here instead of via Nominatim's
+    // polygon_threshold, whose tolerance is an absolute number of degrees: a
+    // value large enough to thin a 5 km airport also flattens a 170 m building
+    // into a few stray corners. See simplifyOutline below.
+    return serviceBase + 'lookup?format=json&polygon_geojson=1' +
+      '&osm_ids=' + prefix + encodeURIComponent(osmId);
+  }
+
+  // Thins the outline without changing how it looks: Visvalingam–Whyatt drops
+  // vertices in order of the area they contribute and stops as soon as the
+  // smallest survivor would be visible at the scale the picker draws the place.
+  // A building keeps every corner that reads as a corner; only redundant
+  // vertices go.
+  function simplifyOutline(geometry) {
+    return simplify.simplifyGeometry(geometry, {maxPoints: MAX_OUTLINE_POINTS_PER_RING});
+  }
+
+  // Resolves to the place's GeoJSON outline, or null when it has none (a node),
+  // when the endpoint is an older Nominatim, or when the request fails. Callers
+  // treat a missing outline as "just don't draw one".
+  function fetchOutline(result) {
+    if (!result || result.osmType === undefined || result.osmId === undefined) {
+      return Promise.resolve(null);
+    }
+    var url = buildLookupUrl(result.osmType, result.osmId);
+    if (!url) return Promise.resolve(null);
+    if (Object.prototype.hasOwnProperty.call(outlineCache, url)) {
+      return Promise.resolve(outlineCache[url]);
+    }
+    if (!supportsFetch) return Promise.resolve(null);
+    return fetch(url, {headers: {'Accept': 'application/json'}}).then(function(resp) {
+      if (!resp.ok) return null;
+      return resp.json();
+    }).then(function(json) {
+      var geometry = Array.isArray(json) && json[0] ? json[0].geojson : null;
+      // Only areas are worth outlining; a node's outline is the point itself.
+      if (!geometry || (geometry.type !== 'Polygon' && geometry.type !== 'MultiPolygon')) {
+        geometry = null;
+      } else {
+        geometry = simplifyOutline(geometry);
+      }
+      outlineCache[url] = geometry;
+      return geometry;
+    }).catch(function() {
+      return null;
+    });
+  }
+
   function setInputBgFromContext(context, color) {
     try {
       if (!context) return;
@@ -648,6 +713,8 @@ geocoder.coordPreserving = function(nominatimUrl) {
         return results;
       });
     },
+
+    fetchOutline: fetchOutline,
 
     reverse: function(latlng, scale, cb, context) {
       return doReverse(latlng, scale, context).then(function(results) {

--- a/src/index.js
+++ b/src/index.js
@@ -739,6 +739,7 @@ var entranceWaypoints = createEntranceWaypoints({
   translate: function(key) {
     return localization.t(mergedOptions.language, key);
   },
+  fetchOutline: routingGeocoder.fetchOutline,
   paneWidth: directionsPaneWidth,
   // Read live: a door forbidden to cars may be fine on foot, so the offer has to
   // follow whatever profile is selected right now.

--- a/src/simplify.js
+++ b/src/simplify.js
@@ -1,0 +1,322 @@
+'use strict';
+
+/**
+ * Visvalingam–Whyatt polygon simplification, driven by visual negligibility.
+ *
+ * Repeatedly discards the vertex whose triangle with its two neighbours has the
+ * smallest area, recomputing the neighbours each time. Ranking by area rather
+ * than by perpendicular distance is what keeps the outline recognisable: a
+ * vertex only goes when the sliver it contributes is too small to see.
+ *
+ * The stopping rule is the point of this module. Simplification halts as soon as
+ * the smallest surviving triangle would be visible on screen, so the shape the
+ * user sees is the shape of the thing on the map — a U-shaped museum stays
+ * U-shaped. The threshold is a fraction of the shape's own bounding box, which
+ * makes it scale-free: the picker frames a place to roughly the same number of
+ * pixels whether it is a 5 km airport or a 170 m building, so the same fraction
+ * means the same number of pixels in both cases. An absolute tolerance in
+ * degrees — Nominatim's polygon_threshold — cannot do this: a value large enough
+ * to thin the airport flattens the building into a few stray corners.
+ *
+ * A point budget exists only as a backstop against pathological geometry. It is
+ * far above what a building or a site actually has, and reaching it is the one
+ * case where the shape may visibly change.
+ *
+ * Coordinates are GeoJSON [lon, lat] pairs. Areas are compared in that raw
+ * degree space: every comparison is between triangles of the same shape, so the
+ * longitude foreshortening is a constant factor and does not affect the ranking.
+ *
+ * @module simplify
+ */
+
+// Roughly the width in pixels the picker gives a framed place. Only used to turn
+// "half a pixel" into a fraction of the shape's extent, so it does not need to
+// match any particular viewport closely.
+var ASSUMED_RENDER_SPAN_PX = 1000;
+
+// A triangle smaller than this on screen cannot be distinguished from the line
+// through its neighbours.
+var NEGLIGIBLE_PX = 0.5;
+
+// Backstop only. A building runs to a few dozen points and BER to under 400, so
+// this is not reached by anything the picker normally draws.
+var DEFAULT_MAX_POINTS = 2000;
+
+// Twice the area of the triangle (a, b, c) — the cross product of its two edges.
+// The factor of two is common to every vertex and to the threshold, so it never
+// affects a comparison and is left in.
+function doubleTriangleArea(a, b, c) {
+  return Math.abs((b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1]));
+}
+
+/**
+ * The doubled-triangle-area below which a vertex is invisible once the given
+ * extent is framed on screen. Returns 0 for a degenerate extent, which disables
+ * negligibility removal rather than removing everything.
+ *
+ * @param {{width: number, height: number}} extent — in degrees
+ */
+function negligibleDoubleArea(extent) {
+  if (!extent) return 0;
+  var span = Math.max(extent.width || 0, extent.height || 0);
+  if (!(span > 0)) return 0;
+  var degreesPerPixel = span / ASSUMED_RENDER_SPAN_PX;
+  return 2 * NEGLIGIBLE_PX * degreesPerPixel * degreesPerPixel;
+}
+
+// Binary min-heap of {area, index}. Entries are never removed on update; a stale
+// entry is recognised on pop by comparing its area against the vertex's current
+// one, which is the usual lazy-deletion trick and keeps the heap simple.
+function createMinHeap() {
+  var items = [];
+
+  function swap(i, j) {
+    var tmp = items[i];
+    items[i] = items[j];
+    items[j] = tmp;
+  }
+
+  return {
+    size: function() {
+      return items.length;
+    },
+    push: function(item) {
+      items.push(item);
+      var i = items.length - 1;
+      while (i > 0) {
+        var parent = (i - 1) >> 1;
+        if (items[parent].area <= items[i].area) break;
+        swap(parent, i);
+        i = parent;
+      }
+    },
+    pop: function() {
+      if (items.length === 0) return null;
+      var top = items[0];
+      var last = items.pop();
+      if (items.length > 0) {
+        items[0] = last;
+        var i = 0;
+        for (;;) {
+          var left = 2 * i + 1;
+          var right = left + 1;
+          var smallest = i;
+          if (left < items.length && items[left].area < items[smallest].area) smallest = left;
+          if (right < items.length && items[right].area < items[smallest].area) smallest = right;
+          if (smallest === i) break;
+          swap(i, smallest);
+          i = smallest;
+        }
+      }
+      return top;
+    }
+  };
+}
+
+/**
+ * Simplifies an open sequence of points, keeping the first and last exactly.
+ *
+ * @param {Array<Array<number>>} points — [[lon, lat], …]
+ * @param {object} [options]
+ * @param {number} [options.minDoubleArea] — remove vertices below this; 0 removes none
+ * @param {number} [options.maxPoints] — hard cap, enforced even if it costs shape
+ * @param {number} [options.floor] — never go below this many points
+ * @param {boolean} [options.closed] — treat the sequence as a cycle, so no vertex
+ *   is pinned. A ring has no start, and pinning one leaves a stray vertex sitting
+ *   on the closing edge that nothing can remove.
+ * @returns {Array<Array<number>>} the input itself when nothing was removed
+ */
+function simplifyLine(points, options) {
+  if (!Array.isArray(points) || points.length < 3) return points;
+  options = options || {};
+  var minDoubleArea = options.minDoubleArea > 0 ? options.minDoubleArea : 0;
+  var maxPoints = options.maxPoints > 0 ? options.maxPoints : DEFAULT_MAX_POINTS;
+  var closed = !!options.closed;
+  var floor = Math.max(closed ? 3 : 2, options.floor || 0);
+
+  if (minDoubleArea === 0 && points.length <= maxPoints) return points;
+
+  // Doubly linked list over the original indices, so neighbours stay findable as
+  // vertices are removed.
+  var n = points.length;
+  var prev = new Array(n);
+  var next = new Array(n);
+  var alive = new Array(n);
+  var area = new Array(n);
+  for (var i = 0; i < n; i++) {
+    prev[i] = i - 1;
+    next[i] = i + 1;
+    alive[i] = true;
+    area[i] = Infinity;
+  }
+  if (closed) {
+    prev[0] = n - 1;
+    next[n - 1] = 0;
+  } else {
+    next[n - 1] = -1;
+  }
+
+  var heap = createMinHeap();
+  var firstCandidate = closed ? 0 : 1;
+  var lastCandidate = closed ? n - 1 : n - 2;
+  for (var k = firstCandidate; k <= lastCandidate; k++) {
+    area[k] = doubleTriangleArea(points[prev[k]], points[k], points[next[k]]);
+    heap.push({area: area[k], index: k});
+  }
+
+  var remaining = points.length;
+  var removed = 0;
+  while (remaining > floor && heap.size() > 0) {
+    var top = heap.pop();
+    var idx = top.index;
+    // Stale entry: this vertex has since been removed, or its area was
+    // recomputed after a neighbour disappeared.
+    if (!alive[idx] || top.area !== area[idx]) continue;
+
+    // The heap is ordered, so once the smallest survivor is visible there is
+    // nothing left that can go without altering the shape. Keep going only if
+    // the hard cap still demands it.
+    var negligible = top.area < minDoubleArea;
+    if (!negligible && remaining <= maxPoints) break;
+
+    alive[idx] = false;
+    remaining--;
+    removed++;
+    var before = prev[idx];
+    var after = next[idx];
+    next[before] = after;
+    prev[after] = before;
+
+    // Both neighbours now span a different triangle.
+    [before, after].forEach(function(nb) {
+      if (prev[nb] < 0 || next[nb] < 0) return;
+      area[nb] = doubleTriangleArea(points[prev[nb]], points[nb], points[next[nb]]);
+      heap.push({area: area[nb], index: nb});
+    });
+  }
+
+  if (removed === 0) return points;
+
+  var out = [];
+  for (var j = 0; j < points.length; j++) {
+    if (alive[j]) out.push(points[j]);
+  }
+  return out;
+}
+
+/**
+ * Simplifies a closed GeoJSON ring. The repeated closing vertex is held out of
+ * the simplification and re-appended, so the ring stays closed, and the result
+ * never drops below the four points a valid ring needs.
+ */
+function simplifyRing(ring, options) {
+  if (!Array.isArray(ring) || ring.length < 5) return ring;
+
+  var first = ring[0];
+  var last = ring[ring.length - 1];
+  var closed = first[0] === last[0] && first[1] === last[1];
+  var open = closed ? ring.slice(0, -1) : ring;
+
+  var opts = {
+    minDoubleArea: options && options.minDoubleArea,
+    maxPoints: options && options.maxPoints ? Math.max(3, options.maxPoints - (closed ? 1 : 0)) : 0,
+    // Cyclic: the vertex the ring happens to start at is not special, and pinning
+    // it would strand a removable point on the closing edge.
+    closed: closed,
+    floor: 3
+  };
+  var simplified = simplifyLine(open, opts);
+  if (simplified === open) return ring;
+  return closed ? simplified.concat([simplified[0]]) : simplified;
+}
+
+function geometryRings(geometry) {
+  if (!geometry || !Array.isArray(geometry.coordinates)) return [];
+  if (geometry.type === 'Polygon') return geometry.coordinates;
+  if (geometry.type === 'MultiPolygon') {
+    return geometry.coordinates.reduce(function(all, polygon) {
+      return all.concat(polygon);
+    }, []);
+  }
+  return [];
+}
+
+/**
+ * Bounding extent of a polygon geometry, in degrees. Null when there is nothing
+ * to measure.
+ */
+function geometryExtent(geometry) {
+  var rings = geometryRings(geometry);
+  var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  var seen = false;
+  rings.forEach(function(ring) {
+    if (!Array.isArray(ring)) return;
+    ring.forEach(function(p) {
+      if (!Array.isArray(p) || p.length < 2) return;
+      seen = true;
+      if (p[0] < minX) minX = p[0];
+      if (p[0] > maxX) maxX = p[0];
+      if (p[1] < minY) minY = p[1];
+      if (p[1] > maxY) maxY = p[1];
+    });
+  });
+  if (!seen) return null;
+  return {width: maxX - minX, height: maxY - minY};
+}
+
+/**
+ * Simplifies a GeoJSON Polygon or MultiPolygon, returning a new geometry and
+ * leaving the input untouched. The negligibility threshold is derived from the
+ * whole shape's extent — not per ring — because that extent is what sets the
+ * scale the shape is drawn at, and a hole's detail has to be judged at the same
+ * scale as the outer ring's. Anything that is not a polygon comes back as-is.
+ *
+ * @param {object} geometry
+ * @param {object} [options]
+ * @param {number} [options.maxPoints] — per-ring backstop
+ */
+function simplifyGeometry(geometry, options) {
+  if (!geometry || !Array.isArray(geometry.coordinates)) return geometry;
+  if (geometry.type !== 'Polygon' && geometry.type !== 'MultiPolygon') return geometry;
+
+  options = options || {};
+  var ringOptions = {
+    minDoubleArea: negligibleDoubleArea(geometryExtent(geometry)),
+    maxPoints: options.maxPoints || DEFAULT_MAX_POINTS
+  };
+
+  if (geometry.type === 'Polygon') {
+    return {
+      type: 'Polygon',
+      coordinates: geometry.coordinates.map(function(ring) {
+        return simplifyRing(ring, ringOptions);
+      })
+    };
+  }
+  return {
+    type: 'MultiPolygon',
+    coordinates: geometry.coordinates.map(function(polygon) {
+      return polygon.map(function(ring) {
+        return simplifyRing(ring, ringOptions);
+      });
+    })
+  };
+}
+
+function countPoints(geometry) {
+  return geometryRings(geometry).reduce(function(sum, ring) {
+    return sum + (Array.isArray(ring) ? ring.length : 0);
+  }, 0);
+}
+
+module.exports = {
+  simplifyLine: simplifyLine,
+  simplifyRing: simplifyRing,
+  simplifyGeometry: simplifyGeometry,
+  geometryExtent: geometryExtent,
+  negligibleDoubleArea: negligibleDoubleArea,
+  countPoints: countPoints,
+  ASSUMED_RENDER_SPAN_PX: ASSUMED_RENDER_SPAN_PX,
+  NEGLIGIBLE_PX: NEGLIGIBLE_PX,
+  DEFAULT_MAX_POINTS: DEFAULT_MAX_POINTS
+};

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -909,6 +909,34 @@ describe('the site outline', () => {
     expect(outlines(map)[0].options.style.interactive).toBe(false);
   });
 
+  // Sharing the overlay pane with the route would order the two by whichever
+  // was added last, and the outline arrives when its request resolves.
+  test('is drawn in a pane below the route line', async () => {
+    const { map, resolveOutline } = openWithOutline();
+    await resolveOutline(GEOMETRY);
+    expect(outlines(map)[0].options.pane).toBe('osrmEntranceOutline');
+    expect(Number(map._panes.osrmEntranceOutline.style.zIndex)).toBeLessThan(400);
+    // And above the tiles.
+    expect(Number(map._panes.osrmEntranceOutline.style.zIndex)).toBeGreaterThan(200);
+    // Still below the labels, which are below the dots.
+    expect(Number(map._panes.osrmEntranceOutline.style.zIndex))
+      .toBeLessThan(Number(map._panes.osrmEntranceLabels.style.zIndex));
+  });
+
+  test('a map that cannot make panes still draws the outline', async () => {
+    let settleOutline;
+    const fetchOutline = jest.fn(() => new Promise((r) => { settleOutline = r; }));
+    const map = makeMap();
+    map.createPane = () => null;
+    const picker = entrancePicker.createEntrancePicker(map, { fetchOutline });
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN, SIDE],
+      place: { osmId: 1 } });
+    settleOutline(GEOMETRY);
+    await Promise.resolve();
+    expect(outlines(map)).toHaveLength(1);
+    expect(outlines(map)[0].options.pane).toBeUndefined();
+  });
+
   test('a place with no outline simply has none', async () => {
     const { map, resolveOutline } = openWithOutline();
     await resolveOutline(null);

--- a/test/entrance_picker_instance.test.js
+++ b/test/entrance_picker_instance.test.js
@@ -41,6 +41,7 @@ jest.mock('leaflet', () => ({
   point: (x, y) => ({ x, y }),
   divIcon: (opts) => ({ _kind: 'divIcon', options: opts }),
   polyline: (points, style) => ({ _kind: 'polyline', points, style }),
+  geoJSON: (geometry, opts) => ({ _kind: 'geoJSON', geometry, options: opts }),
   DomEvent: { stopPropagation: jest.fn() },
   marker: (latLng, opts) => ({
     _kind: 'marker',
@@ -128,17 +129,22 @@ function openPicker(showOpts, options, mapOverrides) {
 
 // The picker's own layer group; its members are indexed by the helpers below.
 function pickerGroup(map) {
-  return map._layers.filter((l) => l._kind === 'layerGroup' && l._layers.length === 3)[0];
+  return map._layers.filter((l) => l._kind === 'layerGroup' && l._layers.length === 4)[0];
 }
 
-function links(map) {
+function outlines(map) {
   const g = pickerGroup(map);
   return g ? g._layers[0]._layers : [];
 }
 
-function labels(map) {
+function links(map) {
   const g = pickerGroup(map);
   return g ? g._layers[1]._layers : [];
+}
+
+function labels(map) {
+  const g = pickerGroup(map);
+  return g ? g._layers[2]._layers : [];
 }
 
 // The names a label shows, with any mark glyph stripped — the marks are
@@ -151,7 +157,7 @@ function labelTexts(map) {
 
 function dots(map) {
   const g = pickerGroup(map);
-  return g ? g._layers[2]._layers : [];
+  return g ? g._layers[3]._layers : [];
 }
 
 beforeEach(() => jest.useFakeTimers());
@@ -878,5 +884,78 @@ describe('choosing what to frame', () => {
       { center: BETWEEN_DOORS, pixelsPerDegree: 630000 });
     settle();
     expect(map.fitBounds).toHaveBeenCalled();
+  });
+});
+
+describe('the site outline', () => {
+  const GEOMETRY = { type: 'Polygon', coordinates: [[[13.395, 52.52], [13.397, 52.52], [13.396, 52.521]]] };
+
+  function openWithOutline(resolve, showOpts) {
+    let settleOutline;
+    const fetchOutline = jest.fn(() => new Promise((r) => { settleOutline = r; }));
+    const opened = openPicker(Object.assign({ place: { osmId: 1 } }, showOpts), { fetchOutline });
+    return Object.assign({ fetchOutline, resolveOutline: (g) => { settleOutline(g); return Promise.resolve(); } }, opened);
+  }
+
+  test('is fetched for the place and drawn behind the doors', async () => {
+    const { map, fetchOutline, resolveOutline } = openWithOutline();
+    expect(fetchOutline).toHaveBeenCalledWith({ osmId: 1 });
+    expect(outlines(map)).toHaveLength(0);
+
+    await resolveOutline(GEOMETRY);
+    expect(outlines(map)).toHaveLength(1);
+    expect(outlines(map)[0].geometry).toBe(GEOMETRY);
+    // Context, not a target: never in the way of a click on a door.
+    expect(outlines(map)[0].options.style.interactive).toBe(false);
+  });
+
+  test('a place with no outline simply has none', async () => {
+    const { map, resolveOutline } = openWithOutline();
+    await resolveOutline(null);
+    expect(outlines(map)).toHaveLength(0);
+    expect(dots(map)).toHaveLength(2);
+  });
+
+  test('the picker works without a fetcher at all', () => {
+    const { map } = openPicker();
+    expect(dots(map)).toHaveLength(2);
+    expect(outlines(map)).toHaveLength(0);
+  });
+
+  test('nothing is fetched for a show that carries no place', () => {
+    const fetchOutline = jest.fn();
+    openPicker(null, { fetchOutline });
+    expect(fetchOutline).not.toHaveBeenCalled();
+  });
+
+  // The offer may be gone by the time the request lands.
+  test('an outline arriving after its offer was withdrawn is dropped', async () => {
+    const { map, picker, resolveOutline } = openWithOutline();
+    picker.hide();
+    await resolveOutline(GEOMETRY);
+    expect(outlines(map)).toHaveLength(0);
+  });
+
+  test('an outline arriving after its offer was replaced is dropped', async () => {
+    const { map, picker, resolveOutline } = openWithOutline();
+    picker.show({ waypointIndex: 1, placeCenter: CENTRE, entrances: [MAIN], frame: false });
+    await resolveOutline(GEOMETRY);
+    expect(outlines(map)).toHaveLength(0);
+  });
+
+  // But another waypoint being shown meanwhile must not cancel this one.
+  test('showing another waypoint does not cancel an outline in flight', async () => {
+    const { map, picker, resolveOutline } = openWithOutline();
+    picker.show({ waypointIndex: 5, placeCenter: CENTRE, entrances: [SIDE], frame: false });
+    await resolveOutline(GEOMETRY);
+    expect(outlines(map)).toHaveLength(1);
+  });
+
+  test('each offer keeps its own outline, and closing clears them', async () => {
+    const { map, picker, resolveOutline } = openWithOutline();
+    await resolveOutline(GEOMETRY);
+    expect(outlines(map)).toHaveLength(1);
+    picker.hide();
+    expect(outlines(map)).toHaveLength(0);
   });
 });

--- a/test/geocoder.test.js
+++ b/test/geocoder.test.js
@@ -383,3 +383,91 @@ describe('geocoder entrance handling', () => {
 
 // Entrance nodes carry no geometry of their own, so the site they belong to is
 // outlined instead. Its polygon is fetched separately, never as part of search.
+
+describe('geocoder.fetchOutline', () => {
+  function mockLeaflet() {
+    jest.doMock('leaflet', () => ({
+      Control: { Geocoder: { nominatim: jest.fn(() => ({})) } },
+      CRS: { EPSG3857: { scale: () => 1 } },
+      latLng: (lat, lng) => ({ lat: +lat, lng: +lng }),
+      latLngBounds: (sw, ne) => ({ sw, ne }),
+      extend: Object.assign
+    }));
+  }
+
+  const POLYGON = { type: 'Polygon', coordinates: [[[13.45, 52.34], [13.53, 52.34], [13.53, 52.39], [13.45, 52.34]]] };
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+  });
+
+  afterEach(() => {
+    delete global.localStorage;
+    delete global.fetch;
+  });
+
+  function respondWith(body) {
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve(body)
+    }));
+  }
+
+  test('looks the place up by OSM id and returns its polygon', async () => {
+    mockLeaflet();
+    respondWith([{ geojson: POLYGON }]);
+    const geocoder = require('../src/geocoder');
+
+    const outline = await geocoder.coordPreserving('https://nominatim.example/')
+      .fetchOutline({ osmType: 'way', osmId: 859790021 });
+
+    expect(outline).toEqual(POLYGON);
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toContain('lookup?');
+    expect(url).toContain('osm_ids=W859790021');
+    expect(url).toContain('polygon_geojson=1');
+    // No polygon_threshold: its tolerance is absolute degrees, so a value that
+    // usefully thins an airport flattens a building into a few stray corners.
+    expect(url).not.toContain('polygon_threshold');
+  });
+
+  test('caches by place so reopening the picker costs no request', async () => {
+    mockLeaflet();
+    respondWith([{ geojson: POLYGON }]);
+    const geocoder = require('../src/geocoder');
+    const g = geocoder.coordPreserving('https://nominatim.example/');
+
+    await g.fetchOutline({ osmType: 'way', osmId: 1 });
+    await g.fetchOutline({ osmType: 'way', osmId: 1 });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns null for a place with no area', async () => {
+    mockLeaflet();
+    respondWith([{ geojson: { type: 'Point', coordinates: [13.5, 52.3] } }]);
+    const geocoder = require('../src/geocoder');
+
+    expect(await geocoder.coordPreserving('https://nominatim.example/')
+      .fetchOutline({ osmType: 'node', osmId: 42 })).toBeNull();
+  });
+
+  test('returns null without requesting anything when the result has no OSM id', async () => {
+    mockLeaflet();
+    respondWith([{ geojson: POLYGON }]);
+    const geocoder = require('../src/geocoder');
+
+    expect(await geocoder.coordPreserving('https://nominatim.example/')
+      .fetchOutline({ name: 'somewhere' })).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('a failed lookup is not fatal — the picker just shows no outline', async () => {
+    mockLeaflet();
+    global.fetch = jest.fn(() => Promise.reject(new Error('offline')));
+    const geocoder = require('../src/geocoder');
+
+    expect(await geocoder.coordPreserving('https://nominatim.example/')
+      .fetchOutline({ osmType: 'relation', osmId: 7 })).toBeNull();
+  });
+});

--- a/test/simplify.test.js
+++ b/test/simplify.test.js
@@ -1,0 +1,247 @@
+'use strict';
+
+const simplify = require('../src/simplify');
+
+// A square with a deep notch cut into its north edge — the U shape a museum or a
+// terminal building has. Every vertex here carries real shape.
+function notchedSquare() {
+  return [
+    [0, 0], [10, 0], [10, 10],
+    [6, 10], [6, 4], [4, 4], [4, 10],
+    [0, 10], [0, 0]
+  ];
+}
+
+// The same U, but with each edge sampled at extra collinear points. Those extras
+// contribute zero area and are exactly what simplification should take.
+function notchedSquareOversampled(perEdge) {
+  const base = notchedSquare();
+  const out = [];
+  for (let i = 0; i < base.length - 1; i++) {
+    const [x1, y1] = base[i];
+    const [x2, y2] = base[i + 1];
+    for (let s = 0; s < perEdge; s++) {
+      const t = s / perEdge;
+      out.push([x1 + (x2 - x1) * t, y1 + (y2 - y1) * t]);
+    }
+  }
+  out.push(base[0]);
+  return out;
+}
+
+const AGGRESSIVE = {minDoubleArea: 1e9};
+
+describe('negligibleDoubleArea', () => {
+  test('scales with the shape, so the same fraction means the same pixels', () => {
+    const big = simplify.negligibleDoubleArea({width: 0.084, height: 0.05});
+    const small = simplify.negligibleDoubleArea({width: 0.0025, height: 0.0015});
+    // A 34x smaller shape tolerates a ~34^2 smaller triangle.
+    expect(big / small).toBeCloseTo(Math.pow(0.084 / 0.0025, 2), 0);
+  });
+
+  test('is zero for a degenerate extent, which removes nothing at all', () => {
+    expect(simplify.negligibleDoubleArea({width: 0, height: 0})).toBe(0);
+    expect(simplify.negligibleDoubleArea(null)).toBe(0);
+  });
+});
+
+describe('simplifyLine', () => {
+  test('removes nothing when no vertex is negligible', () => {
+    const pts = [[0, 0], [1, 5], [2, 0], [3, 5]];
+    expect(simplify.simplifyLine(pts, {minDoubleArea: 0})).toBe(pts);
+  });
+
+  test('keeps the first and last point exactly', () => {
+    const pts = notchedSquareOversampled(6);
+    const out = simplify.simplifyLine(pts, AGGRESSIVE);
+    expect(out[0]).toEqual(pts[0]);
+    expect(out[out.length - 1]).toEqual(pts[pts.length - 1]);
+  });
+
+  test('drops only the vertices that carry no shape', () => {
+    const pts = [[0, 0], [1, 0], [2, 0], [3, 5], [4, 0], [5, 0], [6, 0]];
+    const out = simplify.simplifyLine(pts, {minDoubleArea: 1});
+    // [1,0] and [5,0] are collinear with their neighbours and go. [2,0] and
+    // [4,0] are the feet of the spike — their triangles have real area — so they
+    // stay, and with them the spike's actual shape.
+    expect(out).toEqual([[0, 0], [2, 0], [3, 5], [4, 0], [6, 0]]);
+  });
+
+  test('a run of genuinely collinear points collapses to its endpoints', () => {
+    const pts = [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0], [5, 0]];
+    expect(simplify.simplifyLine(pts, {minDoubleArea: 1})).toEqual([[0, 0], [5, 0]]);
+  });
+
+  test('stops at the first visible vertex rather than running to a budget', () => {
+    const pts = [[0, 0], [1, 0], [2, 0], [3, 5], [4, 0], [5, 0], [6, 0]];
+    const out = simplify.simplifyLine(pts, {minDoubleArea: 1, maxPoints: 3});
+    // The spike survives because it is not negligible, even though the cap is met.
+    expect(out).toContainEqual([3, 5]);
+  });
+
+  test('the hard cap still bites on pathological input', () => {
+    const pts = [];
+    for (let i = 0; i < 200; i++) pts.push([i, i % 2 === 0 ? 0 : 5]);
+    const out = simplify.simplifyLine(pts, {minDoubleArea: 0, maxPoints: 20});
+    expect(out.length).toBeLessThanOrEqual(20);
+  });
+
+  test('never goes below the floor', () => {
+    const out = simplify.simplifyLine(notchedSquareOversampled(6), {minDoubleArea: 1e9, floor: 4});
+    expect(out.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test('tolerates short and non-array input', () => {
+    expect(simplify.simplifyLine(null, AGGRESSIVE)).toBeNull();
+    const two = [[0, 0], [1, 1]];
+    expect(simplify.simplifyLine(two, AGGRESSIVE)).toBe(two);
+  });
+});
+
+describe('simplifyRing', () => {
+  test('keeps the ring closed', () => {
+    const out = simplify.simplifyRing(notchedSquareOversampled(6), {minDoubleArea: 1});
+    expect(out[0]).toEqual(out[out.length - 1]);
+  });
+
+  test('returns the original ring when nothing is negligible', () => {
+    const ring = notchedSquare();
+    expect(simplify.simplifyRing(ring, {minDoubleArea: 0})).toBe(ring);
+  });
+
+  test('recovers the exact U shape from an oversampled one', () => {
+    const out = simplify.simplifyRing(notchedSquareOversampled(8), {minDoubleArea: 0.001});
+    expect(out).toEqual(notchedSquare());
+  });
+
+  test('never reduces a ring below a valid four points', () => {
+    const out = simplify.simplifyRing(notchedSquareOversampled(4), {minDoubleArea: 1e9});
+    expect(out.length).toBeGreaterThanOrEqual(4);
+    expect(out[0]).toEqual(out[out.length - 1]);
+  });
+
+  test('leaves short rings untouched', () => {
+    const tiny = [[0, 0], [1, 0], [0, 1], [0, 0]];
+    expect(simplify.simplifyRing(tiny, AGGRESSIVE)).toBe(tiny);
+  });
+});
+
+describe('simplifyGeometry', () => {
+  test('judges a hole at the whole shape’s scale, not its own', () => {
+    // A large outer ring with a small oversampled hole. Were the hole judged
+    // against its own extent it would keep detail invisible at the drawn scale.
+    const outer = notchedSquareOversampled(8);
+    const hole = notchedSquareOversampled(8).map(([x, y]) => [x / 100 + 4, y / 100 + 4]);
+    const out = simplify.simplifyGeometry({type: 'Polygon', coordinates: [outer, hole]});
+    expect(out.coordinates[1].length).toBeLessThan(hole.length);
+  });
+
+  test('walks every ring of a MultiPolygon', () => {
+    const geometry = {
+      type: 'MultiPolygon',
+      coordinates: [[notchedSquareOversampled(8)], [notchedSquareOversampled(8)]]
+    };
+    const out = simplify.simplifyGeometry(geometry);
+    expect(out.type).toBe('MultiPolygon');
+    expect(out.coordinates[0][0].length).toBeLessThan(geometry.coordinates[0][0].length);
+  });
+
+  test('does not mutate the input', () => {
+    const geometry = {type: 'Polygon', coordinates: [notchedSquareOversampled(8)]};
+    const before = geometry.coordinates[0].length;
+    simplify.simplifyGeometry(geometry);
+    expect(geometry.coordinates[0]).toHaveLength(before);
+  });
+
+  test('passes through anything that is not a polygon', () => {
+    const point = {type: 'Point', coordinates: [1, 2]};
+    expect(simplify.simplifyGeometry(point)).toBe(point);
+    expect(simplify.simplifyGeometry(null)).toBeNull();
+  });
+});
+
+// The regression this module exists for. Nominatim's polygon_threshold is an
+// absolute tolerance in degrees, so the value that thinned BER collapsed the
+// Pergamonmuseum's 32-point outline to 5 stray corners. These are the real
+// coordinates of both.
+describe('real outlines keep their shape', () => {
+  const PERGAMON = [
+    [13.395229, 52.520969], [13.395579, 52.520719], [13.396513, 52.521217],
+    [13.396635, 52.521133], [13.396428, 52.521025], [13.396523, 52.520957],
+    [13.396617, 52.520889], [13.396829, 52.521], [13.396958, 52.520911],
+    [13.396009, 52.520411], [13.39636, 52.52016], [13.396605, 52.520287],
+    [13.39658, 52.520305], [13.397322, 52.520691], [13.397344, 52.520675],
+    [13.397438, 52.520724], [13.397708, 52.520864], [13.397673, 52.520889],
+    [13.397333, 52.521112], [13.397421, 52.521159], [13.397319, 52.52123],
+    [13.397452, 52.521299], [13.397214, 52.521468], [13.397076, 52.521397],
+    [13.396976, 52.521466], [13.396908, 52.52143], [13.396579, 52.521664],
+    [13.396243, 52.52149], [13.396275, 52.521467], [13.39549, 52.521059],
+    [13.395452, 52.521085], [13.395229, 52.520969]
+  ];
+
+  test('the museum survives essentially intact', () => {
+    const out = simplify.simplifyGeometry({type: 'Polygon', coordinates: [PERGAMON]});
+    const kept = out.coordinates[0].length;
+    // The old absolute threshold left 5 points out of 32.
+    expect(kept).toBeGreaterThan(25);
+    expect(out.coordinates[0][0]).toEqual(PERGAMON[0]);
+  });
+
+  test('its extent is preserved to within a pixel of the drawn scale', () => {
+    const out = simplify.simplifyGeometry({type: 'Polygon', coordinates: [PERGAMON]});
+    const before = simplify.geometryExtent({type: 'Polygon', coordinates: [PERGAMON]});
+    const after = simplify.geometryExtent(out);
+    const perPixel = Math.max(before.width, before.height) / simplify.ASSUMED_RENDER_SPAN_PX;
+    expect(Math.abs(after.width - before.width)).toBeLessThan(perPixel);
+    expect(Math.abs(after.height - before.height)).toBeLessThan(perPixel);
+  });
+
+  test('a shape 34x larger is thinned by the same call, not the museum', () => {
+    // Same outline scaled up to airport size, oversampled along every edge.
+    const scaled = PERGAMON.map(([x, y]) => [
+      13.4 + (x - 13.395229) * 34, 52.34 + (y - 52.520969) * 34
+    ]);
+    const dense = [];
+    for (let i = 0; i < scaled.length - 1; i++) {
+      for (let s = 0; s < 12; s++) {
+        const t = s / 12;
+        dense.push([
+          scaled[i][0] + (scaled[i + 1][0] - scaled[i][0]) * t,
+          scaled[i][1] + (scaled[i + 1][1] - scaled[i][1]) * t
+        ]);
+      }
+    }
+    dense.push(scaled[0]);
+    const out = simplify.simplifyGeometry({type: 'Polygon', coordinates: [dense]});
+    expect(out.coordinates[0].length).toBeLessThan(dense.length / 3);
+  });
+});
+
+describe('geometryExtent and countPoints', () => {
+  const RING = [[0, 0], [10, 0], [10, 5], [0, 0]];
+
+  test('measure a Polygon', () => {
+    const g = { type: 'Polygon', coordinates: [RING] };
+    expect(simplify.geometryExtent(g)).toEqual({ width: 10, height: 5 });
+    expect(simplify.countPoints(g)).toBe(4);
+  });
+
+  test('measure a MultiPolygon across all its parts', () => {
+    const g = { type: 'MultiPolygon', coordinates: [[RING], [RING.map(([x, y]) => [x + 20, y])]] };
+    expect(simplify.geometryExtent(g)).toEqual({ width: 30, height: 5 });
+    expect(simplify.countPoints(g)).toBe(8);
+  });
+
+  test('report nothing for a geometry with no rings', () => {
+    expect(simplify.geometryExtent({ type: 'Point', coordinates: [1, 2] })).toBeNull();
+    expect(simplify.geometryExtent(null)).toBeNull();
+    expect(simplify.countPoints({ type: 'Point', coordinates: [1, 2] })).toBe(0);
+    expect(simplify.countPoints(null)).toBe(0);
+  });
+
+  test('ignore malformed rings rather than throwing', () => {
+    const g = { type: 'Polygon', coordinates: [RING, null, [[1], 'nonsense']] };
+    expect(simplify.geometryExtent(g)).toEqual({ width: 10, height: 5 });
+    expect(() => simplify.countPoints(g)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Last of the series splitting #504. Stacked on #524, which is stacked on #523 — **review after those land**; the diff below is against #524's branch.

Five dots floating on a map do not say what they are dots on. The place's outline is drawn behind them: muted, dashed, non-interactive — context for the doors, never a thing to click, and never something that can hide the route line.

## Fetching

From Nominatim's `lookup` endpoint with `polygon_geojson=1`, by the OSM id #517 already carries on the result. One at a time, and only when something is about to draw one: `suggest` runs on every keystroke and a polygon per result would multiply a payload that is almost always discarded. Cached in memory only — the persisted result cache has a fixed shape that geometry has no place in.

An outline that fails, times out, or does not exist (a node, an older Nominatim) simply means the picker shows its dots without a boundary. It is context, not a dependency.

## Why simplify here rather than ask Nominatim to

`polygon_threshold` takes an absolute tolerance in degrees. A value large enough to thin a 5 km airport flattens a 170 m building into a few stray corners, and the picker frames both to roughly the same number of pixels.

`src/simplify.js` implements Visvalingam–Whyatt instead: repeatedly discard the vertex whose triangle with its two neighbours has the smallest area, recomputing neighbours each time. Ranking by area rather than perpendicular distance is what keeps the shape recognisable — a vertex only goes when the sliver it contributes is too small to see.

The stopping rule is the point of the module: simplification halts as soon as the smallest surviving triangle would be visible on screen, and the threshold is a fraction of the shape's own bounding box rather than an absolute figure. That makes it scale-free, so a U-shaped museum stays U-shaped and an airport loses only vertices nobody could have seen. A per-ring point budget exists purely as a backstop against pathological geometry, far above what a real building or site has.

Areas are compared in raw degree space: every comparison is between triangles of the same shape, so longitude foreshortening is a constant factor and does not affect the ranking.

## Tests

`simplify.test.js` covers the ranking, the negligibility threshold, scale-freeness across a building and an airport, ring closure, multi-polygons, degenerate rings, and the point budget. The picker gains: the outline fetched for the place and drawn non-interactively behind the doors, a place with no outline, no fetcher at all, a show with no place, an outline arriving after its offer was withdrawn or replaced, another waypoint's offer *not* cancelling one in flight, and teardown. The geocoder's own `fetchOutline` tests — lookup by OSM id, caching, a place with no area, no OSM id, and a failed request — come back here with the code they cover.

587 tests, 36 suites, lint clean.

## On verification

Not spot-checked live: the browser automation in this session stopped delivering keyboard and mouse input to the page partway through (a click lands on the geocoder input but focus stays on `body`; typed characters never reach it), so I could not drive a geocode by hand. The same limitation applies to #523. What is covered is the unit level, and the geometry module is the part that most warrants it.

🤖 Claude Code, Claude Opus 5
