### PR TITLE
feat: let a deployment name its own tile server via OSRM_TILE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,28 @@ Set `OSRM_DEFAULT_LAYER` to one of: `streets`, `outdoors`, `satellite`, `osm`, `
 docker run -p 9966:9966 -e OSRM_DEFAULT_LAYER=satellite ghcr.io/project-osrm/osrm-frontend:latest
 ```
 
+**Using your own tile server (`OSRM_TILE_URL`):**
+A self-hosted or offline deployment cannot reach the public tile providers above.
+Point `OSRM_TILE_URL` at your own tile server and the frontend adds it as an extra
+base layer — no source edit, no rebuild:
+
+```bash
+docker run -p 9966:9966 \
+  -e 'OSRM_TILE_URL=http://localhost:8080/tile/{z}/{x}/{y}.png' \
+  -e 'OSRM_TILE_NAME=Local tiles' \
+  ghcr.io/project-osrm/osrm-frontend:latest
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OSRM_TILE_URL` | — | Tile URL template. Must be an http(s), protocol-relative or root-relative URL carrying the `{z}`, `{x}` and `{y}` placeholders; anything else is ignored with a console warning. |
+| `OSRM_TILE_NAME` | `Custom` | Label shown in the layer control. |
+| `OSRM_TILE_ATTRIBUTION` | OpenStreetMap credit | Attribution text for the layer. |
+
+Setting `OSRM_TILE_URL` also makes that layer the default, since a deployment
+serving its own tiles is usually offline. Set `OSRM_DEFAULT_LAYER` explicitly to
+override — `custom` selects the tile layer, the other keys the built-in ones.
+
 **Adding or replacing base layers (source builds):**
 Define a new `L.tileLayer` and add it to the `layer` array in `src/leaflet_options.js`:
 ```js

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,17 @@ OSRM_ENVIRONMENT="${OSRM_ENVIRONMENT:-docker}"
 # Empty by default: a self-hosted deployment gets watermarked CARTO tiles until
 # it supplies a key of its own.
 OSRM_CARTO_KEY="${OSRM_CARTO_KEY:-}"
+# Empty by default: only a deployment with its own tile server sets these.
+OSRM_TILE_URL="${OSRM_TILE_URL:-}"
+OSRM_TILE_NAME="${OSRM_TILE_NAME:-}"
+OSRM_TILE_ATTRIBUTION="${OSRM_TILE_ATTRIBUTION:-}"
+
+# A deployment naming its own tile server usually cannot reach the public
+# providers either, so make that layer the default unless the operator picked
+# one. "streets" is the image default, so it reads as "not specified" here.
+if [ -n "$OSRM_TILE_URL" ] && [ "$OSRM_DEFAULT_LAYER" = "streets" ]; then
+  OSRM_DEFAULT_LAYER=custom
+fi
 
 # Validate OSRM_ZOOM is numeric (for valid JSON output)
 case "$OSRM_ZOOM" in
@@ -65,6 +76,9 @@ cat > /usr/share/nginx/html/config.json << EOF
   "OSRM_DEFAULT_LAYER": "$(escape_json "$OSRM_DEFAULT_LAYER")",
   "OSRM_ENVIRONMENT": "$(escape_json "$OSRM_ENVIRONMENT")",
   "OSRM_CARTO_KEY": "$(escape_json "$OSRM_CARTO_KEY")",
+  "OSRM_TILE_URL": "$(escape_json "$OSRM_TILE_URL")",
+  "OSRM_TILE_NAME": "$(escape_json "$OSRM_TILE_NAME")",
+  "OSRM_TILE_ATTRIBUTION": "$(escape_json "$OSRM_TILE_ATTRIBUTION")",
   "OSRM_MODES": "$(escape_json "$MODES_JSON")"
 }
 EOF

--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
         // by config.json, so set the OSRM_CARTO_KEY environment variable
         // instead and the entrypoint will pass it through.
         OSRM_CARTO_KEY: 'cb1_2qvg_1_8e87c8903d178ccf6f862d52'
+        // A deployment with its own tile server adds OSRM_TILE_URL here (plus
+        // optional OSRM_TILE_NAME and OSRM_TILE_ATTRIBUTION); in Docker set the
+        // matching environment variables instead.
         // OSRM_BACKEND and OSRM_MODES will be set by config.json if available
       };
 

--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -57,6 +57,56 @@ var streets = L.tileLayer(cartoVoyagerUrl(), {
   small_components = L.tileLayer('https://tools.geofabrik.de/osmi/tiles/routing/{z}/{x}/{y}.png', {});
 
 /**
+ * Build the custom base layer described by `OSRM_TILE_URL`, if one is configured.
+ *
+ * A self-hosted or offline deployment cannot reach the public tile providers the
+ * built-in layers point at, so `OSRM_TILE_URL` lets it name its own tile server
+ * without patching this file and rebuilding. `OSRM_TILE_NAME` sets the label in
+ * the layer control and `OSRM_TILE_ATTRIBUTION` the attribution text; tiles from
+ * a private server are usually OSM-derived, so the OSM credit is the default.
+ *
+ * The URL must be an absolute http(s), protocol-relative, or root-relative
+ * template carrying the `{z}`, `{x}` and `{y}` placeholders Leaflet substitutes.
+ * Anything else is rejected with a warning rather than added as a layer that
+ * would silently render nothing.
+ *
+ * @returns {?L.TileLayer} the configured layer, or `null` when unconfigured or invalid
+ */
+function customTileLayer() {
+  var url = config.OSRM_TILE_URL;
+  if (typeof url !== 'string' || !url.trim()) return null;
+  url = url.trim();
+
+  if (!/^(https?:)?\/\/|^\//.test(url)) {
+    console.warn('Ignoring OSRM_TILE_URL: expected an http(s), protocol-relative or root-relative URL, got ' + url);
+    return null;
+  }
+  if (!(/\{z\}/.test(url) && /\{x\}/.test(url) && /\{y\}/.test(url))) {
+    console.warn('Ignoring OSRM_TILE_URL: the template is missing one of the {z}, {x}, {y} placeholders: ' + url);
+    return null;
+  }
+
+  var attribution = config.OSRM_TILE_ATTRIBUTION;
+  return L.tileLayer(url, {
+    attribution: (typeof attribution === 'string' && attribution.trim()) ? attribution.trim() : osmAttribution,
+    maxZoom: 19
+  });
+}
+
+/**
+ * The label the custom layer carries in the layer control.
+ *
+ * @returns {string} `OSRM_TILE_NAME` when set, otherwise `'Custom'`
+ */
+function customTileLayerName() {
+  var name = config.OSRM_TILE_NAME;
+  return (typeof name === 'string' && name.trim()) ? name.trim() : 'Custom';
+}
+
+var custom = customTileLayer();
+var customName = customTileLayerName();
+
+/**
  * Parse center coordinates from the runtime config (`OSRM_CENTER` env var).
  *
  * Accepts a comma- or space-separated "lat,lng" string. Falls back to
@@ -383,14 +433,16 @@ function getLanguage() {
 /**
  * Get the default base tile layer name from the runtime config (`OSRM_DEFAULT_LAYER` env var).
  *
- * Returns the configured value, or `'streets'` (CartoDB Voyager) when unset.
- * Key validation (and fallback for unrecognized values) happens at the call
- * site via `layerMap[getDefaultLayer()] || streets`.
+ * Returns the configured value; when unset it falls back to `'custom'` if
+ * `OSRM_TILE_URL` supplied one — a deployment that names its own tile server
+ * usually cannot reach the public providers either — and to `'streets'`
+ * (CartoDB Voyager) otherwise. Key validation (and fallback for unrecognized
+ * values) happens at the call site via `layerMap[getDefaultLayer()] || streets`.
  *
  * @returns {string} The default layer key (default `'streets'`).
  */
 function getDefaultLayer() {
-  return config.OSRM_DEFAULT_LAYER || 'streets';
+  return config.OSRM_DEFAULT_LAYER || (custom ? 'custom' : 'streets');
 }
 
 /**
@@ -407,6 +459,24 @@ var layerMap = {
   osm: osm,
   osm_de: osm_de
 };
+if (custom) layerMap.custom = custom;
+
+/**
+ * Base tile layers keyed by the label they carry in the layer control.
+ *
+ * A configured custom layer is appended last, and replaces a built-in entry
+ * when `OSRM_TILE_NAME` reuses its label.
+ *
+ * @type {Object<string, L.TileLayer>}
+ */
+var baseLayers = {
+  'Streets': streets,
+  'Outdoors': outdoors,
+  'Satellite': satellite,
+  'openstreetmap.org': osm,
+  'openstreetmap.de': osm_de
+};
+if (custom) baseLayers[customName] = custom;
 
 var defaultLayer = layerMap[getDefaultLayer()] || streets;
 
@@ -470,7 +540,10 @@ function buildServices() {
  * | `OSRM_CENTER`          | `38.8995,-77.0269`               | Comma-separated "lat,lng" for the initial map center. |
  * | `OSRM_ZOOM`            | `13`                             | Initial zoom level (0–18). |
  * | `OSRM_LANGUAGE`        | (browser language → `'en'`)      | UI language override. |
- * | `OSRM_DEFAULT_LAYER`   | `'streets'`                      | Default base layer key: `streets`, `outdoors`, `satellite`, `osm`, or `osm_de`. |
+ * | `OSRM_DEFAULT_LAYER`   | `'streets'`                      | Default base layer key: `streets`, `outdoors`, `satellite`, `osm`, `osm_de`, or `custom` when `OSRM_TILE_URL` is set. |
+ * | `OSRM_TILE_URL`        | —                                | Tile URL template (with `{z}`, `{x}`, `{y}`) for a self-hosted or offline tile server. Adds a `custom` base layer and, unless `OSRM_DEFAULT_LAYER` says otherwise, selects it. |
+ * | `OSRM_TILE_NAME`       | `'Custom'`                       | Label for the `OSRM_TILE_URL` layer in the layer control. |
+ * | `OSRM_TILE_ATTRIBUTION`| (OpenStreetMap credit)           | Attribution text for the `OSRM_TILE_URL` layer. |
  * | `OSRM_LABEL`           | `'Car (fastest)'`                | Label for the default routing service. |
  * | `OSRM_ENVIRONMENT`     | —                                | Set to `'docker'` to use Docker-mode backend defaults. |
  * | `OSRM_CARTO_KEY`       | — (bundled key on project-osrm.org) | CARTO Basemaps key for the Streets layer. Without one CARTO watermarks the tiles; they still render. |
@@ -532,21 +605,19 @@ var leafletOptions = {
    * - **Satellite** — ESRI World Imagery (max zoom 19)
    * - **openstreetmap.org** — Standard OSM tile layer
    * - **openstreetmap.de** — German OSM tile layer
+   * - **Custom** — only present when `OSRM_TILE_URL` names a tile server
+   *   (labelled by `OSRM_TILE_NAME`)
    *
-   * **Customizing:** To add or replace base layers, define a `L.tileLayer`
-   * and add an entry to this object. To change the *default* layer, set
+   * **Customizing:** A self-hosted or offline deployment should point
+   * `OSRM_TILE_URL` at its own tile server rather than edit this file. To add
+   * or replace base layers at source level, define a `L.tileLayer` and add an
+   * entry to `baseLayers`. To change the *default* layer, set
    * `OSRM_DEFAULT_LAYER` to one of the layer keys (`layerMap` in this file)
    * or edit `defaultState.layer`.
    *
    * @type {Array<Object<string, L.TileLayer>>}
    */
-  layer: [{
-    'Streets': streets,
-    'Outdoors': outdoors,
-    'Satellite': satellite,
-    'openstreetmap.org': osm,
-    'openstreetmap.de': osm_de
-  }],
+  layer: [baseLayers],
   /**
    * Togglable overlay tile layers shown in the Leaflet layer control.
    *

--- a/test/custom_tile_layer.test.js
+++ b/test/custom_tile_layer.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+// Mock leaflet so this test runs in the node environment without a DOM
+jest.mock('leaflet', () => ({
+  tileLayer: (url, options) => ({ _url: url, _options: options }),
+  latLng: (lat, lng) => ({ lat, lng })
+}));
+
+// Load leaflet_options against a given runtime config, isolated from other tests.
+function loadWithConfig(osrmConfig) {
+  jest.resetModules();
+  global.window = { osrmConfig: osrmConfig };
+  try {
+    return require('../src/leaflet_options');
+  } finally {
+    delete global.window;
+  }
+}
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('OSRM_TILE_URL custom base layer', () => {
+  test('adds a base layer pointing at the configured tile server', () => {
+    // The whole point of the key: an offline deployment names its own tile
+    // server without patching leaflet_options.js and rebuilding the bundle.
+    const opts = loadWithConfig({ OSRM_TILE_URL: 'http://localhost:8080/tile/{z}/{x}/{y}.png' });
+    expect(opts.layer[0]['Custom']._url).toBe('http://localhost:8080/tile/{z}/{x}/{y}.png');
+  });
+
+  test('leaves the layer control untouched when unconfigured', () => {
+    const opts = loadWithConfig({});
+    expect(Object.keys(opts.layer[0])).toEqual([
+      'Streets', 'Outdoors', 'Satellite', 'openstreetmap.org', 'openstreetmap.de'
+    ]);
+  });
+
+  test('OSRM_TILE_NAME labels the layer in the control', () => {
+    const opts = loadWithConfig({
+      OSRM_TILE_URL: 'https://tiles.example.com/{z}/{x}/{y}.png',
+      OSRM_TILE_NAME: 'Local tiles'
+    });
+    expect(opts.layer[0]['Local tiles']._url).toContain('tiles.example.com');
+    expect(opts.layer[0]['Custom']).toBeUndefined();
+  });
+
+  test('a name reusing a built-in label replaces that layer rather than being dropped', () => {
+    const opts = loadWithConfig({
+      OSRM_TILE_URL: 'https://tiles.example.com/{z}/{x}/{y}.png',
+      OSRM_TILE_NAME: 'Streets'
+    });
+    expect(opts.layer[0]['Streets']._url).toContain('tiles.example.com');
+  });
+
+  test('OSRM_TILE_ATTRIBUTION overrides the default OSM credit', () => {
+    const opts = loadWithConfig({
+      OSRM_TILE_URL: 'https://tiles.example.com/{z}/{x}/{y}.png',
+      OSRM_TILE_ATTRIBUTION: '© My Tile Provider'
+    });
+    expect(opts.layer[0]['Custom']._options.attribution).toBe('© My Tile Provider');
+  });
+
+  test('the layer is credited to OpenStreetMap when no attribution is given', () => {
+    // Tiles from a private server are usually OSM-derived, so the credit is a
+    // safer default than an unattributed layer.
+    const opts = loadWithConfig({ OSRM_TILE_URL: 'https://tiles.example.com/{z}/{x}/{y}.png' });
+    expect(opts.layer[0]['Custom']._options.attribution).toContain('OpenStreetMap');
+  });
+
+  test('a blank or non-string URL adds no layer', () => {
+    [undefined, '', '   ', 42, null].forEach((value) => {
+      const opts = loadWithConfig({ OSRM_TILE_URL: value });
+      expect(opts.layer[0]['Custom']).toBeUndefined();
+    });
+  });
+
+  test('surrounding whitespace is trimmed off the URL and name', () => {
+    const opts = loadWithConfig({
+      OSRM_TILE_URL: '  https://tiles.example.com/{z}/{x}/{y}.png  ',
+      OSRM_TILE_NAME: '  Local tiles  '
+    });
+    expect(opts.layer[0]['Local tiles']._url).toBe('https://tiles.example.com/{z}/{x}/{y}.png');
+  });
+
+  test('a URL missing a {z}/{x}/{y} placeholder is rejected with a warning', () => {
+    // Such a layer would request one constant tile forever; failing loudly at
+    // startup beats a map that renders nothing.
+    ['https://tiles.example.com/{z}/{x}.png',
+      'https://tiles.example.com/tiles.png',
+      'https://tiles.example.com/{x}/{y}.png'].forEach((url) => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const opts = loadWithConfig({ OSRM_TILE_URL: url });
+      expect(opts.layer[0]['Custom']).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('{z}, {x}, {y}'));
+      warnSpy.mockRestore();
+    });
+  });
+
+  test('a URL with an unsupported scheme is rejected with a warning', () => {
+    ['javascript:alert(1)//{z}{x}{y}',
+      'data:image/png;base64,{z}{x}{y}',
+      'ftp://tiles.example.com/{z}/{x}/{y}.png',
+      'tiles.example.com/{z}/{x}/{y}.png'].forEach((url) => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const opts = loadWithConfig({ OSRM_TILE_URL: url });
+      expect(opts.layer[0]['Custom']).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('OSRM_TILE_URL'));
+      warnSpy.mockRestore();
+    });
+  });
+
+  test('protocol-relative and root-relative templates are accepted', () => {
+    ['//tiles.example.com/{z}/{x}/{y}.png', '/tiles/{z}/{x}/{y}.png'].forEach((url) => {
+      const opts = loadWithConfig({ OSRM_TILE_URL: url });
+      expect(opts.layer[0]['Custom']._url).toBe(url);
+    });
+  });
+});
+
+describe('OSRM_TILE_URL and the default layer', () => {
+  test('the custom layer becomes the default when no layer is named', () => {
+    // A deployment serving its own tiles usually cannot reach CARTO either.
+    const opts = loadWithConfig({ OSRM_TILE_URL: 'http://localhost:8080/tile/{z}/{x}/{y}.png' });
+    expect(opts.defaultState.layer._url).toContain('localhost:8080');
+  });
+
+  test('OSRM_DEFAULT_LAYER=custom selects the configured tile server', () => {
+    const opts = loadWithConfig({
+      OSRM_TILE_URL: 'http://localhost:8080/tile/{z}/{x}/{y}.png',
+      OSRM_DEFAULT_LAYER: 'custom'
+    });
+    expect(opts.defaultState.layer._url).toContain('localhost:8080');
+  });
+
+  test('an explicit OSRM_DEFAULT_LAYER still wins over the custom layer', () => {
+    const opts = loadWithConfig({
+      OSRM_TILE_URL: 'http://localhost:8080/tile/{z}/{x}/{y}.png',
+      OSRM_DEFAULT_LAYER: 'satellite'
+    });
+    expect(opts.defaultState.layer._url).toContain('arcgisonline.com');
+  });
+
+  test('OSRM_DEFAULT_LAYER=custom without a tile URL falls back to streets', () => {
+    const opts = loadWithConfig({ OSRM_DEFAULT_LAYER: 'custom' });
+    expect(opts.defaultState.layer._url).toContain('cartocdn.com');
+  });
+
+  test('a rejected tile URL leaves streets as the default', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const opts = loadWithConfig({ OSRM_TILE_URL: 'ftp://tiles.example.com/{z}/{x}/{y}.png' });
+    expect(opts.defaultState.layer._url).toContain('cartocdn.com');
+    warnSpy.mockRestore();
+  });
+});

--- a/test/custom_tile_layer.test.js
+++ b/test/custom_tile_layer.test.js
@@ -153,3 +153,67 @@ describe('OSRM_TILE_URL and the default layer', () => {
     warnSpy.mockRestore();
   });
 });
+
+describe('OSRM_TILE_URL layer selection via URL and stored preference', () => {
+  const links = require('../src/links');
+
+  // Mirrors resolveLayerByName() in src/index.js: exact match first, then
+  // case-insensitive, over the labels in the layer control.
+  function resolveLayerByName(baseLayers, name) {
+    if (baseLayers[name]) return baseLayers[name];
+    const lower = String(name).toLowerCase();
+    const key = Object.keys(baseLayers).find((k) => k.toLowerCase() === lower);
+    return key ? baseLayers[key] : undefined;
+  }
+
+  // Mirrors canonicalizeLayer() in src/index.js for the object form: the label
+  // a layer is written back to the URL under.
+  function canonicalizeLayer(baseLayers, layer) {
+    return Object.keys(baseLayers).find((k) => baseLayers[k] === layer);
+  }
+
+  function loadWithCustomLayer() {
+    return loadWithConfig({
+      OSRM_TILE_URL: 'http://localhost:8080/tile/{z}/{x}/{y}.png',
+      OSRM_TILE_NAME: 'Local tiles'
+    });
+  }
+
+  test('a ly URL parameter selects the custom layer', () => {
+    const opts = loadWithCustomLayer();
+    const parsed = links.parse('ly=' + encodeURIComponent('Local tiles'));
+    expect(resolveLayerByName(opts.layer[0], parsed.layer)._url).toContain('localhost:8080');
+  });
+
+  test('the custom label is matched case-insensitively', () => {
+    // Stored preferences and hand-edited links do not preserve casing.
+    const opts = loadWithCustomLayer();
+    expect(resolveLayerByName(opts.layer[0], 'local tiles')._url).toContain('localhost:8080');
+  });
+
+  test('the custom layer canonicalizes back to its label for the URL', () => {
+    // Without this the layer choice would be dropped from state.update().
+    const opts = loadWithCustomLayer();
+    expect(canonicalizeLayer(opts.layer[0], opts.defaultState.layer)).toBe('Local tiles');
+  });
+
+  test('a ly value naming no layer leaves the custom layer as the fallback', () => {
+    const opts = loadWithCustomLayer();
+    const parsed = links.parse('ly=NoSuchLayer');
+    const chosen = resolveLayerByName(opts.layer[0], parsed.layer) || opts.defaultState.layer;
+    expect(chosen._url).toContain('localhost:8080');
+  });
+
+  test('the built-in layers stay selectable alongside the custom one', () => {
+    const opts = loadWithCustomLayer();
+    expect(resolveLayerByName(opts.layer[0], 'Satellite')._url).toContain('arcgisonline.com');
+    expect(Object.keys(opts.layer[0])).toEqual([
+      'Streets', 'Outdoors', 'Satellite', 'openstreetmap.org', 'openstreetmap.de', 'Local tiles'
+    ]);
+  });
+
+  test('overlays are untouched by a custom base layer', () => {
+    const opts = loadWithCustomLayer();
+    expect(Object.keys(opts.overlay)).toEqual(['Hiking', 'Bike', 'Small Components']);
+  });
+});

--- a/test/entrypoint.test.js
+++ b/test/entrypoint.test.js
@@ -52,6 +52,60 @@ function generateConfig(envOverrides, options) {
 }
 
 describe('docker entrypoint runtime config', () => {
+  test('passes a custom tile server through to config.json', () => {
+    const config = generateConfig({
+      OSRM_ENVIRONMENT: 'docker',
+      OSRM_TILE_URL: 'http://localhost:8080/tile/{z}/{x}/{y}.png',
+      OSRM_TILE_NAME: 'Local tiles',
+      OSRM_TILE_ATTRIBUTION: '\u00a9 My Tile Provider'
+    });
+    expect(config.OSRM_TILE_URL).toBe('http://localhost:8080/tile/{z}/{x}/{y}.png');
+    expect(config.OSRM_TILE_NAME).toBe('Local tiles');
+    expect(config.OSRM_TILE_ATTRIBUTION).toBe('\u00a9 My Tile Provider');
+  });
+
+  test('emits empty tile settings when none are configured', () => {
+    const config = generateConfig({ OSRM_ENVIRONMENT: 'docker' });
+    expect(config.OSRM_TILE_URL).toBe('');
+    expect(config.OSRM_TILE_NAME).toBe('');
+    expect(config.OSRM_TILE_ATTRIBUTION).toBe('');
+  });
+
+  test('a custom tile server becomes the default layer when none was chosen', () => {
+    // The image ships OSRM_DEFAULT_LAYER=streets, so that value reads as
+    // "operator did not choose" the same way the default backend does.
+    const config = generateConfig({
+      OSRM_ENVIRONMENT: 'docker',
+      OSRM_DEFAULT_LAYER: 'streets',
+      OSRM_TILE_URL: 'http://localhost:8080/tile/{z}/{x}/{y}.png'
+    });
+    expect(config.OSRM_DEFAULT_LAYER).toBe('custom');
+  });
+
+  test('an explicitly chosen layer survives a custom tile server', () => {
+    const config = generateConfig({
+      OSRM_ENVIRONMENT: 'docker',
+      OSRM_DEFAULT_LAYER: 'satellite',
+      OSRM_TILE_URL: 'http://localhost:8080/tile/{z}/{x}/{y}.png'
+    });
+    expect(config.OSRM_DEFAULT_LAYER).toBe('satellite');
+  });
+
+  test('the default layer is untouched without a custom tile server', () => {
+    const config = generateConfig({ OSRM_ENVIRONMENT: 'docker', OSRM_DEFAULT_LAYER: 'streets' });
+    expect(config.OSRM_DEFAULT_LAYER).toBe('streets');
+  });
+
+  test('a tile URL with JSON-significant characters stays valid JSON', () => {
+    const config = generateConfig({
+      OSRM_ENVIRONMENT: 'docker',
+      OSRM_TILE_URL: 'http://localhost:8080/"{z}"/{x}/{y}.png',
+      OSRM_TILE_ATTRIBUTION: 'a "quoted" \\ credit'
+    });
+    expect(config.OSRM_TILE_URL).toBe('http://localhost:8080/"{z}"/{x}/{y}.png');
+    expect(config.OSRM_TILE_ATTRIBUTION).toBe('a "quoted" \\ credit');
+  });
+
   test('uses public profiles as Docker defaults when no routing env vars are provided', () => {
     const config = generateConfig({
       OSRM_BACKEND: 'http://localhost:5000',


### PR DESCRIPTION
Closes #328.

A self-hosted or offline deployment cannot reach the public tile providers the built-in base layers point at, and the only way to swap them was editing `src/leaflet_options.js` and rebuilding the bundle. The issue asked for the tile URL as an environment variable back in 2020; the runtime config mechanism added since (`window.osrmConfig` / `config.json`) is the right place for it, it just had no tile key.

## What this adds

| Variable | Default | Description |
|----------|---------|-------------|
| `OSRM_TILE_URL` | — | Tile URL template. Adds the named tile server as an extra base layer. |
| `OSRM_TILE_NAME` | `Custom` | Label in the layer control. |
| `OSRM_TILE_ATTRIBUTION` | OpenStreetMap credit | Attribution text for that layer. |

```bash
docker run -p 9966:9966 \
  -e 'OSRM_TILE_URL=http://localhost:8080/tile/{z}/{x}/{y}.png' \
  -e 'OSRM_TILE_NAME=Local tiles' \
  ghcr.io/project-osrm/osrm-frontend:latest
```

## Notable decisions

- **The custom layer becomes the default** unless `OSRM_DEFAULT_LAYER` names another one — a deployment serving its own tiles usually cannot reach CARTO either. The image ships `OSRM_DEFAULT_LAYER=streets`, so the entrypoint treats that value as "operator did not choose", the same sentinel-default pattern already used for `OSRM_BACKEND=http://localhost:5000`.
- **Invalid URLs are rejected with a console warning** rather than added as a layer that renders nothing. The template must be http(s), protocol-relative or root-relative and carry the `{z}`, `{x}` and `{y}` placeholders.
- **The default attribution is the OpenStreetMap credit**, since tiles from a private server are overwhelmingly OSM-derived; `OSRM_TILE_ATTRIBUTION` overrides it.
- **A name colliding with a built-in label replaces that layer** instead of being silently dropped.

`?ly=` URL state and the localStorage layer preference pick the new layer up for free — both resolve by control label.

## Testing

22 new tests (`test/custom_tile_layer.test.js`, plus entrypoint cases covering JSON escaping and the default-layer promotion). Lint, full suite (612 tests) and build pass.

🤖 Claude Code, Claude Opus 5
