### PR TITLE
feat: let a deployment choose its geocoders, or none, via OSRM_GEOCODERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,37 @@ For Docker deployments, prefer runtime configuration via `OSRM_MODES` (see [abov
 instead of editing source files. If you need source-level customization, edit the
 `parseModes()` and `buildServices()` functions in `src/leaflet_options.js`.
 
+## Geocoding
+
+Address search and the reverse lookups that name dropped or dragged waypoints go
+to the public [Nominatim](https://nominatim.openstreetmap.org/) instance by
+default. `OSRM_GEOCODERS` decides which geocoders a deployment offers — a JSON
+array shaped like `OSRM_MODES`:
+
+```bash
+docker run -p 9966:9966 \
+  -e 'OSRM_GEOCODERS=[{"name":"House Nominatim","url":"https://nominatim.internal/"}]' \
+  ghcr.io/project-osrm/osrm-frontend:latest
+```
+
+An entry whose `url` is empty is the **coordinates-only** geocoder: it contacts
+nothing at all. The search box still accepts typed coordinates, and waypoints are
+named by their coordinates (`34.129382, -118.141254`) — a form that pastes back
+into the search box. Configure it alone when the deployment may not reach a
+third-party geocoder:
+
+```bash
+docker run -p 9966:9966 -e 'OSRM_GEOCODERS=[{"url":""}]' ghcr.io/project-osrm/osrm-frontend:latest
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `name` | `Geocoder <n>`, or `Coordinates only` for an empty `url` | Display name. |
+| `url` | — | Nominatim endpoint. Empty means no geocoding at all. |
+
+The first entry is the one in use. With `OSRM_GEOCODERS` unset, the single entry
+is the Nominatim instance baked in at build time via `NOMINATIM_ENDPOINT`.
+
 ## Customizing Tile Layers and Overlays
 
 ### Base layers (`layer`)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,6 +15,10 @@ OSRM_CARTO_KEY="${OSRM_CARTO_KEY:-}"
 OSRM_TILE_URL="${OSRM_TILE_URL:-}"
 OSRM_TILE_NAME="${OSRM_TILE_NAME:-}"
 OSRM_TILE_ATTRIBUTION="${OSRM_TILE_ATTRIBUTION:-}"
+# Empty by default: the frontend then offers the bundled Nominatim instance.
+# Set to a JSON array of {"name","url"} to choose the geocoders on offer; an
+# entry with an empty url contacts nothing and names waypoints by coordinates.
+OSRM_GEOCODERS="${OSRM_GEOCODERS:-}"
 
 # A deployment naming its own tile server usually cannot reach the public
 # providers either, so make that layer the default unless the operator picked
@@ -79,6 +83,7 @@ cat > /usr/share/nginx/html/config.json << EOF
   "OSRM_TILE_URL": "$(escape_json "$OSRM_TILE_URL")",
   "OSRM_TILE_NAME": "$(escape_json "$OSRM_TILE_NAME")",
   "OSRM_TILE_ATTRIBUTION": "$(escape_json "$OSRM_TILE_ATTRIBUTION")",
+  "OSRM_GEOCODERS": "$(escape_json "$OSRM_GEOCODERS")",
   "OSRM_MODES": "$(escape_json "$MODES_JSON")"
 }
 EOF

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -725,6 +725,49 @@ geocoder.coordPreserving = function(nominatimUrl) {
   };
 };
 
+// Formats a coordinate the way the search box accepts it back: plain decimals,
+// comma-separated. The hemispheric form below reads better but cannot be pasted
+// into the input, which is what a deployment without geocoding leaves users
+// doing with every pinned location.
+geocoder.plainCoordinateNameFallback = function(latLng) {
+  var wrapped = (latLng && typeof latLng.wrap === 'function') ? latLng.wrap() : latLng;
+  var ll = wrapped || latLng || {};
+  return Number(ll.lat || 0).toFixed(6) + ', ' + Number(ll.lng || 0).toFixed(6);
+};
+
+// A geocoder that contacts nothing. The search box still accepts typed
+// coordinates, and waypoints are named by their coordinates instead of by a
+// place: LRM's GeocoderElement falls straight through to `waypointNameFallback`
+// when the geocoder has no `reverse`, so the omission below is what disables
+// the automatic lookup that a map click, a drag or a URL-restored waypoint
+// would otherwise trigger.
+geocoder.coordinatesOnly = function() {
+  function resolve(query) {
+    var latlng = parseCoords(query);
+    if (!latlng) return [];
+    return [{
+      name: geocoder.plainCoordinateNameFallback(latlng),
+      center: latlng,
+      bbox: latlng.toBounds(1000)
+    }];
+  }
+
+  function respond(query, cb, context) {
+    var results = resolve(query);
+    if (typeof cb === 'function') cb.call(context, results);
+    return Promise.resolve(results);
+  }
+
+  return {
+    geocode: respond,
+    suggest: respond,
+    // Nothing to outline without a place to look up.
+    fetchOutline: function() {
+      return Promise.resolve(null);
+    }
+  };
+};
+
 // Replacement for LRM's built-in waypointNameFallback that wraps the longitude
 // into [-180, 180] before formatting. When reverse geocoding fails (no network,
 // rate limit, location in the ocean) and the raw coordinate is shown, this

--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,14 @@ function makeIcon(i, n) {
   return L.icon(waypointMarker.waypointIconOptions(i, n));
 }
 
-var routingGeocoder = createGeocoder.coordPreserving(leafletOptions.nominatim && leafletOptions.nominatim.path);
+// The deployment decides which geocoders exist; the first one is used. An entry
+// with no URL is the coordinates-only geocoder, which contacts nothing — a
+// deployment that may not reach a third-party geocoder configures only that one.
+var activeGeocoder = leafletOptions.geocoders[0];
+var geocodingDisabled = !activeGeocoder || !activeGeocoder.url;
+var routingGeocoder = geocodingDisabled
+  ? createGeocoder.coordinatesOnly()
+  : createGeocoder.coordPreserving(activeGeocoder.url);
 
 // Declared before the geocoder wrapper below, which reads it back late: the
 // plan is built from that geocoder and so cannot exist yet when it is made.
@@ -310,7 +317,11 @@ var planGeocoder = entranceWaypointsModule.createReverseNotifier({
 
 plan = new ReversablePlan([], {
   geocoder: planGeocoder,
-  waypointNameFallback: createGeocoder.wrappedWaypointNameFallback,
+  // Without geocoding every waypoint is named by its coordinates, so the name
+  // has to be one the search box accepts back.
+  waypointNameFallback: geocodingDisabled
+    ? createGeocoder.plainCoordinateNameFallback
+    : createGeocoder.wrappedWaypointNameFallback,
   language: mergedOptions.language,
   routeWhileDragging: true,
   createMarker: function(i, wp, n) {

--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -24,6 +24,14 @@ function cartoVoyagerUrl() {
   return base + '?key=' + encodeURIComponent(key.trim());
 }
 
+// The label the coordinates-only geocoder carries. Named here because both the
+// parser and the deployment's own OSRM_GEOCODERS entries can produce it.
+var COORDINATES_ONLY_NAME = 'Coordinates only';
+
+// The Nominatim instance used when OSRM_GEOCODERS names none. `NOMINATIM_ENDPOINT`
+// rewrites this literal at build time (scripts/replace.js).
+var nominatimPath = 'https://nominatim.openstreetmap.org/';
+
 var osmAttribution = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
   cartoAttribution = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attribution">CARTO</a>',
   esriAttribution = 'Tiles © <a href="https://www.esri.com/">Esri</a> — Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AeroGRID, IGN, and the GIS User Community',
@@ -481,6 +489,54 @@ if (custom) baseLayers[customName] = custom;
 var defaultLayer = layerMap[getDefaultLayer()] || streets;
 
 /**
+ * The geocoding endpoints the deployment offers, from `OSRM_GEOCODERS`.
+ *
+ * Shaped like `OSRM_MODES`: a JSON array (or an already-parsed array) of
+ * `{name, url}` entries. An entry whose `url` is empty is the coordinates-only
+ * geocoder — it contacts nothing, names waypoints by their coordinates, and
+ * lets the search box accept typed coordinates. A deployment that may not
+ * reach third parties at all configures that entry alone.
+ *
+ * With `OSRM_GEOCODERS` unset the single entry is the Nominatim instance in
+ * `nominatim.path`, so an untouched deployment behaves exactly as before and
+ * the build-time `NOMINATIM_ENDPOINT` substitution keeps working.
+ *
+ * @returns {Array<{name: string, url: string}>} one entry per offered geocoder
+ */
+function parseGeocoders() {
+  // Read config fresh from window each time, not the captured config variable
+  var currentConfig = (typeof window !== 'undefined' ? window.osrmConfig : null) || {};
+  var value = currentConfig.OSRM_GEOCODERS;
+  var entries = null;
+
+  if (Array.isArray(value)) {
+    entries = value;
+  } else if (typeof value === 'string' && value.trim().length > 0) {
+    try {
+      entries = JSON.parse(value);
+    } catch (e) {
+      console.warn('Failed to parse OSRM_GEOCODERS JSON:', e);
+    }
+  }
+
+  if (Array.isArray(entries) && entries.length > 0) {
+    return entries.map(function(entry, index) {
+      // A bare string is the endpoint URL; '' asks for coordinates only.
+      if (typeof entry === 'string') {
+        return { name: entry.trim() ? 'Geocoder ' + (index + 1) : COORDINATES_ONLY_NAME, url: entry.trim() };
+      }
+      var url = (entry && typeof entry.url === 'string') ? entry.url.trim() : '';
+      var name = (entry && typeof entry.name === 'string' && entry.name.trim())
+        ? entry.name.trim()
+        : (url ? 'Geocoder ' + (index + 1) : COORDINATES_ONLY_NAME);
+      return { name: name, url: url };
+    });
+  }
+
+  return [{ name: 'Nominatim', url: nominatimPath }];
+}
+
+/**
  * Build the services array consumed by the routing control and mode selector.
  *
  * Each entry exposes a human-readable `label`, a `labelKey` for localization,
@@ -651,7 +707,20 @@ var leafletOptions = {
    * @type {{path: string}}
    */
   nominatim: {
-    path: 'https://nominatim.openstreetmap.org/'
+    path: nominatimPath
+  },
+
+  /**
+   * Geocoding endpoints offered by this deployment, in the order they are
+   * presented. The first entry is the default; an entry with an empty `url`
+   * is the coordinates-only geocoder, which contacts nothing.
+   *
+   * A getter so it always reflects the current runtime config, like `services`.
+   *
+   * @type {Array<{name: string, url: string}>}
+   */
+  get geocoders() {
+    return parseGeocoders();
   }
 };
 

--- a/test/entrypoint.test.js
+++ b/test/entrypoint.test.js
@@ -52,6 +52,20 @@ function generateConfig(envOverrides, options) {
 }
 
 describe('docker entrypoint runtime config', () => {
+  test('passes the configured geocoders through to config.json', () => {
+    const geocoders = JSON.stringify([
+      { name: 'House Nominatim', url: 'https://nominatim.internal/' },
+      { name: 'Coordinates only', url: '' }
+    ]);
+    const config = generateConfig({ OSRM_ENVIRONMENT: 'docker', OSRM_GEOCODERS: geocoders });
+    expect(JSON.parse(config.OSRM_GEOCODERS)).toEqual(JSON.parse(geocoders));
+  });
+
+  test('emits an empty geocoder list when none is configured', () => {
+    const config = generateConfig({ OSRM_ENVIRONMENT: 'docker' });
+    expect(config.OSRM_GEOCODERS).toBe('');
+  });
+
   test('passes a custom tile server through to config.json', () => {
     const config = generateConfig({
       OSRM_ENVIRONMENT: 'docker',

--- a/test/geocoder_config.test.js
+++ b/test/geocoder_config.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+jest.mock('leaflet', () => {
+  const latLng = (lat, lng) => ({
+    lat: lat,
+    lng: lng,
+    wrap: function() { return latLng(this.lat, ((this.lng + 180) % 360 + 360) % 360 - 180); },
+    toBounds: function() { return { _center: this }; }
+  });
+  return {
+    tileLayer: (url, options) => ({ _url: url, _options: options }),
+    latLng: latLng
+  };
+});
+
+// `geocoders` is a getter reading window.osrmConfig fresh on every access, so
+// the config has to stay in place while the returned module is used.
+function loadOptions(osrmConfig) {
+  jest.resetModules();
+  global.window = { osrmConfig: osrmConfig };
+  return require('../src/leaflet_options');
+}
+
+afterEach(() => {
+  delete global.window;
+  jest.resetModules();
+});
+
+describe('OSRM_GEOCODERS configuration', () => {
+  test('an unconfigured deployment offers the bundled Nominatim instance', () => {
+    // Behaviour has to be unchanged for anyone who sets nothing, and the
+    // build-time NOMINATIM_ENDPOINT substitution still feeds this entry.
+    const opts = loadOptions({});
+    expect(opts.geocoders).toEqual([
+      { name: 'Nominatim', url: 'https://nominatim.openstreetmap.org/' }
+    ]);
+    expect(opts.geocoders[0].url).toBe(opts.nominatim.path);
+  });
+
+  test('a JSON string of entries is parsed in order', () => {
+    const opts = loadOptions({
+      OSRM_GEOCODERS: JSON.stringify([
+        { name: 'House Nominatim', url: 'https://nominatim.internal/' },
+        { name: 'Coordinates only', url: '' }
+      ])
+    });
+    expect(opts.geocoders).toEqual([
+      { name: 'House Nominatim', url: 'https://nominatim.internal/' },
+      { name: 'Coordinates only', url: '' }
+    ]);
+  });
+
+  test('an already-parsed array is accepted', () => {
+    const opts = loadOptions({
+      OSRM_GEOCODERS: [{ name: 'House', url: 'https://nominatim.internal/' }]
+    });
+    expect(opts.geocoders[0].url).toBe('https://nominatim.internal/');
+  });
+
+  test('a lone empty-url entry offers coordinates only', () => {
+    // The configuration a deployment forbidden from reaching third parties ships.
+    const opts = loadOptions({ OSRM_GEOCODERS: '[{"url":""}]' });
+    expect(opts.geocoders).toEqual([{ name: 'Coordinates only', url: '' }]);
+  });
+
+  test('bare strings are accepted as endpoint URLs', () => {
+    const opts = loadOptions({ OSRM_GEOCODERS: '["https://nominatim.internal/",""]' });
+    expect(opts.geocoders).toEqual([
+      { name: 'Geocoder 1', url: 'https://nominatim.internal/' },
+      { name: 'Coordinates only', url: '' }
+    ]);
+  });
+
+  test('an unnamed endpoint gets a positional name', () => {
+    const opts = loadOptions({ OSRM_GEOCODERS: '[{"url":"https://a.example/"},{"url":"https://b.example/"}]' });
+    expect(opts.geocoders.map((g) => g.name)).toEqual(['Geocoder 1', 'Geocoder 2']);
+  });
+
+  test('surrounding whitespace is trimmed off names and URLs', () => {
+    const opts = loadOptions({ OSRM_GEOCODERS: '[{"name":"  House  ","url":"  https://nominatim.internal/  "}]' });
+    expect(opts.geocoders).toEqual([{ name: 'House', url: 'https://nominatim.internal/' }]);
+  });
+
+  test('malformed JSON warns and falls back to the default geocoder', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const opts = loadOptions({ OSRM_GEOCODERS: '[{not json' });
+    expect(opts.geocoders[0].name).toBe('Nominatim');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse OSRM_GEOCODERS JSON:'), expect.anything());
+    warnSpy.mockRestore();
+  });
+
+  test('an empty or blank value falls back to the default geocoder', () => {
+    ['', '   ', '[]', undefined, null, 42].forEach((value) => {
+      const opts = loadOptions({ OSRM_GEOCODERS: value });
+      expect(opts.geocoders[0].name).toBe('Nominatim');
+    });
+  });
+
+  test('the config is read fresh, not captured at module load', () => {
+    const opts = loadOptions({});
+    expect(opts.geocoders[0].name).toBe('Nominatim');
+    global.window = { osrmConfig: { OSRM_GEOCODERS: '[{"name":"Late","url":"https://late.example/"}]' } };
+    expect(opts.geocoders[0].name).toBe('Late');
+  });
+});
+
+describe('coordinates-only geocoder', () => {
+  const createGeocoder = require('../src/geocoder');
+
+  test('has no reverse method, so LRM names waypoints without a request', () => {
+    // GeocoderElement.update() checks for `reverse` and falls straight through
+    // to waypointNameFallback when it is absent — that omission is the feature.
+    expect(createGeocoder.coordinatesOnly().reverse).toBeUndefined();
+  });
+
+  test('resolves typed coordinates without contacting anything', async () => {
+    const results = await createGeocoder.coordinatesOnly().geocode('34.129382, -118.141254');
+    expect(results).toHaveLength(1);
+    expect(results[0].center.lat).toBe(34.129382);
+    expect(results[0].center.lng).toBe(-118.141254);
+  });
+
+  test('returns nothing for a place name', () => {
+    return createGeocoder.coordinatesOnly().suggest('Berlin').then((results) => {
+      expect(results).toEqual([]);
+    });
+  });
+
+  test('calls back with the results, as LRM autocomplete expects', () => {
+    const cb = jest.fn();
+    const context = {};
+    return createGeocoder.coordinatesOnly().geocode('1,2', cb, context).then(() => {
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb.mock.instances[0]).toBe(context);
+      expect(cb.mock.calls[0][0][0].center.lat).toBe(1);
+    });
+  });
+
+  test('outlines resolve to null rather than hitting the lookup endpoint', () => {
+    return createGeocoder.coordinatesOnly().fetchOutline({ osmType: 'way', osmId: 1 })
+      .then((outline) => expect(outline).toBeNull());
+  });
+
+  test('names coordinates in a form the search box accepts back', () => {
+    // A pinned location the user cannot paste back is the complaint in #321.
+    const name = createGeocoder.plainCoordinateNameFallback({ lat: 34.129382, lng: -118.141254 });
+    expect(name).toBe('34.129382, -118.141254');
+    return createGeocoder.coordinatesOnly().geocode(name).then((results) => {
+      expect(results[0].center.lat).toBeCloseTo(34.129382, 6);
+      expect(results[0].center.lng).toBeCloseTo(-118.141254, 6);
+    });
+  });
+
+  test('the coordinate name wraps longitude into [-180, 180]', () => {
+    const latLng = require('leaflet').latLng(10, 190);
+    expect(createGeocoder.plainCoordinateNameFallback(latLng)).toBe('10.000000, -170.000000');
+  });
+});


### PR DESCRIPTION
Closes #321. Part of #160.

Address search and the reverse lookups that name dropped, dragged and URL-restored waypoints go to `nominatim.openstreetmap.org` with no way to redirect or stop them at runtime. `NOMINATIM_ENDPOINT` is a build-time string substitution, so a Docker deployment cannot change it at all — which leaves an operator who may not reach third parties without an option, and puts avoidable load on the OSM servers.

## What this adds

| Variable | Default | Description |
|----------|---------|-------------|
| `OSRM_GEOCODERS` | the instance baked in at build time | JSON array of `{name, url}`, shaped like `OSRM_MODES`. The first entry is the one in use. |

```bash
docker run -p 9966:9966 \
  -e 'OSRM_GEOCODERS=[{"name":"House Nominatim","url":"https://nominatim.internal/"}]' \
  ghcr.io/project-osrm/osrm-frontend:latest
```

An entry whose `url` is empty is the **coordinates-only** geocoder — it contacts nothing:

```bash
docker run -p 9966:9966 -e 'OSRM_GEOCODERS=[{"url":""}]' ghcr.io/project-osrm/osrm-frontend:latest
```

## Notable decisions

- **Omitting `reverse` is what disables the lookups.** LRM's `GeocoderElement` falls straight through to `waypointNameFallback` when the geocoder has no `reverse` method, so the coordinates-only geocoder disables the automatic request a map click, a drag or a URL-restored waypoint would otherwise trigger — no call sites had to learn about it.
- **Waypoint names switch to plain decimals** (`38.897700, -77.036500`) when geocoding is off. The existing hemispheric fallback reads better but cannot be pasted back into the search box, which is exactly what a deployment without geocoding leaves users doing with every pinned location.
- **The search box still resolves typed coordinates.** `geocode` and `suggest` parse them locally; only the network lookups go away.
- **An unset `OSRM_GEOCODERS` keeps the single build-time entry**, so an untouched deployment is byte-for-byte unchanged and the `NOMINATIM_ENDPOINT` substitution keeps working.
- **A bare string entry is accepted as the URL**, matching how the other list-shaped variables are forgiving about input.
- **Only the first entry is used.** The selector that lets a user switch between several is a follow-up — that is the part of #160 this does not cover.

`leafletOptions.geocoders` is a getter, so it reflects the current runtime config the same way `services` does.

## Testing

19 new tests (`test/geocoder_config.test.js`, plus two entrypoint cases covering the pass-through and the empty default). Full suite (637 tests) and build pass.

Verified in the browser against both configurations: with `OSRM_GEOCODERS` unset the two waypoints resolve to "White House, …" and "United States Capitol, …"; with the coordinates-only entry they read `38.897700, -77.036500` and `38.889900, -77.009100`, with no geocoder request and an identical route.

🤖 Claude Code, Claude Opus 5
